### PR TITLE
Feature/media-preview-on-rooms-last-message

### DIFF
--- a/chats/apps/api/v1/rooms/serializers.py
+++ b/chats/apps/api/v1/rooms/serializers.py
@@ -97,7 +97,7 @@ class ListRoomSerializer(serializers.ModelSerializer):
     contact = serializers.SerializerMethodField()
     queue = serializers.SerializerMethodField()
     unread_msgs = serializers.IntegerField(required=False, default=0)
-    last_message = serializers.CharField(read_only=True, source="last_message_text")
+    last_message = serializers.SerializerMethodField()
     is_waiting = serializers.BooleanField()
     is_24h_valid = serializers.BooleanField(
         default=True, source="is_24h_valid_computed"
@@ -158,6 +158,15 @@ class ListRoomSerializer(serializers.ModelSerializer):
 
     def get_can_edit_custom_fields(self, room: Room):
         return room.queue.sector.can_edit_custom_fields
+
+    def get_last_message(self, room: Room):
+        last_message = (
+            room.messages.order_by("-created_on")
+            .exclude(user__isnull=True, contact__isnull=True)
+            .first()
+        )
+
+        return MessageSerializer(last_message).data
 
 
 class TransferRoomSerializer(serializers.ModelSerializer):

--- a/chats/apps/api/v1/rooms/serializers.py
+++ b/chats/apps/api/v1/rooms/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from chats.apps.accounts.models import User
 from chats.apps.api.v1.accounts.serializers import UserSerializer
 from chats.apps.api.v1.contacts.serializers import ContactRelationsSerializer
+from chats.apps.api.v1.msgs.serializers import MessageSerializer
 from chats.apps.api.v1.queues.serializers import QueueSerializer
 from chats.apps.api.v1.sectors.serializers import DetailSectorTagSerializer
 from chats.apps.queues.models import Queue
@@ -79,10 +80,13 @@ class RoomSerializer(serializers.ModelSerializer):
         last_message = (
             room.messages.order_by("-created_on")
             .exclude(user__isnull=True, contact__isnull=True)
-            .exclude(text="")
             .first()
         )
-        return "" if last_message is None else last_message.text
+
+        if not last_message:
+            return None
+
+        return MessageSerializer(last_message).data
 
     def get_can_edit_custom_fields(self, room: Room):
         return room.queue.sector.can_edit_custom_fields


### PR DESCRIPTION
### What
Returning the full object on the last_message field on Room serializers.

### Why
The frontend application needs more information than the current version, that only returns the text, without media, for example.