### PR TITLE
Fix/export chats dashboard

### DIFF
--- a/chats/apps/api/v1/dashboard/viewsets.py
+++ b/chats/apps/api/v1/dashboard/viewsets.py
@@ -306,6 +306,7 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
         if not data_frame_3.empty:
             data_frame_3.columns = [
                 "Nome",
+                "Sobrenome",
                 "Email",
                 "Status",
                 "Salas Fechadas",


### PR DESCRIPTION
### **What**
Adding last last name column to the dashboard export data


### **Why**
There is a mismatch between the number of CSV/XLS sheet columns (5) and the number of fields returned by the DashboardAgentsSerializer (6). The only missing field is the last name.