### PR TITLE
feat: change update method on the SectorUpdateSerializer

### DIFF
--- a/chats/apps/api/v1/contacts/filters.py
+++ b/chats/apps/api/v1/contacts/filters.py
@@ -53,9 +53,7 @@ class ContactFilter(filters.FilterSet):
             raise exceptions.APIException(
                 detail="Access denied! Make sure you have the right permission to access this project"
             )
-
-        queue_ids = user_permission.queue_ids
-
+        queue_ids = user_permission.queue_ids_increment
         subquery = Room.objects.filter(
             Q(queue_id__in=queue_ids) | Q(user=user, queue__sector__project=value),
             is_active=False,

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -1,7 +1,7 @@
 import json
 
 from django.conf import settings
-from django.db.models import F, Max, Sum
+from django.db.models import Max
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, mixins, permissions, status

--- a/chats/apps/api/v1/sectors/serializers.py
+++ b/chats/apps/api/v1/sectors/serializers.py
@@ -42,8 +42,18 @@ class SectorUpdateSerializer(serializers.ModelSerializer):
             "can_trigger_flows",
             "sign_messages",
             "can_edit_custom_fields",
+            "config",
         ]
         extra_kwargs = {field: {"required": False} for field in fields}
+
+    def update(self, instance, validated_data):
+        config = validated_data.pop("config", None)
+        sector = super().update(instance, validated_data)
+        if config:
+            sector.config = sector.config or {}
+            sector.config.update(config)
+            sector.save()
+        return sector
 
 
 class SectorReadOnlyListSerializer(serializers.ModelSerializer):

--- a/chats/apps/contacts/tests/test_viewsets.py
+++ b/chats/apps/contacts/tests/test_viewsets.py
@@ -20,7 +20,6 @@ class TestContactsViewsets(BaseAPIChatsTestCase):
         payload = {"project": str(self.project.uuid)}
         self.deactivate_rooms()
         response = self._list_request(token=self.admin_token, data=payload)[0]
-        # print("response", response.json())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json().get("count"), self.count_project_1_contact)
 

--- a/chats/apps/contacts/tests/test_viewsets.py
+++ b/chats/apps/contacts/tests/test_viewsets.py
@@ -20,6 +20,7 @@ class TestContactsViewsets(BaseAPIChatsTestCase):
         payload = {"project": str(self.project.uuid)}
         self.deactivate_rooms()
         response = self._list_request(token=self.admin_token, data=payload)[0]
+        # print("response", response.json())
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json().get("count"), self.count_project_1_contact)
 

--- a/chats/apps/projects/models.py
+++ b/chats/apps/projects/models.py
@@ -8,6 +8,8 @@ from timezone_field import TimeZoneField
 from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
 from chats.core.models import BaseConfigurableModel, BaseModel
 from chats.utils.websockets import send_channels_group
+import pdb
+
 
 # Create your models here.
 
@@ -243,6 +245,17 @@ class ProjectPermission(
         queues = set(sector_manager_queues + queue_agent_queues)
 
         return queues
+
+    @property
+    def queue_ids_increment(self):
+        increment_queue_ids = list(
+            self.project.sectors.filter(config__can_see_historic=True).values_list(
+                "queues__pk", flat=True
+            )
+        )
+        queue_ids_list = list(self.queue_ids)
+
+        return set(queue_ids_list + increment_queue_ids)
 
     def get_permission(self, user):
         try:

--- a/chats/apps/projects/models.py
+++ b/chats/apps/projects/models.py
@@ -8,8 +8,6 @@ from timezone_field import TimeZoneField
 from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
 from chats.core.models import BaseConfigurableModel, BaseModel
 from chats.utils.websockets import send_channels_group
-import pdb
-
 
 # Create your models here.
 

--- a/chats/apps/projects/tests/test_viewsets.py
+++ b/chats/apps/projects/tests/test_viewsets.py
@@ -75,5 +75,4 @@ class PermissionTests(APITestCase):
         "can_see_historic" is true.
         """
         self.project_permission.queue_ids_increment
-        print(len(self.project_permission.queue_ids_increment))
         self.assertEqual(len(self.project_permission.queue_ids_increment), 3)

--- a/chats/apps/projects/tests/test_viewsets.py
+++ b/chats/apps/projects/tests/test_viewsets.py
@@ -71,7 +71,8 @@ class PermissionTests(APITestCase):
 
     def test_queue_ids_method(self):
         """
-        Ensure that queue_ids method from ProjectPermission its working properly when the flag "can_see_historic" is true.
+        Ensure that queue_ids method from ProjectPermission its working properly when the flag
+        "can_see_historic" is true.
         """
         self.project_permission.queue_ids_increment
         print(len(self.project_permission.queue_ids_increment))

--- a/chats/apps/projects/tests/test_viewsets.py
+++ b/chats/apps/projects/tests/test_viewsets.py
@@ -3,7 +3,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
 from chats.apps.accounts.models import User
-from chats.apps.projects.models import Project
+from chats.apps.projects.models import Project, ProjectPermission
 
 
 class PermissionTests(APITestCase):
@@ -14,6 +14,9 @@ class PermissionTests(APITestCase):
         self.project_2 = Project.objects.get(pk="32e74fec-0dd7-413d-8062-9659f2e213d2")
         self.manager_user = User.objects.get(pk=9)
         self.login_token = Token.objects.get_or_create(user=self.manager_user)[0]
+        self.project_permission = ProjectPermission.objects.get(
+            uuid="ce3f052c-e71d-402c-b02e-1dfaca8b3d45"
+        )
 
     def test_get_first_access_status(self):
         """
@@ -65,3 +68,11 @@ class PermissionTests(APITestCase):
         self.assertEqual(
             response.data["Detail"], "You dont have permission in this project."
         )
+
+    def test_queue_ids_method(self):
+        """
+        Ensure that queue_ids method from ProjectPermission its working properly when the flag "can_see_historic" is true.
+        """
+        self.project_permission.queue_ids_increment
+        print(len(self.project_permission.queue_ids_increment))
+        self.assertEqual(len(self.project_permission.queue_ids_increment), 3)

--- a/chats/apps/rooms/views.py
+++ b/chats/apps/rooms/views.py
@@ -1,10 +1,10 @@
-from rest_framework import status
-from rest_framework.exceptions import APIException
 from django.conf import settings
 from django.db import transaction
+from rest_framework import status
+from rest_framework.exceptions import APIException
 
-from chats.apps.dashboard.tasks import close_metrics, generate_metrics
 from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
+from chats.apps.dashboard.tasks import close_metrics, generate_metrics
 from chats.apps.rooms.models import Room
 
 
@@ -16,6 +16,7 @@ def close_room(room_pk: str):
             )
         )
     generate_metrics(room_pk)
+
 
 def update_custom_fields(room: Room, custom_fields_update: dict):
     room.custom_fields.update(custom_fields_update)

--- a/chats/apps/sectors/tests/test_viewsets.py
+++ b/chats/apps/sectors/tests/test_viewsets.py
@@ -112,14 +112,14 @@ class SectorTests(APITestCase):
             "work_start": "11:00",
             "work_end": "19:30",
             "project": str(self.project.pk),
-            "config": {"can_see_historic": "True"},
+            "config": {"can_see_historic": "true"},
         }
         response = client.post(url, data=data, format="json")
         created_sector = Sector.objects.get(
             name="Finances", project=str(self.project.pk)
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(created_sector.config, {"can_see_historic": "True"})
+        self.assertEqual(created_sector.config, {"can_see_historic": "true"})
 
 
 class RoomsExternalTests(APITestCase):

--- a/chats/apps/sectors/tests/test_viewsets.py
+++ b/chats/apps/sectors/tests/test_viewsets.py
@@ -99,6 +99,28 @@ class SectorTests(APITestCase):
         response = client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+    def test_create_sector_with_can_see_all_history(self):
+        """
+        Verify if the Project Permission its returning the correct value from first_access field.
+        """
+        url = reverse("sector-list")
+        client = self.client
+        client.credentials(HTTP_AUTHORIZATION="Token " + self.login_token.key)
+        data = {
+            "name": "Finances",
+            "rooms_limit": 3,
+            "work_start": "11:00",
+            "work_end": "19:30",
+            "project": str(self.project.pk),
+            "config": {"can_see_historic": "True"},
+        }
+        response = client.post(url, data=data, format="json")
+        created_sector = Sector.objects.get(
+            name="Finances", project=str(self.project.pk)
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(created_sector.config, {"can_see_historic": "True"})
+
 
 class RoomsExternalTests(APITestCase):
     fixtures = ["chats/fixtures/fixture_app.json"]

--- a/chats/fixtures/fixture_app.json
+++ b/chats/fixtures/fixture_app.json
@@ -2285,7 +2285,10 @@
             "rooms_limit": 3,
             "work_start": "01:00:00",
             "work_end": "19:00:00",
-            "is_deleted": false
+            "is_deleted": false,
+            "config": {
+                "can_see_historic": true
+            }
         }
     },
     {


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Do we need to implement analytics?


### **What**
Change update method on the SectorUpdateSerializer 
Flag in sector to control access to history


### **Why**
To update the custom fields without losing the previous data
To make agents see all history even if it does not have access in a sector/queue.

