### PR TITLE
feat: add retry on the send_channels_group try to ensure message delivery

### DIFF
--- a/chats/settings.py
+++ b/chats/settings.py
@@ -401,3 +401,7 @@ if USE_EDA:
     DEFAULT_DEAD_LETTER_EXCHANGE = env(
         "DEFAULT_DEAD_LETTER_EXCHANGE", default="chats.dlx.topic"
     )
+
+# Websockets
+
+WS_MESSAGE_RETRIES = env.int("WS_MESSAGE_RETRIES", default=5)

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -405,3 +405,4 @@ if USE_EDA:
 # Websockets
 
 WS_MESSAGE_RETRIES = env.int("WS_MESSAGE_RETRIES", default=5)
+WEBSOCKET_RETRY_SLEEP = env.int("WEBSOCKET_RETRY_SLEEP", default=0.5)

--- a/chats/utils/websockets.py
+++ b/chats/utils/websockets.py
@@ -2,11 +2,18 @@ import json
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
+from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from sentry_sdk import capture_exception
 
 
-def send_channels_group(group_name: str, call_type: str, content: str, action: str):
+def send_channels_group(
+    group_name: str,
+    call_type: str,
+    content: str,
+    action: str,
+    retry=settings.WS_MESSAGE_RETRIES,
+):
     """
     helper function that sends data to channels groups
     """
@@ -21,4 +28,8 @@ def send_channels_group(group_name: str, call_type: str, content: str, action: s
             },
         )
     except Exception as err:
+        if retry > 0:
+            return send_channels_group(
+                group_name, call_type, content, action, retry - 1
+            )
         capture_exception(err)

--- a/chats/utils/websockets.py
+++ b/chats/utils/websockets.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -29,6 +30,7 @@ def send_channels_group(
         )
     except Exception as err:
         if retry > 0:
+            time.sleep(settings.WEBSOCKET_RETRY_SLEEP)
             return send_channels_group(
                 group_name, call_type, content, action, retry - 1
             )


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Do we need to implement analytics?


### **What**
Add a recursive retry for sending notifications 


### **Why**
Sometimes the connection with redis is lost when it's trying to send notifications, this will ensure that the message will be sent to the clients.