### PR TITLE
Fix/CI tests

### DIFF
--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -154,22 +154,33 @@ class RoomViewset(
         """
         Close a room, setting the ended_at date and turning the is_active flag as false
         """
+        print("1")
         # Add send room notification to the channels group
         instance = self.get_object()
+        print("2")
 
         tags = request.data.get("tags", None)
+        print("3")
         instance.close(tags, "agent")
+        print("4")
         serialized_data = RoomSerializer(instance=instance)
+        print("5")
         instance.notify_queue("close", callback=True)
+        print("6")
         instance.notify_user("close")
+        print("7")
 
         if not settings.ACTIVATE_CALC_METRICS:
+            print("7.1")
             return Response(serialized_data.data, status=status.HTTP_200_OK)
 
+        print("8")
         close_room(str(instance.pk))
-
+        print("9")
         room_client = RoomInfoUseCase()
+        print("10")
         room_client.get_room(instance)
+        print("11")
 
         return Response(serialized_data.data, status=status.HTTP_200_OK)
 

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -154,33 +154,22 @@ class RoomViewset(
         """
         Close a room, setting the ended_at date and turning the is_active flag as false
         """
-        print("1")
         # Add send room notification to the channels group
         instance = self.get_object()
-        print("2")
 
         tags = request.data.get("tags", None)
-        print("3")
         instance.close(tags, "agent")
-        print("4")
         serialized_data = RoomSerializer(instance=instance)
-        print("5")
         instance.notify_queue("close", callback=True)
-        print("6")
         instance.notify_user("close")
-        print("7")
 
         if not settings.ACTIVATE_CALC_METRICS:
-            print("7.1")
             return Response(serialized_data.data, status=status.HTTP_200_OK)
 
-        print("8")
         close_room(str(instance.pk))
-        print("9")
+
         room_client = RoomInfoUseCase()
-        print("10")
         room_client.get_room(instance)
-        print("11")
 
         return Response(serialized_data.data, status=status.HTTP_200_OK)
 

--- a/chats/apps/api/v1/tests/test_dashboard.py
+++ b/chats/apps/api/v1/tests/test_dashboard.py
@@ -47,6 +47,7 @@ class DashboardTests(APITestCase):
         """
         Verify if the interaction_time of a room metric its calculated correctly.
         """
+        print("1")
         url = "/v1/external/rooms/"
         client = self.client
         client.credentials(
@@ -63,10 +64,13 @@ class DashboardTests(APITestCase):
                 "custom_fields": {},
             },
         }
+        print("2")
         client.post(url, data=data, format="json")
+        print("3")
         room_created = Room.objects.get(queue_id=data["queue_uuid"])
         room_created.user = self.manager_user
         room_created.save()
+        print("4")
 
         time.sleep(3)
 
@@ -79,7 +83,9 @@ class DashboardTests(APITestCase):
                 "1a84b46e-0f91-41da-ac9d-a68c0b9753ab",
             ]
         }
+        print("4")
         client.patch(url_close, data=data_close, format="json")
+        print("5")
 
         room_closed = Room.objects.get(queue_id=data["queue_uuid"])
         metric = RoomMetrics.objects.get(room=room_closed)

--- a/chats/apps/api/v1/tests/test_dashboard.py
+++ b/chats/apps/api/v1/tests/test_dashboard.py
@@ -47,7 +47,6 @@ class DashboardTests(APITestCase):
         """
         Verify if the interaction_time of a room metric its calculated correctly.
         """
-        print("1")
         url = "/v1/external/rooms/"
         client = self.client
         client.credentials(
@@ -64,13 +63,10 @@ class DashboardTests(APITestCase):
                 "custom_fields": {},
             },
         }
-        print("2")
         client.post(url, data=data, format="json")
-        print("3")
         room_created = Room.objects.get(queue_id=data["queue_uuid"])
         room_created.user = self.manager_user
         room_created.save()
-        print("4")
 
         time.sleep(3)
 
@@ -83,9 +79,7 @@ class DashboardTests(APITestCase):
                 "1a84b46e-0f91-41da-ac9d-a68c0b9753ab",
             ]
         }
-        print("4")
         client.patch(url_close, data=data_close, format="json")
-        print("5")
 
         room_closed = Room.objects.get(queue_id=data["queue_uuid"])
         metric = RoomMetrics.objects.get(room=room_closed)

--- a/chats/apps/api/v1/tests/test_dashboard.py
+++ b/chats/apps/api/v1/tests/test_dashboard.py
@@ -1,4 +1,5 @@
 import time
+from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
@@ -17,6 +18,20 @@ class DashboardTests(APITestCase):
         self.queue_1 = Queue.objects.get(uuid="f341417b-5143-4469-a99d-f141a0676bd4")
         self.manager_user = User.objects.get(pk=7)
         self.login_token = Token.objects.get_or_create(user=self.manager_user)[0]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.patcher = patch(
+            "chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room",
+            return_value=None,
+        )
+        cls.mocked_function = cls.patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.patcher.stop()
+        super().tearDownClass()
 
     def test_create_room_metrics(self):
         """


### PR DESCRIPTION
### **What**
Patching RoomInfoUseCase.get_room method to avoid errors in DashboardTests

### **Why**
DashboardTests have tests that calls the endpoint for closing rooms. When closing a room, the aplication publishes a message to the room info exchange. If not patched in the tests, the app attempts to publish this message, which fails.
