### PR TITLE
Fix/remove requireness from contact name in flow start

### DIFF
--- a/chats/apps/api/v1/projects/serializers.py
+++ b/chats/apps/api/v1/projects/serializers.py
@@ -81,7 +81,7 @@ class ProjectFlowStartSerializer(serializers.Serializer):
         trim_whitespace=True,
     )
     params = serializers.JSONField(required=False)
-    contact_name = serializers.CharField()
+    contact_name = serializers.CharField(required=False)
 
 
 class ListFlowStartSerializer(serializers.ModelSerializer):

--- a/chats/apps/api/v1/projects/viewsets.py
+++ b/chats/apps/api/v1/projects/viewsets.py
@@ -314,11 +314,7 @@ class ProjectViewset(
     def start_flow(self, request, *args, **kwargs):
         project = self.get_object()
         serializer = ProjectFlowStartSerializer(data=request.data)
-        if serializer.is_valid() is False:
-            return Response(
-                {"Detail": "Invalid data."},
-                status.HTTP_400_BAD_REQUEST,
-            )
+        serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         flow = data.get("flow", None)
 


### PR DESCRIPTION
### What
Make contact_name field optional in ProjectFlowStartSerializer and improve validation handling in start_flow method

- Updated the contact_name field in ProjectFlowStartSerializer to be optional.
- Refactored the start_flow method in ProjectViewset to raise exceptions on invalid serializer data, improving error handling.

### Why
So the frontend application can start a flow inside Weni Chats even if the contact has no name
