### PR TITLE
Feature/use transaction atomic when creating room

### DIFF
--- a/chats/apps/api/v1/external/rooms/viewsets.py
+++ b/chats/apps/api/v1/external/rooms/viewsets.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError
@@ -88,6 +89,7 @@ class RoomFlowViewSet(viewsets.ModelViewSet):
         close_room(str(instance.pk))
         return Response(serialized_data.data, status=status.HTTP_200_OK)
 
+    @transaction.atomic
     def create(self, request, *args, **kwargs):
         try:
             return super().create(request, *args, **kwargs)


### PR DESCRIPTION
### What
Added transaction atomicity to the create method of the RoomFlowViewSet.

### Why
This change ensures that room creation is fully atomic. If an error occurs during the process after the room is created, the transaction will be rolled back. This prevents the creation of a room if subsequent steps fail.