### PR TITLE
feature: verify if status code its 404

### DIFF
--- a/chats/apps/api/v1/queues/viewsets.py
+++ b/chats/apps/api/v1/queues/viewsets.py
@@ -125,6 +125,10 @@ class QueueViewset(ModelViewSet):
             return super().perform_destroy(instance)
 
         response = FlowRESTClient().destroy_queue(**content)
+
+        if response.status_code == status.HTTP_404_NOT_FOUND:
+            return super().perform_destroy(instance)
+
         if response.status_code not in [
             status.HTTP_200_OK,
             status.HTTP_201_CREATED,


### PR DESCRIPTION
### **What**
Added a condition to check if the response status code is 404 after attempting to destroy a queue using FlowRESTClient().destroy_queue(**content).

### **Why**
If the status code is 404, the code now proceeds with the default super().perform_destroy(instance) method.