### PR TITLE
feat: Corrupted audio files

### DIFF
--- a/chats/apps/api/v1/msgs/serializers.py
+++ b/chats/apps/api/v1/msgs/serializers.py
@@ -77,7 +77,8 @@ class MessageMediaSerializer(serializers.ModelSerializer):
         media = validated_data["media_file"]
         file_bytes = media.file.read()
         file_type = magic.from_buffer(file_bytes, mime=True)
-
+        if file_type in settings.FILE_CHECK_CONTENT_TYPE:
+            file_type = media.name[-3:]
         if (
             file_type.startswith("audio")
             or file_type.lower() in settings.UNPERMITTED_AUDIO_TYPES

--- a/chats/apps/api/v1/msgs/viewsets.py
+++ b/chats/apps/api/v1/msgs/viewsets.py
@@ -4,6 +4,8 @@ from rest_framework import mixins, pagination, parsers, viewsets, filters, statu
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from pydub.exceptions import CouldntDecodeError
+
 
 from chats.apps.api.v1.msgs.filters import MessageFilter, MessageMediaFilter
 from chats.apps.api.v1.msgs.serializers import (
@@ -88,6 +90,18 @@ class MessageMediaViewset(
         ):
             return super().get_queryset()
         return self.queryset.none()
+
+    def create(self, request, *args, **kwargs):
+        try:
+            return super().create(request, *args, **kwargs)
+        except CouldntDecodeError:
+            return Response(
+                {
+                    "detail": "Could not decode audio file, possibility of corrupted file",
+                    "status": "error",
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
     def perform_create(self, serializer):
         serializer.save()

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -313,6 +313,9 @@ PROMETHEUS_AUTH_TOKEN = env.str("PROMETHEUS_AUTH_TOKEN")
 
 ACTIVATE_CALC_METRICS = env.bool("ACTIVATE_CALC_METRICS", default=True)
 
+FILE_CHECK_CONTENT_TYPE = env.str(
+    "FILE_CHECK_CONTENT_TYPE", default="application/octet-stream"
+)
 AUDIO_TYPE_TO_CONVERT = env.str("AUDIO_TYPE_TO_CONVERT", default="ogg")
 AUDIO_EXTENSION_TO_CONVERT = env.str("AUDIO_EXTENSION_TO_CONVERT", default="ogg")
 AUDIO_CODEC_TO_CONVERT = env.str("AUDIO_CODEC_TO_CONVERT", default="libopus")


### PR DESCRIPTION
### **What**
- Throw api error when trying to save a corrupted audio file

### **Why**
- So the client knows the audio is corrupted and  not save/send corrupted audio files
