### PR TITLE
feat: add reverse_results parameter when listing messages

### DIFF
--- a/chats/apps/api/v1/msgs/viewsets.py
+++ b/chats/apps/api/v1/msgs/viewsets.py
@@ -27,8 +27,13 @@ class MessageViewset(
     filter_backends = [filters.OrderingFilter, DjangoFilterBackend]
     filterset_class = MessageFilter
     permission_classes = [IsAuthenticated, MessagePermission]
-    # pagination_class = pagination.PageNumberPagination
     lookup_field = "uuid"
+
+    def get_paginated_response(self, data):
+        if self.request.query_params.get("reverse_results", False):
+            data.reverse()
+        qs = super().get_paginated_response(data)
+        return qs
 
     def create(self, request, *args, **kwargs):
         # TODO USE THE REQUEST.USER TO SET THE USER IN THE MESSAGE


### PR DESCRIPTION
### **What**
- Add reverse_results parameter when listing messages


### **Why**
- To reverse the page results ordering.