### PR TITLE
fix: uncomment created_on related code on MsgFlowSerializer

### DIFF
--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -46,6 +46,7 @@ class MsgFlowSerializer(serializers.ModelSerializer):
             "text",
             "direction",
             "attachments",
+            "created_on",
             # Read
             "user",
             "contact",

--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -35,7 +35,7 @@ class MsgFlowSerializer(serializers.ModelSerializer):
     media = MessageMediaSerializer(required=False, many=True, read_only=True)
     contact = ContactRelationsSerializer(many=False, required=False, read_only=True)
     user = UserSerializer(many=False, required=False, read_only=True)
-    # created_on = serializers.DateTimeField(required=False, allow_null=True)
+    created_on = serializers.DateTimeField(required=False, allow_null=True)
 
     class Meta:
         model = Message
@@ -60,12 +60,9 @@ class MsgFlowSerializer(serializers.ModelSerializer):
         ]
 
     def validate(self, attrs: dict):
-        if "created_on" in attrs:
+        if "created_on" in attrs and attrs["created_on"] is None:
+            # defaults to current time and date
             attrs.pop("created_on")
-
-        # if "created_on" in attrs and attrs["created_on"] is None:
-        #     # defaults to current time and date
-        #     attrs.pop("created_on")
 
         return super().validate(attrs)
 


### PR DESCRIPTION
### What
Uncomment code related to the created_on field in MsgFlowSerializer.

### Why
The relevant code was previously commented out due to errors arising from the submission of invalid datetime values for the created_on field. This update restores the functionality after addressing the issue with invalid datetime handling.