### PR TITLE
Feature/add info when user is selected for room

### DIFF
--- a/chats/apps/api/v1/external/rooms/viewsets.py
+++ b/chats/apps/api/v1/external/rooms/viewsets.py
@@ -24,7 +24,10 @@ from chats.apps.api.v1.external.rooms.serializers import (
 )
 from chats.apps.api.v1.internal.permissions import ModuleHasPermission
 from chats.apps.dashboard.models import RoomMetrics
-from chats.apps.queues.utils import start_queue_priority_routing
+from chats.apps.queues.utils import (
+    create_room_assigned_from_queue_feedback,
+    start_queue_priority_routing,
+)
 from chats.apps.rooms.choices import RoomFeedbackMethods
 from chats.apps.rooms.models import Room
 from chats.apps.rooms.views import (
@@ -181,6 +184,9 @@ class RoomFlowViewSet(viewsets.ModelViewSet):
 
         notification_method = getattr(instance, f"notify_{notify_level}")
         notification_method(notification_type)
+
+        if instance.user:
+            create_room_assigned_from_queue_feedback(instance, instance.user)
 
         room.notify_billing()
 

--- a/chats/apps/api/v1/projects/serializers.py
+++ b/chats/apps/api/v1/projects/serializers.py
@@ -81,7 +81,9 @@ class ProjectFlowStartSerializer(serializers.Serializer):
         trim_whitespace=True,
     )
     params = serializers.JSONField(required=False)
-    contact_name = serializers.CharField(required=False)
+    contact_name = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
 
 
 class ListFlowStartSerializer(serializers.ModelSerializer):

--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -28,10 +28,6 @@ class QueueRouterService:
         Route rooms to available agents.
         """
         from chats.apps.rooms.models import Room
-        from chats.apps.rooms.views import (
-            create_room_feedback_message,
-            create_transfer_json,
-        )
         from chats.apps.queues.utils import create_room_assigned_from_queue_feedback
 
         logger.info("Start routing rooms for queue %s", self.queue.uuid)

--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -32,6 +32,7 @@ class QueueRouterService:
             create_room_feedback_message,
             create_transfer_json,
         )
+        from chats.apps.queues.utils import create_room_assigned_from_queue_feedback
 
         logger.info("Start routing rooms for queue %s", self.queue.uuid)
 
@@ -74,15 +75,7 @@ class QueueRouterService:
             room.notify_user("update")
             room.notify_queue("update")
 
-            feedback = create_transfer_json(
-                action="auto_assign_from_queue",
-                from_=self.queue,
-                to=agent,
-            )
-
-            create_room_feedback_message(
-                room, feedback, method=RoomFeedbackMethods.ROOM_TRANSFER
-            )
+            create_room_assigned_from_queue_feedback(room, agent)
 
             rooms_routed += 1
 

--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -1,8 +1,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-from chats.apps.rooms.choices import RoomFeedbackMethods
-
 
 logger = logging.getLogger(__name__)
 

--- a/chats/apps/queues/utils.py
+++ b/chats/apps/queues/utils.py
@@ -5,7 +5,6 @@ from chats.apps.projects.models.models import Project
 from chats.apps.queues.models import Queue
 from chats.apps.queues.tasks import route_queue_rooms
 from chats.apps.rooms.choices import RoomFeedbackMethods
-from chats.apps.rooms.views import create_room_feedback_message, create_transfer_json
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +66,11 @@ def create_room_assigned_from_queue_feedback(room: "Room", user: "User"):
     """
     Create a feedback message for a room assigned from a queue.
     """
+    from chats.apps.rooms.views import (
+        create_room_feedback_message,
+        create_transfer_json,
+    )
+
     feedback = create_transfer_json(
         action="auto_assign_from_queue",
         from_=room.queue,


### PR DESCRIPTION
### What
This pull request introduces an indicator to show that a room was assigned to a user when the room is created (this is ignored if no user was selected).

### Why
This message is important for the chat history, to mark the moment in which a user was selected. It is already created for the case where room is sent to the queue before being assigned to user.