### PR TITLE
feat: fix flowstart verification on room create

### DIFF
--- a/chats/apps/api/v1/external/rooms/serializers.py
+++ b/chats/apps/api/v1/external/rooms/serializers.py
@@ -40,8 +40,9 @@ def get_active_room_flow_start(contact, flow_uuid, project):
             fs.is_deleted = True
             fs.save()
             room = fs.room
-            room.close([], "new_room")
-            close_room(str(room.pk))
+            if room.is_active:
+                room.close([], "new_room")
+                close_room(str(room.pk))
         return None
     return None
 

--- a/chats/apps/api/v1/projects/viewsets.py
+++ b/chats/apps/api/v1/projects/viewsets.py
@@ -1,6 +1,7 @@
 import json
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import transaction
 from django.db.models import CharField, Value
 from django.db.models.functions import Concat
 from django_filters.rest_framework import DjangoFilterBackend
@@ -263,6 +264,7 @@ class ProjectViewset(
         url_name="flows",
         serializer_class=ProjectFlowStartSerializer,
     )
+    @transaction.atomic  # revert room update if the flows request fails
     def start_flow(self, request, *args, **kwargs):
         project = self.get_object()
         serializer = ProjectFlowStartSerializer(data=request.data)


### PR DESCRIPTION
### **What**
- When closing the flowstarts, verify if the room is active before closing it
- use transaction atomic on the flowstart endpoint

### **Why**
- there's a bug where the system cannot open new rooms if there's a closed room linked to a active flowstart