### PR TITLE
Fix/add connection id to manager agent room consumer

### DIFF
--- a/chats/apps/api/websockets/rooms/consumers/agent.py
+++ b/chats/apps/api/websockets/rooms/consumers/agent.py
@@ -273,7 +273,10 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
             {
                 "type": "notify",
                 "action": "connection_check",
-                "content": {"connection_id": str(self.connection_id)},
+                "content": {
+                    "connection_id": str(self.connection_id),
+                    "user_email": self.user.email,
+                },
             },
         )
 

--- a/chats/apps/api/websockets/rooms/consumers/agent.py
+++ b/chats/apps/api/websockets/rooms/consumers/agent.py
@@ -209,7 +209,10 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
                 event["content"].get("connection_id"),
                 event["content"].get("user_email"),
             )
-            if event["content"].get("connection_id") != str(self.connection_id):
+            if (
+                event["content"].get("connection_id") != str(self.connection_id)
+                and event["content"].get("user_email") == self.user.email
+            ):
                 logger.info(
                     "Connection ID: %s sending connection check response to user %s",
                     self.connection_id,

--- a/chats/apps/api/websockets/rooms/consumers/manager.py
+++ b/chats/apps/api/websockets/rooms/consumers/manager.py
@@ -1,3 +1,5 @@
+import uuid
+
 from channels.db import database_sync_to_async
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
@@ -19,6 +21,7 @@ class ManagerAgentRoomConsumer(AgentRoomConsumer):
         # Are they logged in?
         close = False
         self.permission = None
+        self.connection_id = uuid.uuid4()
         UserModel = None
 
         try:


### PR DESCRIPTION
### What
This pull request adds the creation of an UUID in the ManagerAgentRoomConsumer.

Also adding the user_email verification to ensure that the connection check response is only sent to the same user's connections.

### Why
The connection_id is used by the inherited class, AgentRoomConsumer, but it was not being created by ManagerAgentRoomConsumer, which causes errors when checking the connection check response.