### PR TITLE
feature: order by full name in project permission viewset

### DIFF
--- a/chats/apps/api/v1/projects/viewsets.py
+++ b/chats/apps/api/v1/projects/viewsets.py
@@ -460,10 +460,17 @@ class ProjectViewset(
 
 
 class ProjectPermissionViewset(viewsets.ReadOnlyModelViewSet):
-    queryset = ProjectPermission.objects.all().annotate(
-        full_name=Concat(
-            "user__first_name", Value(" "), "user__last_name", output_field=CharField()
+    queryset = (
+        ProjectPermission.objects.all()
+        .annotate(
+            full_name=Concat(
+                "user__first_name",
+                Value(" "),
+                "user__last_name",
+                output_field=CharField(),
+            )
         )
+        .order_by("full_name")
     )
     serializer_class = ProjectPermissionReadSerializer
     permission_classes = []


### PR DESCRIPTION
### **What**
ordering the project permission viewset return by name.

### **Why**
prevent pagination using limit and offset from losing data by not returning ordered data.