### PR TITLE
Feature/add pinned rooms to list

### DIFF
--- a/chats/apps/api/v1/rooms/pagination.py
+++ b/chats/apps/api/v1/rooms/pagination.py
@@ -1,0 +1,26 @@
+from collections import OrderedDict
+
+from django.conf import settings
+from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.response import Response
+
+
+class RoomListPagination(LimitOffsetPagination):
+    """
+    Pagination class for the room list endpoint.
+
+    It adds the max pin limit to the response.
+    """
+
+    def get_paginated_response(self, data):
+        return Response(
+            OrderedDict(
+                [
+                    ("max_pin_limit", settings.MAX_ROOM_PINS_LIMIT),
+                    ("count", self.count),
+                    ("next", self.get_next_link()),
+                    ("previous", self.get_previous_link()),
+                    ("results", data),
+                ]
+            )
+        )

--- a/chats/apps/api/v1/rooms/serializers.py
+++ b/chats/apps/api/v1/rooms/serializers.py
@@ -11,7 +11,7 @@ from chats.apps.api.v1.msgs.serializers import MessageSerializer
 from chats.apps.api.v1.queues.serializers import QueueSerializer
 from chats.apps.api.v1.sectors.serializers import DetailSectorTagSerializer
 from chats.apps.queues.models import Queue
-from chats.apps.rooms.models import Room
+from chats.apps.rooms.models import Room, RoomPin
 
 
 class RoomMessageStatusSerializer(serializers.Serializer):
@@ -109,7 +109,7 @@ class ListRoomSerializer(serializers.ModelSerializer):
     last_interaction = serializers.DateTimeField(read_only=True)
     can_edit_custom_fields = serializers.SerializerMethodField()
     is_active = serializers.BooleanField(default=True)
-    is_pinned = serializers.BooleanField(required=False, read_only=True)
+    is_pinned = serializers.SerializerMethodField()
 
     class Meta:
         model = Room
@@ -173,6 +173,14 @@ class ListRoomSerializer(serializers.ModelSerializer):
         )
 
         return MessageSerializer(last_message).data
+
+    def get_is_pinned(self, room: Room) -> bool:
+        request = self.context.get("request")
+
+        if not request:
+            return False
+
+        return RoomPin.objects.filter(room=room, user=request.user).exists()
 
 
 class TransferRoomSerializer(serializers.ModelSerializer):

--- a/chats/apps/api/v1/rooms/serializers.py
+++ b/chats/apps/api/v1/rooms/serializers.py
@@ -109,6 +109,7 @@ class ListRoomSerializer(serializers.ModelSerializer):
     last_interaction = serializers.DateTimeField(read_only=True)
     can_edit_custom_fields = serializers.SerializerMethodField()
     is_active = serializers.BooleanField(default=True)
+    is_pinned = serializers.BooleanField(required=False, read_only=True)
 
     class Meta:
         model = Room
@@ -130,6 +131,7 @@ class ListRoomSerializer(serializers.ModelSerializer):
             "service_chat",
             "is_active",
             "config",
+            "is_pinned",
         ]
 
     def get_user(self, room: Room):

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -148,8 +148,12 @@ class RoomViewset(
     def list(self, request, *args, **kwargs):
         qs = self.get_queryset()
         project = request.query_params.get("project")
+        is_active = request.query_params.get("is_active", None)
 
-        if not project:
+        if isinstance(is_active, str):
+            is_active = is_active.lower() == "true"
+
+        if not project or is_active is False:
             filtered_qs = self.filter_queryset(qs)
             return self._get_paginated_response(filtered_qs)
 

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -170,11 +170,9 @@ class RoomViewset(
         else:
             annotated_qs = annotated_qs.order_by("-is_pinned")
 
-        return self._get_paginated_response(annotated_qs)
+        return self.paginate_queryset(annotated_qs)
 
     def _get_paginated_response(self, queryset):
-        from rest_framework.pagination import LimitOffsetPagination
-
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -25,6 +25,7 @@ from chats.apps.api.v1 import permissions as api_permissions
 from chats.apps.api.v1.internal.rest_clients.openai_rest_client import OpenAIClient
 from chats.apps.api.v1.msgs.serializers import ChatCompletionSerializer
 from chats.apps.api.v1.rooms import filters as room_filters
+from chats.apps.api.v1.rooms.pagination import RoomListPagination
 from chats.apps.api.v1.rooms.serializers import (
     ListRoomSerializer,
     PinRoomSerializer,
@@ -79,6 +80,7 @@ class RoomViewset(
     search_fields = ["contact__name", "urn", "protocol", "service_chat"]
     ordering_fields = "__all__"
     ordering = ["user", "-last_interaction", "created_on"]
+    pagination_class = RoomListPagination
 
     def get_permissions(self):
         permission_classes = [permissions.IsAuthenticated]
@@ -171,6 +173,8 @@ class RoomViewset(
         return self._get_paginated_response(annotated_qs)
 
     def _get_paginated_response(self, queryset):
+        from rest_framework.pagination import LimitOffsetPagination
+
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -158,6 +158,8 @@ class RoomViewset(
             )
         )
 
+        # Order by pinned rooms first, then by secondary sort fields
+        # So that pinned rooms are always at the top of the list
         if secondary_sort_fields:
             queryset = annotated_queryset.order_by("-is_pinned", *secondary_sort_fields)
         else:

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -146,7 +146,7 @@ class RoomViewset(
         if not secondary_sort_fields and isinstance(self.ordering, (list, tuple)):
             secondary_sort_fields = list(self.ordering)
 
-        base_queryset_for_annotation = Room.objects.filter(
+        base_queryset_for_annotation = self.get_queryset().filter(
             pk__in=rooms_pks_query | pinned_rooms_qs
         )
 

--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -413,7 +413,12 @@ class Room(BaseModel, BaseConfigurableModel):
         if self.pins.filter(user=user).exists():
             return
 
-        if RoomPin.objects.filter(user=user).count() >= settings.MAX_ROOM_PINS_LIMIT:
+        if (
+            RoomPin.objects.filter(
+                user=user, room__queue__sector__project=self.queue.sector.project
+            ).count()
+            >= settings.MAX_ROOM_PINS_LIMIT
+        ):
             raise MaxPinRoomLimitReachedError
 
         if self.user != user:

--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -236,6 +236,8 @@ class Room(BaseModel, BaseConfigurableModel):
         if tags is not None:
             self.tags.add(*tags)
 
+        self.clear_pins()
+
         self.save()
 
     def request_callback(self, room_data: dict):
@@ -415,7 +417,9 @@ class Room(BaseModel, BaseConfigurableModel):
 
         if (
             RoomPin.objects.filter(
-                user=user, room__queue__sector__project=self.queue.sector.project
+                user=user,
+                room__queue__sector__project=self.queue.sector.project,
+                room__is_active=True,
             ).count()
             >= settings.MAX_ROOM_PINS_LIMIT
         ):

--- a/chats/apps/rooms/tests/test_models.py
+++ b/chats/apps/rooms/tests/test_models.py
@@ -8,11 +8,14 @@ from django.utils import timezone
 from rest_framework.test import APITestCase
 
 from chats.apps.accounts.models import User
+from chats.apps.projects.models.models import Project
+from chats.apps.queues.models import Queue
 from chats.apps.rooms.exceptions import (
     MaxPinRoomLimitReachedError,
     RoomIsNotActiveError,
 )
 from chats.apps.rooms.models import Room
+from chats.apps.sectors.models import Sector
 
 
 class ConstraintTests(APITestCase):
@@ -31,8 +34,22 @@ class ConstraintTests(APITestCase):
 
 
 class TestRoomModel(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Test Sector",
+            project=self.project,
+            rooms_limit=10,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        self.queue = Queue.objects.create(
+            name="Test Queue",
+            sector=self.sector,
+        )
+
     def test_user_assigned_at_field(self):
-        room = Room.objects.create()
+        room = Room.objects.create(queue=self.queue)
 
         self.assertIsNone(room.user_assigned_at)
 
@@ -63,7 +80,7 @@ class TestRoomModel(TestCase):
 
     def test_pin_room(self):
         user = User.objects.create(email="a@user.com")
-        room = Room.objects.create(user=user)
+        room = Room.objects.create(user=user, queue=self.queue)
 
         self.assertEqual(room.pins.count(), 0)
 
@@ -78,21 +95,43 @@ class TestRoomModel(TestCase):
         self.assertEqual(room.pins.count(), 1)
         self.assertEqual(room.pins.first(), pin)
 
+        queue_2 = Queue.objects.create(
+            sector=Sector.objects.create(
+                project=Project.objects.create(),
+                rooms_limit=10,
+                work_start="09:00",
+                work_end="18:00",
+            ),
+        )
+
+        for i in range(settings.MAX_ROOM_PINS_LIMIT):
+            room = Room.objects.create(
+                user=user,
+                queue=queue_2,
+            )
+            room.pin(user)
+
+        room = Room.objects.create(user=user, queue=self.queue)
+
+        # Should not raise an error because the limit is not reached
+        # since the previous rooms are from a different project
+        room.pin(user)
+
     def test_pin_room_limit_reached(self):
         user = User.objects.create(email="a@user.com")
 
         for i in range(settings.MAX_ROOM_PINS_LIMIT):
-            room = Room.objects.create(user=user)
+            room = Room.objects.create(user=user, queue=self.queue)
 
             room.pin(user)
 
-        room = Room.objects.create()
+        room = Room.objects.create(queue=self.queue)
 
         with self.assertRaises(MaxPinRoomLimitReachedError):
             room.pin(user)
 
     def test_pin_room_user_not_assigned(self):
-        room = Room.objects.create()
+        room = Room.objects.create(queue=self.queue)
         user = User.objects.create(email="a@user.com")
 
         with self.assertRaises(PermissionDenied):
@@ -100,7 +139,7 @@ class TestRoomModel(TestCase):
 
     def test_pin_room_is_not_active(self):
         user = User.objects.create(email="a@user.com")
-        room = Room.objects.create(user=user)
+        room = Room.objects.create(user=user, queue=self.queue)
         room.close()
 
         with self.assertRaises(RoomIsNotActiveError):
@@ -108,7 +147,7 @@ class TestRoomModel(TestCase):
 
     def test_unpin_room(self):
         user = User.objects.create(email="a@user.com")
-        room = Room.objects.create(user=user)
+        room = Room.objects.create(user=user, queue=self.queue)
 
         room.pin(user)
         self.assertEqual(room.pins.count(), 1)
@@ -120,7 +159,7 @@ class TestRoomModel(TestCase):
         self.assertEqual(room.pins.count(), 0)
 
     def test_unpin_room_user_not_assigned(self):
-        room = Room.objects.create()
+        room = Room.objects.create(queue=self.queue)
         user = User.objects.create(email="a@user.com")
 
         with self.assertRaises(PermissionDenied):
@@ -128,7 +167,7 @@ class TestRoomModel(TestCase):
 
     def test_clear_pins(self):
         user = User.objects.create(email="a@user.com")
-        room = Room.objects.create(user=user)
+        room = Room.objects.create(user=user, queue=self.queue)
 
         room.pin(user)
         self.assertEqual(room.pins.count(), 1)
@@ -138,7 +177,7 @@ class TestRoomModel(TestCase):
 
     def test_change_user_clears_pins(self):
         user = User.objects.create(email="a@user.com")
-        room = Room.objects.create(user=user)
+        room = Room.objects.create(user=user, queue=self.queue)
 
         room.pin(user)
         self.assertEqual(room.pins.count(), 1)
@@ -150,7 +189,7 @@ class TestRoomModel(TestCase):
 
     def test_remove_user_clears_pins(self):
         user = User.objects.create(email="a@user.com")
-        room = Room.objects.create(user=user)
+        room = Room.objects.create(user=user, queue=self.queue)
 
         room.pin(user)
         self.assertEqual(room.pins.count(), 1)

--- a/chats/apps/rooms/tests/test_models.py
+++ b/chats/apps/rooms/tests/test_models.py
@@ -198,3 +198,13 @@ class TestRoomModel(TestCase):
         room.save()
 
         self.assertEqual(room.pins.count(), 0)
+
+    def test_close_room_clears_pins(self):
+        user = User.objects.create(email="a@user.com")
+        room = Room.objects.create(user=user, queue=self.queue)
+
+        room.pin(user)
+        self.assertEqual(room.pins.count(), 1)
+
+        room.close()
+        self.assertEqual(room.pins.count(), 0)

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -4,8 +4,6 @@ from unittest.mock import patch
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
-from datetime import timedelta
-from django.utils import timezone
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APITestCase

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -439,6 +439,10 @@ class TestRoomsViewSet(APITestCase):
             queue=self.queue,
             contact=Contact.objects.create(),
         )
+        room_3 = Room.objects.create(
+            queue=self.queue,
+            contact=Contact.objects.create(),
+        )
 
         RoomPin.objects.create(room=room_2, user=self.user)
 
@@ -452,6 +456,9 @@ class TestRoomsViewSet(APITestCase):
         )
         self.assertEqual(
             response.json().get("results")[1].get("uuid"), str(room_1.uuid)
+        )
+        self.assertEqual(
+            response.json().get("results")[2].get("uuid"), str(room_3.uuid)
         )
 
 

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -455,10 +455,10 @@ class TestRoomsViewSet(APITestCase):
             response.json().get("results")[0].get("uuid"), str(room_2.uuid)
         )
         self.assertEqual(
-            response.json().get("results")[1].get("uuid"), str(room_1.uuid)
+            response.json().get("results")[1].get("uuid"), str(room_3.uuid)
         )
         self.assertEqual(
-            response.json().get("results")[2].get("uuid"), str(room_3.uuid)
+            response.json().get("results")[2].get("uuid"), str(room_1.uuid)
         )
 
 

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -478,14 +478,24 @@ class TestRoomsViewSet(APITestCase):
             filters={"project": str(self.project.uuid), "ordering": "-created_on"}
         )
 
-        rooms_uuids = [room["uuid"] for room in response.json().get("results")]
+        self.assertIn("max_pin_limit", response.data)
+        self.assertEqual(
+            response.data.get("max_pin_limit"), settings.MAX_ROOM_PINS_LIMIT
+        )
+
+        results = response.data.get("results")
+        rooms_uuids = [room["uuid"] for room in results]
 
         self.assertNotIn(str(room_4.uuid), rooms_uuids)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(rooms_uuids[0], str(room_2.uuid))
+        self.assertEqual(results[0].get("is_pinned"), True)
+
         self.assertEqual(rooms_uuids[1], str(room_3.uuid))
+        self.assertEqual(results[1].get("is_pinned"), False)
         self.assertEqual(rooms_uuids[2], str(room_1.uuid))
+        self.assertEqual(results[2].get("is_pinned"), False)
 
 
 class RoomPickTests(APITestCase):

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -466,7 +466,11 @@ class TestRoomsViewSet(APITestCase):
 
         # Call your list endpoint
         response = self.list_rooms(
-            filters={"project": str(self.project.uuid), "ordering": "-created_on"}
+            filters={
+                "project": str(self.project.uuid),
+                "is_active": True,
+                "ordering": "-created_on",
+            }
         )
 
         # Assertions unchanged...

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -430,6 +430,30 @@ class TestRoomsViewSet(APITestCase):
             response.json().get("results")[1].get("uuid"), str(room_1.uuid)
         )
 
+    def test_room_order_with_pin(self):
+        room_1 = Room.objects.create(
+            queue=self.queue,
+            contact=Contact.objects.create(),
+        )
+        room_2 = Room.objects.create(
+            queue=self.queue,
+            contact=Contact.objects.create(),
+        )
+
+        RoomPin.objects.create(room=room_2, user=self.user)
+
+        response = self.list_rooms(
+            filters={"project": str(self.project.uuid), "ordering": "-created_on"}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json().get("results")[0].get("uuid"), str(room_2.uuid)
+        )
+        self.assertEqual(
+            response.json().get("results")[1].get("uuid"), str(room_1.uuid)
+        )
+
 
 class RoomPickTests(APITestCase):
     def setUp(self) -> None:

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -464,7 +464,6 @@ class TestRoomsViewSet(APITestCase):
         room_5 = Room.objects.create(queue=queue, contact=Contact.objects.create())
         RoomPin.objects.create(room=room_5, user=self.user)
 
-        # Call your list endpoint
         response = self.list_rooms(
             filters={
                 "project": str(self.project.uuid),
@@ -473,7 +472,6 @@ class TestRoomsViewSet(APITestCase):
             }
         )
 
-        # Assertions unchanged...
         self.assertIn("max_pin_limit", response.data)
         self.assertEqual(
             response.data.get("max_pin_limit"), settings.MAX_ROOM_PINS_LIMIT


### PR DESCRIPTION
### What
Adding the pinned rooms to the top of the list in the rooms endpoint.
The pinned rooms must *always* be at the top of the list (for the first page), ordered by the creation date/time of the pin.
The rest of the rooms are ordered by the ordering filter used by the frontend application. These orderings must *not* affect each other. 
For this to happen, the "list" method in the rooms viewset was overridden. A custom pagination class was created with the purpose of adding a field that indicates the limit for room pins per project, so that the frontend application can use this number to apply this rule even without making any additional requests to the backend, as well as without hardcoding this value.

### Why
This endpoint is used by the frontend app to fetch and display the list of rooms in the chats application, that will have the feature of pinning rooms.