### PR TITLE
fix gunicorn graceful shutdown

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,5 @@
 echo "Running collectstatic"
 python manage.py collectstatic --noinput
 
-ls
-
 echo "Starting server"
-gunicorn chats.asgi -c gunicorn.conf.py
+exec gunicorn chats.asgi -c gunicorn.conf.py


### PR DESCRIPTION
If gunicorn is not PID 0 or all signals is not routed for it, a incoming connection can be interrupted while the pod is terminating.

The exec give the current PID to the child process, fixing it.
