### PR TITLE
Feature/send rooms data to billing on creation

### DIFF
--- a/chats/apps/api/v1/external/rooms/viewsets.py
+++ b/chats/apps/api/v1/external/rooms/viewsets.py
@@ -169,7 +169,7 @@ class RoomFlowViewSet(viewsets.ModelViewSet):
                 message="Ticketer token permission failed on room project",
                 code=403,
             )
-        room = serializer.save()
+        room: Room = serializer.save()
         if room.flowstarts.exists():
             instance = room
             notification_type = "update"
@@ -181,6 +181,8 @@ class RoomFlowViewSet(viewsets.ModelViewSet):
 
         notification_method = getattr(instance, f"notify_{notify_level}")
         notification_method(notification_type)
+
+        room.notify_billing()
 
     def perform_update(self, serializer):
         serializer.save()

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -45,7 +45,6 @@ from chats.apps.rooms.views import (
 )
 from django.utils.timezone import make_aware
 from datetime import datetime
-from chats.apps.projects.usecases.send_room_info import RoomInfoUseCase
 
 
 logger = logging.getLogger(__name__)

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -180,8 +180,8 @@ class RoomViewset(
 
         close_room(str(instance.pk))
 
-        room_client = RoomInfoUseCase()
-        room_client.get_room(instance)
+        if not instance.is_billing_notified:
+            instance.notify_billing()
 
         if instance.queue:
             logger.info(

--- a/chats/apps/projects/usecases/send_room_info.py
+++ b/chats/apps/projects/usecases/send_room_info.py
@@ -10,7 +10,7 @@ class RoomInfoUseCase:
     def __init__(self):
         self._rooms_client = RoomsInfoMixin()
 
-    def get_room(self, room: Room):
+    def get_room(self, room: "Room"):
         room = {
             "uuid": str(room.uuid),
             "project_uuid": str(room.project.uuid),

--- a/chats/apps/projects/usecases/send_room_info.py
+++ b/chats/apps/projects/usecases/send_room_info.py
@@ -1,5 +1,9 @@
+from typing import TYPE_CHECKING
 from chats.apps.api.v1.internal.eda_clients.billing_client import RoomsInfoMixin
-from chats.apps.rooms.models import Room
+
+
+if TYPE_CHECKING:
+    from chats.apps.rooms.models import Room
 
 
 class RoomInfoUseCase:

--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -18,6 +18,7 @@ from rest_framework.exceptions import ValidationError
 
 from chats.apps.accounts.models import User
 from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
+from chats.apps.projects.usecases.send_room_info import RoomInfoUseCase
 from chats.core.models import BaseConfigurableModel, BaseModel
 from chats.utils.websockets import send_channels_group
 
@@ -105,6 +106,23 @@ class Room(BaseModel, BaseConfigurableModel):
     )
 
     tracker = FieldTracker(fields=["user"])
+
+    @property
+    def is_billing_notified(self) -> bool:
+        """
+        Returns True if the room has been billed
+        """
+        return self.get_config("is_billing_notified", False)
+
+    def notify_billing(self):
+        """
+        Notify the billing system that the room has been billed
+        """
+        room_client = RoomInfoUseCase()
+        room_client.get_room(self)
+
+        self.set_config("is_billing_notified", True)
+        self.save()
 
     class Meta:
         verbose_name = _("Room")

--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -118,11 +118,15 @@ class Room(BaseModel, BaseConfigurableModel):
         """
         Notify the billing system and set the is_billing_notified flag to True
         """
+        logger.info("Notifying billing for room %s...", self.pk)
         room_client = RoomInfoUseCase()
         room_client.get_room(self)
 
         self.set_config("is_billing_notified", True)
-        self.save()
+        logger.info(
+            "Billing notified for room %s. Setting is_billing_notified to True",
+            self.pk,
+        )
 
     class Meta:
         verbose_name = _("Room")

--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -116,7 +116,7 @@ class Room(BaseModel, BaseConfigurableModel):
 
     def notify_billing(self):
         """
-        Notify the billing system that the room has been billed
+        Notify the billing system and set the is_billing_notified flag to True
         """
         room_client = RoomInfoUseCase()
         room_client.get_room(self)

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -254,11 +254,16 @@ class RoomsQueuePriorityExternalTests(APITestCase):
 
     @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
     @patch("chats.apps.api.v1.external.rooms.serializers.logger")
+    @mock.patch(
+        "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
+    )
     def test_create_room_with_queue_priority_when_queue_is_empty_and_no_user_is_online(
         self,
+        mock_get_userinfo,
         mock_logger,
         mock_start_queue_priority_routing,
     ):
+        mock_get_userinfo.return_value = None
         mock_start_queue_priority_routing.return_value = None
         data = {
             "queue_uuid": str(self.queue.uuid),
@@ -281,11 +286,16 @@ class RoomsQueuePriorityExternalTests(APITestCase):
 
     @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
     @patch("chats.apps.api.v1.external.rooms.serializers.logger")
+    @mock.patch(
+        "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
+    )
     def test_create_room_with_queue_priority_when_queue_is_empty_and_user_is_online(
         self,
+        mock_get_userinfo,
         mock_logger,
         mock_start_queue_priority_routing,
     ):
+        mock_get_userinfo.return_value = None
         mock_start_queue_priority_routing.return_value = None
 
         user = User.objects.create(
@@ -315,11 +325,16 @@ class RoomsQueuePriorityExternalTests(APITestCase):
 
     @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
     @patch("chats.apps.api.v1.external.rooms.serializers.logger")
+    @mock.patch(
+        "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
+    )
     def test_create_room_with_queue_priority_when_user_is_online_but_queue_is_not_empty(
         self,
+        mock_get_userinfo,
         mock_logger,
         mock_start_queue_priority_routing,
     ):
+        mock_get_userinfo.return_value = None
         mock_start_queue_priority_routing.return_value = None
 
         user = User.objects.create(
@@ -413,7 +428,9 @@ class RoomsFlowStartExternalTests(APITestCase):
         return client.post(url, data=data, format="json")
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_room_with_flow_start(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_room_with_flow_start(self, mock_get_room, mock_is_attending):
+        mock_get_room.return_value = None
         flow_start = self.room_flowstart
         data = {
             "queue_uuid": str(self.queue_1.pk),
@@ -432,7 +449,11 @@ class RoomsFlowStartExternalTests(APITestCase):
         self.assertTrue(flow_start.is_deleted)
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_room_with_deleted_flow_start(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_room_with_deleted_flow_start(
+        self, mock_get_room, mock_is_attending
+    ):
+        mock_get_room.return_value = None
         flow_start = self.room_flowstart
         flow_start.is_deleted = True
         flow_start.save()
@@ -457,9 +478,11 @@ class RoomsFlowStartExternalTests(APITestCase):
         )
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_contact_flow_start_with_offline_user(
-        self, mock_is_attending
+        self, mock_get_room, mock_is_attending
     ):
+        mock_get_room.return_value = None
         data = {
             "queue_uuid": str(self.queue_1.pk),
             "contact": {
@@ -477,9 +500,11 @@ class RoomsFlowStartExternalTests(APITestCase):
         )
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_contact_flow_start_with_online_user(
-        self, mock_is_attending
+        self, mock_get_room, mock_is_attending
     ):
+        mock_get_room.return_value = None
         permission = self.permission
         permission.status = "ONLINE"
         permission.save()
@@ -501,9 +526,11 @@ class RoomsFlowStartExternalTests(APITestCase):
         )
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_group_flow_start_with_online_user(
-        self, mock_is_attending
+        self, mock_get_room, mock_is_attending
     ):
+        mock_get_room.return_value = None
         permission = self.permission
         permission.status = "ONLINE"
         permission.save()
@@ -533,9 +560,11 @@ class RoomsFlowStartExternalTests(APITestCase):
         )
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_group_flow_start_with_offline_user(
-        self, mock_is_attending
+        self, mock_get_room, mock_is_attending
     ):
+        mock_get_room.return_value = None
         data = {
             "queue_uuid": str(self.queue_1.pk),
             "contact": {
@@ -669,7 +698,11 @@ class RoomsRoutingExternalTests(APITestCase):
         return client.post(url, data=data, format="json")
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_external_room_can_open_offline(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_external_room_can_open_offline(
+        self, mock_get_room, mock_is_attending
+    ):
+        mock_get_room.return_value = None
         data = {
             "queue_uuid": "8590ad29-5629-448c-bfb6-1bfd5219b8ec",
             "contact": {

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -39,7 +39,10 @@ class RoomsExternalTests(APITestCase):
     @mock.patch(
         "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
     )
-    def test_create_external_room_with_internal_token(self, mock_get_userinfo):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_external_room_with_internal_token(
+        self, mock_get_room, mock_get_userinfo
+    ):
         # Mock the userinfo response
         mock_get_userinfo.return_value = {
             "sub": "test_user",
@@ -48,6 +51,7 @@ class RoomsExternalTests(APITestCase):
             "given_name": "Test",
             "family_name": "User",
         }
+        mock_get_room.return_value = None
 
         user, token = create_user_and_token("test_user")
 

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -36,6 +36,9 @@ class RoomsExternalTests(APITestCase):
 
         return client.put(url, format="json")
 
+    @mock.patch(
+        "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
+    )
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_external_room_with_internal_token(
         self, mock_get_room, mock_get_userinfo

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -109,6 +109,10 @@ class RoomsExternalTests(APITestCase):
         response = self._create_room("f3ce543e-d77e-4508-9140-15c95752a380", data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        room = Room.objects.get(uuid=response.data.get("uuid"))
+
+        mock_get_room.assert_called_once_with(room)
+
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_external_room_with_external_uuid(

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -112,6 +112,7 @@ class RoomsExternalTests(APITestCase):
         room = Room.objects.get(uuid=response.data.get("uuid"))
 
         mock_get_room.assert_called_once_with(room)
+        self.assertTrue(room.is_billing_notified)
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -86,10 +86,12 @@ class RoomsExternalTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_external_room(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_external_room(self, mock_get_room, mock_is_attending):
         """
         Verify if the endpoint for create external room it is working correctly.
         """
+        mock_get_room.return_value = None
         data = {
             "queue_uuid": str(self.queue_1.uuid),
             "contact": {
@@ -104,10 +106,14 @@ class RoomsExternalTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_external_room_with_external_uuid(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_external_room_with_external_uuid(
+        self, mock_get_room, mock_is_attending
+    ):
         """
         Verify if the endpoint for create external room it is working correctly, passing custom fields.
         """
+        mock_get_room.return_value = None
         data = {
             "queue_uuid": str(self.queue_1.uuid),
             "contact": {
@@ -127,10 +133,14 @@ class RoomsExternalTests(APITestCase):
         )
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_external_room_editing_contact(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_external_room_editing_contact(
+        self, mock_get_room, mock_is_attending
+    ):
         """
         Verify if the endpoint for edit external room it is working correctly.
         """
+        mock_get_room.return_value = None
         data = {
             "queue_uuid": str(self.queue_1.uuid),
             "contact": {
@@ -158,7 +168,9 @@ class RoomsExternalTests(APITestCase):
         self.assertEqual(response.data["contact"]["custom_fields"]["job"], "streamer")
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_is_anon_true_wont_save_urn(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_is_anon_true_wont_save_urn(self, mock_get_room, mock_is_attending):
+        mock_get_room.return_value = None
         data = {
             "queue_uuid": str(self.queue_1.uuid),
             "contact": {

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -36,9 +36,6 @@ class RoomsExternalTests(APITestCase):
 
         return client.put(url, format="json")
 
-    @mock.patch(
-        "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
-    )
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_external_room_with_internal_token(
         self, mock_get_room, mock_get_userinfo
@@ -205,7 +202,9 @@ class RoomsExternalTests(APITestCase):
     @mock.patch(
         "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
     )
-    def test_close_room_with_internal_token(self, mock_get_userinfo):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_close_room_with_internal_token(self, mock_get_room, mock_get_userinfo):
+        mock_get_room.return_value = None
         room = Room.objects.create(queue=self.queue_1)
         mock_get_userinfo.return_value = {
             "sub": "test_user",
@@ -258,16 +257,14 @@ class RoomsQueuePriorityExternalTests(APITestCase):
 
     @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
     @patch("chats.apps.api.v1.external.rooms.serializers.logger")
-    @mock.patch(
-        "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
-    )
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_queue_priority_when_queue_is_empty_and_no_user_is_online(
         self,
-        mock_get_userinfo,
+        mock_get_room,
         mock_logger,
         mock_start_queue_priority_routing,
     ):
-        mock_get_userinfo.return_value = None
+        mock_get_room.return_value = None
         mock_start_queue_priority_routing.return_value = None
         data = {
             "queue_uuid": str(self.queue.uuid),
@@ -290,16 +287,14 @@ class RoomsQueuePriorityExternalTests(APITestCase):
 
     @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
     @patch("chats.apps.api.v1.external.rooms.serializers.logger")
-    @mock.patch(
-        "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
-    )
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_queue_priority_when_queue_is_empty_and_user_is_online(
         self,
-        mock_get_userinfo,
+        mock_get_room,
         mock_logger,
         mock_start_queue_priority_routing,
     ):
-        mock_get_userinfo.return_value = None
+        mock_get_room.return_value = None
         mock_start_queue_priority_routing.return_value = None
 
         user = User.objects.create(
@@ -329,16 +324,14 @@ class RoomsQueuePriorityExternalTests(APITestCase):
 
     @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
     @patch("chats.apps.api.v1.external.rooms.serializers.logger")
-    @mock.patch(
-        "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
-    )
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_queue_priority_when_user_is_online_but_queue_is_not_empty(
         self,
-        mock_get_userinfo,
+        mock_get_room,
         mock_logger,
         mock_start_queue_priority_routing,
     ):
-        mock_get_userinfo.return_value = None
+        mock_get_room.return_value = None
         mock_start_queue_priority_routing.return_value = None
 
         user = User.objects.create(

--- a/chats/apps/sectors/tests/test_viewsets.py
+++ b/chats/apps/sectors/tests/test_viewsets.py
@@ -109,7 +109,9 @@ class RoomsExternalTests(APITestCase):
         self.queue_1 = Queue.objects.get(uuid="f2519480-7e58-4fc4-9894-9ab1769e29cf")
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_external_room(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_external_room(self, mock_get_room, mock_is_attending):
+        mock_get_room.return_value = None
         url = reverse("external_rooms-list")
         client = self.client
         client.credentials(
@@ -129,7 +131,11 @@ class RoomsExternalTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_external_room_with_external_uuid(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_external_room_with_external_uuid(
+        self, mock_get_room, mock_is_attending
+    ):
+        mock_get_room.return_value = None
         url = reverse("external_rooms-list")
         client = self.client
         client.credentials(
@@ -155,7 +161,11 @@ class RoomsExternalTests(APITestCase):
         )
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_external_room_editing_contact(self, mock_is_attending):
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_external_room_editing_contact(
+        self, mock_get_room, mock_is_attending
+    ):
+        mock_get_room.return_value = None
         url = reverse("external_rooms-list")
         client = self.client
         client.credentials(

--- a/chats/core/models.py
+++ b/chats/core/models.py
@@ -9,15 +9,12 @@ from chats.utils.websockets import send_channels_group
 
 class WebSocketsNotifiableMixin:
     @property
-    def serialized_ws_data(self) -> dict:
-        ...
+    def serialized_ws_data(self) -> dict: ...
 
     @property
-    def notification_groups(self) -> list:
-        ...
+    def notification_groups(self) -> list: ...
 
-    def get_action(self, action: str) -> str:
-        ...
+    def get_action(self, action: str) -> str: ...
 
     def notify(self, action: str, groups: list = [], content: dict = {}) -> None:
         if "." not in action:
@@ -78,6 +75,21 @@ class BaseConfigurableModel(models.Model):
 
     class Meta:
         abstract = True
+
+    def get_config(self, key: str, default: any = None) -> any:
+        """
+        Get a config value from the config field
+        """
+        config = self.config or {}
+        return config.get(key, default)
+
+    def set_config(self, key: str, value: any):
+        """
+        Set a config value in the config field
+        """
+        self.config = self.config or {}
+        self.config[key] = value
+        self.save(update_fields=["config"])
 
 
 class BaseIntegrationConfigurableModel(models.Model):


### PR DESCRIPTION
### What
This pull requests introduces a change in the way that the billing application is notified about new rooms in Chats. Currently, the notification happens (via RabbitMQ) when closing a room. Now, the notification it happens when the room is created.

To ensure that all rooms that are open at the moment of the deploy of this modification are still sent to billing, a flag is now added to the Room's config, indicating if billing was already notified. So, when closing the room, the system checks if the room has this flag set as true. If it doesn't, billing is notified. If it already is, this step is skipped.

### Why
This change was requested to ensure that the Nexus' supervisor have this information since the rooms creation.