### PR TITLE
Feature: Adding is_active field to ListRoomSerializer

### DIFF
--- a/chats/apps/api/v1/rooms/serializers.py
+++ b/chats/apps/api/v1/rooms/serializers.py
@@ -100,6 +100,7 @@ class ListRoomSerializer(serializers.ModelSerializer):
 
     last_interaction = serializers.DateTimeField(read_only=True)
     can_edit_custom_fields = serializers.SerializerMethodField()
+    is_active = serializers.BooleanField(default=True)
 
     class Meta:
         model = Room
@@ -119,6 +120,7 @@ class ListRoomSerializer(serializers.ModelSerializer):
             "transfer_history",
             "protocol",
             "service_chat",
+            "is_active",
         ]
 
     def get_user(self, room: Room):


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
-  [x] The commit message follows our guidelines
-  [ ] Tests for the changes have been added (for bug fixes/features)
-  [ ] Docs have been added / updated (for bug fixes / features)
-  [ ] Do we need to implement analytics?

### **What**
This pull request introduces an `is_active` field to the `ListRoomSerializer`. This change allows the serializer to handle the active status of rooms, which can be useful for filtering and displaying only active rooms in the application.

### **Why**
The addition of the `is_active` field is necessary to fix an front-end bug.