### PR TITLE
Feature/filter-agents-by-queue-and-sector

### DIFF
--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -32,8 +32,10 @@ class AgentRepository:
 
         if filters.queue:
             # If filtering by queue, the agents list will include:
-            # - Agents with authorization to the queue (even if they were never assigned to a room from the queue)
-            # - Agents that are linked to rooms related to the queue (even if they don't have authorization to the queue anymore)
+            # - Agents with authorization to the queue
+            #   (even if they were never assigned to a room from the queue)
+            # - Agents that are linked to rooms related to the queue
+            #   (even if they don't have authorization to the queue anymore)
 
             rooms_filter["rooms__queue"] = filters.queue
             agents_filters &= Q(
@@ -42,8 +44,10 @@ class AgentRepository:
 
         elif filters.sector:
             # If filtering by sector, the agents list will include:
-            # - Agents with authorization to the sector (even if they were never assigned to a room from the sector)
-            # - Agents that are linked to rooms related to the sector (even if they don't have authorization to the sector anymore)
+            # - Agents with authorization to the sector
+            #   (even if they were never assigned to a room from the sector)
+            # - Agents that are linked to rooms related to the sector
+            #   (even if they don't have authorization to the sector anymore)
 
             rooms_filter["rooms__queue__sector"] = filters.sector
             agents_filters &= Q(

--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -31,12 +31,20 @@ class AgentRepository:
         agents_filters = Q(project_permissions__project=project) & Q(is_active=True)
 
         if filters.queue:
+            # If filtering by queue, the agents list will include:
+            # - Agents with authorization to the queue (even if they were never assigned to a room from the queue)
+            # - Agents that are linked to rooms related to the queue (even if they don't have authorization to the queue anymore)
+
             rooms_filter["rooms__queue"] = filters.queue
             agents_filters &= Q(
                 project_permissions__queue_authorizations__queue=filters.queue
             ) | Q(rooms__queue=filters.queue)
 
         elif filters.sector:
+            # If filtering by sector, the agents list will include:
+            # - Agents with authorization to the sector (even if they were never assigned to a room from the sector)
+            # - Agents that are linked to rooms related to the sector (even if they don't have authorization to the sector anymore)
+
             rooms_filter["rooms__queue__sector"] = filters.sector
             agents_filters &= Q(
                 project_permissions__sector_authorizations__sector=filters.sector


### PR DESCRIPTION
### **What**
Add filtering capabilities to the agents dashboard to allow filtering by queue and sector.

### **Why**
This ensures that only relevant agents, who are assigned to or have interacted with a specific queue or sector, are displayed in the agent list. Agents who are not part of the selected queue or sector, or who have never interacted with a room in the chosen queue/sector, will be excluded from the filtered results, providing a more accurate and efficient view of active agents.