### PR TITLE
fix: passing user to ws notify

### DIFF
--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -395,8 +395,7 @@ class RoomViewset(
                     room.save()
 
                     create_room_feedback_message(room, feedback, method="rt")
-                    user = User.objects.get(email=user_email)
-                    room.notify_user("update", user=user)
+                    room.notify_user("update", user=transfer_user)
                     room.notify_queue("update")
 
         except Exception as error:

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -395,7 +395,8 @@ class RoomViewset(
                     room.save()
 
                     create_room_feedback_message(room, feedback, method="rt")
-                    room.notify_user("update")
+                    user = User.objects.get(email=user_email)
+                    room.notify_user("update", user=user)
                     room.notify_queue("update")
 
         except Exception as error:


### PR DESCRIPTION
### **What**
passing user to ws function

### **Why**
make possible notify a user of a transfer when he dont have access to determined queue