### PR TITLE
Fix/flow message serializer created on

### DIFF
--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -35,7 +35,7 @@ class MsgFlowSerializer(serializers.ModelSerializer):
     media = MessageMediaSerializer(required=False, many=True, read_only=True)
     contact = ContactRelationsSerializer(many=False, required=False, read_only=True)
     user = UserSerializer(many=False, required=False, read_only=True)
-    created_on = serializers.DateTimeField(required=False)
+    created_on = serializers.DateTimeField(required=False, allow_null=True)
 
     class Meta:
         model = Message
@@ -59,6 +59,13 @@ class MsgFlowSerializer(serializers.ModelSerializer):
             "contact",
             "media",
         ]
+
+    def validate(self, attrs: dict):
+        if "created_on" in attrs and attrs["created_on"] is None:
+            # defaults to current time and date
+            attrs.pop("created_on")
+
+        return super().validate(attrs)
 
     def create(self, validated_data):
         direction = validated_data.pop("direction")

--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -55,7 +55,6 @@ class MsgFlowSerializer(serializers.ModelSerializer):
         read_only_fields = [
             "uuid",
             "user",
-            "created_on",
             "contact",
             "media",
         ]

--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -35,6 +35,7 @@ class MsgFlowSerializer(serializers.ModelSerializer):
     media = MessageMediaSerializer(required=False, many=True, read_only=True)
     contact = ContactRelationsSerializer(many=False, required=False, read_only=True)
     user = UserSerializer(many=False, required=False, read_only=True)
+    created_on = serializers.DateTimeField(required=False)
 
     class Meta:
         model = Message

--- a/chats/apps/msgs/tests/test_viewsets_external.py
+++ b/chats/apps/msgs/tests/test_viewsets_external.py
@@ -34,7 +34,7 @@ class MsgsExternalTests(APITestCase):
         )
         data = {
             "room": self.room.uuid,
-            "text": "olá!!!!.",
+            "text": "olá.",
             "direction": direction,
             "attachments": [{"content_type": "string", "url": "http://example.com"}],
             "created_on": created_on,

--- a/chats/apps/msgs/tests/test_viewsets_external.py
+++ b/chats/apps/msgs/tests/test_viewsets_external.py
@@ -55,6 +55,20 @@ class MsgsExternalTests(APITestCase):
         self.assertIsNotNone(msg)
         self.assertEqual(msg.created_on, created_on)
 
+    def test_create_external_msgs_with_null_created_on(self):
+        """
+        Verify if the external message endpoint are creating messages correctly
+        when passing a null created_on.
+        """
+        response = self._request_create_message()
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(self.room.messages.count(), 3)
+
+        msg = Message.objects.filter(uuid=response.data["uuid"]).first()
+        self.assertIsNotNone(msg)
+        self.assertEqual(msg.created_on.date(), timezone.now().date())
+
     def test_create_with_default_message_room_without_user(self):
         _ = self._remove_user()
 


### PR DESCRIPTION
### What
This pull request makes the created_on field for messages received from Flows writable, allowing it to be set explicitly rather than being read-only.

It complements [this other pull request](https://github.com/weni-ai/chats-engine/pull/435), which addresses the issue at the model level. This PR targets the serializer level, ensuring that the created_on field can be properly set during message creation.

### Why
Currently, the created_on field defaults to the current date and time when a message is created. This update allows the field to be set as part of the request.
