### PR TITLE
fix: adding rooms filter prefix in online agents count

### DIFF
--- a/chats/apps/api/v1/dashboard/serializers.py
+++ b/chats/apps/api/v1/dashboard/serializers.py
@@ -335,7 +335,7 @@ class DashboardSectorSerializer(serializers.ModelSerializer):
             }
             online_agents_subquery = model.objects.annotate(
                 online_agents=Count(
-                    "queues__authorizations__permission",
+                    f"{rooms_filter_prefix}authorizations__permission",
                     distinct=True,
                     filter=Q(**online_agents_filter),
                 ),


### PR DESCRIPTION
### **What**
Add filter prefix inside online agents subquery

### **Why**
to solve the problem that occours when someone use sector filter in user dashboar.

