### PR TITLE
Fix/agents data filters

### DIFF
--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -103,13 +103,13 @@ class AgentRepository:
 
         agents_query = (
             agents_query.filter(agents_filters)
+            .distinct()
             .annotate(
                 status=Subquery(project_permission_subquery),
                 closed=Count("rooms", filter=Q(**closed_rooms, **rooms_filter)),
                 opened=Count("rooms", filter=Q(**opened_rooms, **rooms_filter)),
                 custom_status=custom_status_subquery,
             )
-            .distinct()
             .values(
                 "first_name",
                 "last_name",
@@ -139,17 +139,17 @@ class AgentRepository:
         if filters.queue and filters.sector:
             rooms_filter["rooms__queue"] = filters.queue
             rooms_filter["rooms__queue__sector__in"] = filters.sector
-            agents_filter[
-                "project_permissions__queue_authorizations__queue"
-            ] = filters.queue
+            agents_filter["project_permissions__queue_authorizations__queue"] = (
+                filters.queue
+            )
             agents_filter[
                 "project_permissions__queue_authorizations__queue__sector__in"
             ] = filters.sector
         elif filters.queue:
             rooms_filter["rooms__queue"] = filters.queue
-            agents_filter[
-                "project_permissions__queue_authorizations__queue"
-            ] = filters.queue
+            agents_filter["project_permissions__queue_authorizations__queue"] = (
+                filters.queue
+            )
         elif filters.sector:
             rooms_filter["rooms__queue__sector__in"] = filters.sector
             agents_filter[

--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -103,13 +103,21 @@ class AgentRepository:
 
         agents_query = (
             agents_query.filter(agents_filters)
-            .distinct()
             .annotate(
                 status=Subquery(project_permission_subquery),
-                closed=Count("rooms", filter=Q(**closed_rooms, **rooms_filter)),
-                opened=Count("rooms", filter=Q(**opened_rooms, **rooms_filter)),
+                closed=Count(
+                    "rooms__uuid",
+                    distinct=True,
+                    filter=Q(**closed_rooms, **rooms_filter),
+                ),
+                opened=Count(
+                    "rooms__uuid",
+                    distinct=True,
+                    filter=Q(**opened_rooms, **rooms_filter),
+                ),
                 custom_status=custom_status_subquery,
             )
+            .distinct()
             .values(
                 "first_name",
                 "last_name",
@@ -213,9 +221,16 @@ class AgentRepository:
             agents_query.filter(project_permissions__project=project, is_active=True)
             .annotate(
                 status=Subquery(project_permission_queryset),
-                closed=Count("rooms", filter=Q(**closed_rooms, **rooms_filter)),
-                opened=Count("rooms", filter=Q(**opened_rooms, **rooms_filter)),
-                custom_status=custom_status_subquery,
+                closed=Count(
+                    "rooms__uuid",
+                    distinct=True,
+                    filter=Q(**closed_rooms, **rooms_filter),
+                ),
+                opened=Count(
+                    "rooms__uuid",
+                    distinct=True,
+                    filter=Q(**opened_rooms, **rooms_filter),
+                ),
             )
             .values(
                 "first_name",

--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -231,6 +231,7 @@ class AgentRepository:
                     distinct=True,
                     filter=Q(**opened_rooms, **rooms_filter),
                 ),
+                custom_status=custom_status_subquery,
             )
             .values(
                 "first_name",


### PR DESCRIPTION
### What
This pull request adjusts the queries used for gathering agents data, adding a distinct clause on both "closed" and "opened" room counts. This data is pulled by the Insights module.

### Why
The count number for closed and opened rooms was being calculated incorrectly due to the way the query was before, showing a higher number than it actually was.