### PR TITLE
fix: check if room is active before adding the link

### DIFF
--- a/chats/apps/api/v1/internal/rooms/serializers.py
+++ b/chats/apps/api/v1/internal/rooms/serializers.py
@@ -38,7 +38,7 @@ class RoomInternalListSerializer(serializers.ModelSerializer):
         return {
             "url": (
                 f"chats:dashboard/view-mode/{obj.user.email}/?room_uuid={obj.uuid}"
-                if obj.user
+                if obj.user and obj.is_active
                 else None
             ),
             "type": "internal",


### PR DESCRIPTION
### **What**
Add verification to check if the room is active before.

### **Why**
The link must not returned when the room is not active.
