### PR TITLE
Fix/project details permissions

### DIFF
--- a/chats/apps/api/v1/projects/viewsets.py
+++ b/chats/apps/api/v1/projects/viewsets.py
@@ -520,7 +520,7 @@ class ProjectViewset(
 
             if not (
                 project := self.get_queryset()
-                .filter(Project, uuid=project_uuid)
+                .filter(uuid=project_uuid)
                 .first()
             ):
                 return Response(

--- a/chats/apps/api/v1/projects/viewsets.py
+++ b/chats/apps/api/v1/projects/viewsets.py
@@ -5,12 +5,12 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.db.models import CharField, Value
 from django.db.models.functions import Concat
-from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import decorators, filters, mixins, serializers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -376,19 +376,19 @@ class ProjectViewset(
         flows_start_verify = {}
         flows_start_verify["show_warning"] = False
 
-        try:
-            project: Project = get_object_or_404(
-                Project, uuid=request.query_params.get("project")
-            )
-            contact: Contact = get_object_or_404(
-                Contact,
-                external_id=request.query_params.get("contact"),
-            )
-        except Exception as error:
-            return Response(
-                {"error": f"{type(error)}: {error}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if not (
+            project := self.get_queryset()
+            .filter(uuid=request.query_params.get("project"))
+            .first()
+        ):
+            raise DRFValidationError({"project": "Project not found"})
+
+        if not (
+            contact := Contact.objects.filter(
+                external_id=request.query_params.get("contact")
+            ).first()
+        ):
+            raise DRFValidationError({"contact": "Contact not found"})
 
         try:
             room = Room.objects.get(
@@ -505,11 +505,16 @@ class ProjectViewset(
 
     @action(detail=False, methods=["POST"], url_name="integrate_sectors")
     def integrate_sectors(self, request, *args, **kwargs):
+        if not (
+            project := self.get_queryset()
+            .filter(Project, uuid=request.query_params["project"])
+            .first()
+        ):
+            raise DRFValidationError({"project": "Project not found"})
+
+        print("projeto principal", project)
+
         try:
-            project: Project = get_object_or_404(
-                Project, uuid=request.query_params["project"]
-            )
-            print("projeto principal", project)
             integrations = IntegratedTicketers()
 
             print("classe de integracao", integrations)

--- a/chats/apps/api/v1/projects/viewsets.py
+++ b/chats/apps/api/v1/projects/viewsets.py
@@ -69,6 +69,9 @@ class ProjectViewset(
     ]
     lookup_field = "uuid"
 
+    def get_queryset(self):
+        return super().get_queryset().filter(permissions__user=self.request.user)
+
     @swagger_auto_schema(
         manual_parameters=[
             openapi.Parameter(


### PR DESCRIPTION
### What
This PR modifies the queryset in the ProjectViewSet to ensure that users can only access projects for which they have the appropriate permissions. Internal clients will not be subject to this restriction, allowing them unrestricted access to all projects.

### Why
The change is implemented to enhance security and ensure that users can only view projects they are authorized to access, preventing unauthorized users from viewing sensitive project data.