### PR TITLE
fix: queue deletion

### DIFF
--- a/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Callable
 
@@ -83,9 +84,10 @@ class FlowsQueueMixin:
             )
         return response
 
-    def destroy_queue(self, uuid: str, sector_uuid: str):
+    def destroy_queue(self, uuid: str, sector_uuid: str, project_uuid: str):
         response = requests.delete(
             url=f"{self.base_url}/api/v2/internals/ticketers/{sector_uuid}/queues/{uuid}/",
+            json={"project_uuid": project_uuid},
             headers=self.headers,
         )
 

--- a/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Callable
 

--- a/chats/apps/api/v1/queues/viewsets.py
+++ b/chats/apps/api/v1/queues/viewsets.py
@@ -98,6 +98,7 @@ class QueueViewset(ModelViewSet):
         content = {
             "uuid": str(instance.uuid),
             "sector_uuid": str(instance.sector.uuid),
+            "project_uuid": str(instance.sector.project.uuid),
         }
 
         if not settings.USE_WENI_FLOWS:


### PR DESCRIPTION
### **What**
Fix queue deletion by adding a "project_uuid" to the request's body that is sent to the flows API.


### **Why**
This field is required. Without it, a 404 not found error is returned, not allowing the queue deletion.
