### PR TITLE
Fix/allow null and blank contact names in flow starts 

### DIFF
--- a/chats/apps/api/v1/projects/serializers.py
+++ b/chats/apps/api/v1/projects/serializers.py
@@ -81,7 +81,9 @@ class ProjectFlowStartSerializer(serializers.Serializer):
         trim_whitespace=True,
     )
     params = serializers.JSONField(required=False)
-    contact_name = serializers.CharField(required=False)
+    contact_name = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
 
 
 class ListFlowStartSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
### **What**
Update contact_name field in ProjectFlowStartSerializer to allow blank and null values.


### **Why**
To cover cases where the contact name field is sent but the value is not present.
