### PR TITLE
Feature/randomize available agents ordering for repeated active rooms count

### DIFF
--- a/chats/apps/api/v1/external/rooms/serializers.py
+++ b/chats/apps/api/v1/external/rooms/serializers.py
@@ -106,7 +106,7 @@ def get_room_user(
         if current_queue_size == 0:
             # If the queue is empty, the available user with the least number
             # of rooms will be selected, if any.
-            return queue.available_agents.first()
+            return queue.get_available_agent()
 
         logger.info(
             "Calling start_queue_priority_routing for queue %s from get_room_user because the queue is not empty",
@@ -120,7 +120,7 @@ def get_room_user(
         return None
 
     # General room routing type
-    return queue.available_agents.first() or None
+    return queue.get_available_agent()
 
 
 class RoomListSerializer(serializers.ModelSerializer):

--- a/chats/apps/queues/models.py
+++ b/chats/apps/queues/models.py
@@ -134,7 +134,7 @@ class Queue(BaseSoftDeleteModel, BaseConfigurableModel, BaseModel):
         )
         return queue_auth
 
-    def get_available_agent_for_queue(self):
+    def get_available_agent(self):
         """
         Get an available agent for a queue, based on the number of active rooms.
 

--- a/chats/apps/queues/models.py
+++ b/chats/apps/queues/models.py
@@ -115,25 +115,6 @@ class Queue(BaseSoftDeleteModel, BaseConfigurableModel, BaseModel):
 
         return online_agents.order_by("active_rooms_count")
 
-    def is_agent(self, user):
-        return self.authorizations.filter(permission__user=user).exists()
-
-    def get_or_create_user_authorization(self, user):
-        queue_auth, created = self.authorizations.get_or_create(permission__user=user)
-        return queue_auth
-
-    def set_queue_authorization(self, user, role: int):
-        queue_auth, created = self.authorizations.get_or_create(
-            permission__user=user, role=role
-        )
-        return queue_auth
-
-    def set_user_authorization(self, permission, role: int):
-        queue_auth, created = self.authorizations.get_or_create(
-            permission=permission, role=role
-        )
-        return queue_auth
-
     def get_available_agent(self):
         """
         Get an available agent for a queue, based on the number of active rooms.
@@ -160,6 +141,25 @@ class Queue(BaseSoftDeleteModel, BaseConfigurableModel, BaseModel):
         ]
 
         return random.choice(eligible_agents)
+
+    def is_agent(self, user):
+        return self.authorizations.filter(permission__user=user).exists()
+
+    def get_or_create_user_authorization(self, user):
+        queue_auth, created = self.authorizations.get_or_create(permission__user=user)
+        return queue_auth
+
+    def set_queue_authorization(self, user, role: int):
+        queue_auth, created = self.authorizations.get_or_create(
+            permission__user=user, role=role
+        )
+        return queue_auth
+
+    def set_user_authorization(self, permission, role: int):
+        queue_auth, created = self.authorizations.get_or_create(
+            permission=permission, role=role
+        )
+        return queue_auth
 
     @property
     def project(self):

--- a/chats/apps/queues/models.py
+++ b/chats/apps/queues/models.py
@@ -1,3 +1,4 @@
+import random
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
@@ -132,6 +133,33 @@ class Queue(BaseSoftDeleteModel, BaseConfigurableModel, BaseModel):
             permission=permission, role=role
         )
         return queue_auth
+
+    def get_available_agent_for_queue(self):
+        """
+        Get an available agent for a queue, based on the number of active rooms.
+
+        If the active rooms count is the same for different agents,
+        a random agent, among the ones with the rooms count, is returned.
+        """
+        agents = list(self.available_agents)
+
+        if not agents:
+            return None
+
+        routing_option = self.sector.project.routing_option
+        field_name = (
+            "active_and_day_closed_rooms"
+            if routing_option == "general"
+            else "active_rooms_count"
+        )
+
+        min_rooms_count = min(getattr(agent, field_name) for agent in agents)
+
+        eligible_agents = [
+            agent for agent in agents if getattr(agent, field_name) == min_rooms_count
+        ]
+
+        return random.choice(eligible_agents)
 
     @property
     def project(self):

--- a/chats/apps/queues/tests/test_models.py
+++ b/chats/apps/queues/tests/test_models.py
@@ -316,3 +316,19 @@ class TestQueueGetAvailableAgent(TestCase):
 
         available_agent = self.queue.get_available_agent()
         self.assertEqual(available_agent, self.agent_3)
+
+    def test_get_available_agent_returns_random_agent_if_rooms_count_is_equal(self):
+        for i in range(3):
+            # Agent 1 has 3 active rooms
+            Room.objects.create(user=self.agent_1, queue=self.queue, is_active=True)
+
+        for i in range(2):
+            # Agent 2 has 2 active rooms
+            Room.objects.create(user=self.agent_2, queue=self.queue, is_active=True)
+
+        for i in range(2):
+            # Agent 3 has 2 active rooms
+            Room.objects.create(user=self.agent_3, queue=self.queue, is_active=True)
+
+        available_agent = self.queue.get_available_agent()
+        self.assertIn(available_agent, [self.agent_2, self.agent_3])

--- a/chats/apps/queues/tests/test_models.py
+++ b/chats/apps/queues/tests/test_models.py
@@ -318,15 +318,6 @@ class TestQueueGetAvailableAgent(TestCase):
         self.assertEqual(available_agent, self.agent_3)
 
     def test_get_available_agent_returns_random_agent_if_rooms_count_is_equal(self):
-        # Ensure the project uses a routing option that relies on active_rooms_count
-        # (i.e., not "general") for this test's logic to be consistent.
-        # We assume 'least_active' or any other non-'general' value will suffice.
-        if self.queue.sector.project.routing_option == "general":
-            self.queue.sector.project.routing_option = (
-                "least_active"  # Or any other appropriate value
-            )
-            self.queue.sector.project.save()
-
         for i in range(3):
             # Agent 1 has 3 active rooms
             Room.objects.create(user=self.agent_1, queue=self.queue, is_active=True)
@@ -337,6 +328,51 @@ class TestQueueGetAvailableAgent(TestCase):
 
         for i in range(2):
             # Agent 3 has 2 active rooms
+            Room.objects.create(user=self.agent_3, queue=self.queue, is_active=True)
+
+        num_trials = 100
+        picked_agents_results = []
+        for _ in range(num_trials):
+            available_agent = self.queue.get_available_agent()
+            self.assertIsNotNone(
+                available_agent, "get_available_agent should return an agent."
+            )
+            self.assertIn(available_agent, [self.agent_2, self.agent_3])
+            picked_agents_results.append(available_agent)
+
+        # Verify that both eligible agents were picked at least once over the trials.
+        picked_agents_set = set(picked_agents_results)
+        self.assertIn(
+            self.agent_2,
+            picked_agents_set,
+            "Agent 2 was never picked, suggesting non-random selection.",
+        )
+        self.assertIn(
+            self.agent_3,
+            picked_agents_set,
+            "Agent 3 was never picked, suggesting non-random selection.",
+        )
+
+    def test_get_available_agent_returns_random_agent_if_rooms_count_is_equal_for_general_routing_option(
+        self,
+    ):
+        self.project.config = {"routing_option": "general"}
+        self.project.save()
+
+        for i in range(4):
+            # Agent 1 has 3 active rooms
+            Room.objects.create(user=self.agent_1, queue=self.queue, is_active=True)
+
+        for i in range(2):
+            # Agent 2 has 2 active rooms
+            Room.objects.create(user=self.agent_2, queue=self.queue, is_active=True)
+
+        # Agent 2 has 1 closed room
+        r = Room.objects.create(user=self.agent_2, queue=self.queue)
+        r.close()
+
+        for i in range(3):
+            # Agent 3 has 3 active rooms
             Room.objects.create(user=self.agent_3, queue=self.queue, is_active=True)
 
         num_trials = 100

--- a/chats/apps/queues/utils.py
+++ b/chats/apps/queues/utils.py
@@ -1,5 +1,4 @@
 import logging
-import random
 from typing import TYPE_CHECKING
 from django.conf import settings
 from chats.apps.projects.models.models import Project
@@ -81,31 +80,3 @@ def create_room_assigned_from_queue_feedback(room: "Room", user: "User"):
     create_room_feedback_message(
         room, feedback, method=RoomFeedbackMethods.ROOM_TRANSFER
     )
-
-
-def get_available_agent_for_queue(queue: Queue):
-    """
-    Get an available agent for a queue, based on the number of active rooms.
-
-    If the active rooms count is the same for different agents,
-    a random agent, among the ones with the rooms count, is returned.
-    """
-    agents = list(queue.available_agents)
-
-    if not agents:
-        return None
-
-    routing_option = queue.sector.project.routing_option
-    field_name = (
-        "active_and_day_closed_rooms"
-        if routing_option == "general"
-        else "active_rooms_count"
-    )
-
-    min_rooms_count = min(getattr(agent, field_name) for agent in agents)
-
-    eligible_agents = [
-        agent for agent in agents if getattr(agent, field_name) == min_rooms_count
-    ]
-
-    return random.choice(eligible_agents)


### PR DESCRIPTION
### What
This pull request introduces a new method for the Queue model, called get_available_agent. This method is responsible for picking an agent from the available agents list, prioritizing agents with the lowest number of rooms. If two or more agents have the same number of rooms, a random one will be selected from these options.

### Why
To ensure that a random agents is chosen when two or more agents have the same number of rooms.

### Note
Python's [random](https://docs.python.org/3/library/random.html) was chosen, even though it is actually pseudo-random. For this case, it is "random" enough, since the goal here is just to balance the distribution of rooms between agents.