### PR TITLE
Fix/tags-list-permission

### DIFF
--- a/chats/apps/api/v1/sectors/viewsets.py
+++ b/chats/apps/api/v1/sectors/viewsets.py
@@ -207,15 +207,17 @@ class SectorTagsViewset(viewsets.ModelViewSet):
     lookup_field = "uuid"
 
     def get_queryset(self):
-        queryset = (
-            super()
-            .get_queryset()
-            .filter(
+        queryset = super().get_queryset()
+
+        if self.request.user.has_perm("accounts.can_communicate_internally"):
+            queryset = queryset.all()
+
+        else:
+            queryset = queryset.filter(
                 sector__project__in=ProjectPermission.objects.filter(
                     user=self.request.user
                 ).values_list("project", flat=True)
             )
-        )
 
         if self.action != "list":
             self.filterset_class = None

--- a/chats/apps/api/v1/sectors/viewsets.py
+++ b/chats/apps/api/v1/sectors/viewsets.py
@@ -22,6 +22,7 @@ from chats.apps.api.v1.sectors.filters import (
     SectorTagFilter,
 )
 from chats.apps.projects.models import Project
+from chats.apps.projects.models.models import ProjectPermission
 from chats.apps.sectors.models import Sector, SectorAuthorization, SectorTag
 from chats.apps.projects.usecases.integrate_ticketers import IntegratedTicketers
 
@@ -206,9 +207,20 @@ class SectorTagsViewset(viewsets.ModelViewSet):
     lookup_field = "uuid"
 
     def get_queryset(self):
+        queryset = (
+            super()
+            .get_queryset()
+            .filter(
+                sector__project__in=ProjectPermission.objects.filter(
+                    user=self.request.user
+                ).values_list("project", flat=True)
+            )
+        )
+
         if self.action != "list":
             self.filterset_class = None
-        return super().get_queryset()
+
+        return queryset
 
     def get_permissions(self):
         permission_classes = self.permission_classes

--- a/chats/apps/sectors/tests/test_viewsets_tag.py
+++ b/chats/apps/sectors/tests/test_viewsets_tag.py
@@ -1,3 +1,5 @@
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.authtoken.models import Token
@@ -22,14 +24,17 @@ class SectorTagTests(APITestCase):
         self.tag_1 = self.sector.tags.create(name="tag 1")
         self.tag_2 = self.sector.tags.create(name="tag 2")
 
-    def list_sector_tag_with_token(self, token):
+    def list_sector_tag_with_token(self, token, filter_by_sector=True):
         """
         Verify if the list endpoint for sector tag its returning the correct object.
         """
         url = reverse("sectortag-list")
         client = self.client
         client.credentials(HTTP_AUTHORIZATION="Token " + token)
-        response = client.get(url, data={"sector": self.sector.pk})
+
+        data = {"sector": self.sector.pk} if filter_by_sector else {}
+
+        response = client.get(url, data=data)
         return response
 
     def test_list_sector_tags_with_manager_token(self):
@@ -101,7 +106,7 @@ class SectorTagTests(APITestCase):
         response = client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_cannot_list_sector_tags_from_projects_without_permission(self):
+    def test_cannot_list_sector_tags_from_other_projects(self):
         """
         Verify if the list endpoint for sector tags only returns tags from projects the user has access to.
         """
@@ -115,10 +120,46 @@ class SectorTagTests(APITestCase):
         )
         tag = SectorTag.objects.create(name="tag 3", sector=sector)
 
-        response = self.list_sector_tag_with_token(self.manager_token.key)
+        response = self.list_sector_tag_with_token(
+            self.manager_token.key, filter_by_sector=False
+        )
         results = response.json().get("results")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         tags_uuids = [result.get("uuid") for result in results]
 
         self.assertNotIn(str(tag.uuid), tags_uuids)
+
+    def test_list_sector_tags_with_internal_token(self):
+        """
+        Verify if the list endpoint for sector tags returns all tags when the user has internal permission.
+        """
+        project = Project.objects.create(name="project 3")
+        sector = Sector.objects.create(
+            name="sector 3",
+            project=project,
+            rooms_limit=1,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        tag = SectorTag.objects.create(name="tag 3", sector=sector)
+
+        user = User.objects.create(
+            email="teste@teste.com",
+            password="teste",
+            is_staff=True,
+        )
+        token = Token.objects.create(user=user)
+        perm = Permission.objects.create(
+            codename="can_communicate_internally",
+            content_type=ContentType.objects.get_for_model(User),
+        )
+        user.user_permissions.add(perm)
+
+        response = self.list_sector_tag_with_token(token.key, filter_by_sector=False)
+        results = response.json().get("results")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        tags_uuids = [result.get("uuid") for result in results]
+
+        self.assertIn(str(tag.uuid), tags_uuids)


### PR DESCRIPTION
### What
Implement access control for the sector tags list returned by the /v1/tag/ endpoint. This change restricts the returned sector tags based on the user's permissions, ensuring only authorized users can view tags associated with projects they have access to.

### Why
To improve security and prevent unauthorized access to sector tags from projects outside of the user's authorized scope. This ensures that users can only view sector tags relevant to the projects they have permission to interact with.