### PR TITLE
Feature/return-sucess-status-when-updating-queue

### DIFF
--- a/chats/apps/api/v1/queues/viewsets.py
+++ b/chats/apps/api/v1/queues/viewsets.py
@@ -1,3 +1,4 @@
+import logging
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django_filters.rest_framework import DjangoFilterBackend
@@ -24,6 +25,9 @@ from chats.apps.sectors.usecases.group_sector_authorization import (
 )
 
 from .serializers import QueueAgentsSerializer
+
+
+LOGGER = logging.getLogger(__name__)
 
 User = get_user_model()
 
@@ -108,10 +112,14 @@ class QueueViewset(ModelViewSet):
             return super().perform_create(serializer)
 
         response = FlowRESTClient().update_queue(**content)
+
         if response.status_code not in [status.HTTP_200_OK, status.HTTP_201_CREATED]:
-            raise exceptions.APIException(
-                detail=f"[{response.status_code}] Error updating the queue on flows. Exception: {response.content}"
+            LOGGER.error(
+                "[%s] Error updating the queue on Flows. Exception: %s",
+                response.status_code,
+                response.content,
             )
+
         return instance
 
     def perform_destroy(self, instance):


### PR DESCRIPTION
### **What**
Remove error response for the case where a queue is being updated on Chats but Flows returns an error. It is replaced with a log.

### **Why**
To avoid returning errors when Flows returns an error but the queue needs to be updated on Chats regardless of it. The only change sent to Flows is the name of the queue.
