### PR TITLE
feat: add link to RoomInternalListSerializer

### DIFF
--- a/chats/apps/api/v1/internal/rooms/serializers.py
+++ b/chats/apps/api/v1/internal/rooms/serializers.py
@@ -10,6 +10,7 @@ class RoomInternalListSerializer(serializers.ModelSerializer):
     tags = TagSimpleSerializer(many=True, required=False)
     sector = serializers.CharField(source="queue.sector.name")
     queue = serializers.CharField(source="queue.name")
+    link = serializers.SerializerMethodField()
 
     class Meta:
         model = Room
@@ -31,3 +32,12 @@ class RoomInternalListSerializer(serializers.ModelSerializer):
             return obj.user.full_name
         except AttributeError:
             return ""
+
+    def get_link(self, obj: Room) -> dict:
+        return {
+            "url": (
+                f"chats:dashboard/view-mode/{obj.user.email}/?room_uuid={obj.uuid}"
+                if obj.user
+                else None
+            )
+        }

--- a/chats/apps/api/v1/internal/rooms/serializers.py
+++ b/chats/apps/api/v1/internal/rooms/serializers.py
@@ -25,6 +25,7 @@ class RoomInternalListSerializer(serializers.ModelSerializer):
             "queue",
             "created_on",
             "tags",
+            "link",
         ]
 
     def get_agent(self, obj):
@@ -39,5 +40,6 @@ class RoomInternalListSerializer(serializers.ModelSerializer):
                 f"chats:dashboard/view-mode/{obj.user.email}/?room_uuid={obj.uuid}"
                 if obj.user
                 else None
-            )
+            ),
+            "type": "internal",
         }


### PR DESCRIPTION
### **What**
Adding a internal link field to the RoomInternalListSerializer.


### **Why**
This serializer is [used in a internal endpoint](https://github.com/weni-ai/chats-engine/blob/main/chats/apps/api/v1/internal/rooms/viewsets.py), [**used by insights-engine**](https://github.com/weni-ai/insights-engine/blob/main/insights/sources/rooms/clients.py). The newly added link field will allow the chat room page to be opened in view mode when a user clicks on the contact in the Atendimento humano dashboard table.
