### PR TITLE
feat: remove last_interaction from user serializer and model

### DIFF
--- a/chats/apps/accounts/models.py
+++ b/chats/apps/accounts/models.py
@@ -73,13 +73,6 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self.sector_authorizations.values_list("sector__id", flat=True)
 
     @property
-    def last_interaction(self):
-        try:
-            return self.messages.last().created_on
-        except AttributeError:
-            return ""
-
-    @property
     def full_name(self):
         return f"{self.first_name} {self.last_name}"
 

--- a/chats/apps/api/v1/accounts/serializers.py
+++ b/chats/apps/api/v1/accounts/serializers.py
@@ -15,7 +15,6 @@ class LoginSerializer(AuthTokenSerializer, serializers.ModelSerializer):
 
 class UserSerializer(serializers.ModelSerializer):
     status = serializers.SerializerMethodField()
-    last_interaction = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -24,18 +23,11 @@ class UserSerializer(serializers.ModelSerializer):
             "last_name",
             "email",
             "status",
-            "last_interaction",
         ]
         ref_name = None
 
     def get_status(self, user: User):
-        """
-        TODO: Return if a user has active channel groups
-        """
         return ""
-
-    def get_last_interaction(self, user: User):
-        return user.last_interaction
 
 
 class UserNameSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
### **What**
Remove the last_interaction field from the user serializer.


### **Why**
For performance issues and it wasn't being used
