### PR TITLE
feat: treat bot messages at the message serializer

### DIFF
--- a/chats/apps/api/v1/msgs/serializers.py
+++ b/chats/apps/api/v1/msgs/serializers.py
@@ -65,7 +65,10 @@ class MessageMediaSerializer(serializers.ModelSerializer):
         return media.url
 
     def get_sender(self, media: MessageMedia):
-        return media.message.get_sender().full_name
+        try:
+            return media.message.get_sender().full_name
+        except AttributeError:
+            return ""
 
     def create(self, validated_data):
         media = validated_data["media_file"]


### PR DESCRIPTION
### **What**
Update get_sender method at MessageMediaSerializer, to treat bot messages(without user or contact)


### **Why**
Was throwing errors when a bot message with media is created