### PR TITLE
Feature: check if there are rooms in the queue before returning the user

### DIFF
--- a/chats/apps/api/v1/external/rooms/serializers.py
+++ b/chats/apps/api/v1/external/rooms/serializers.py
@@ -21,7 +21,6 @@ from chats.apps.queues.utils import start_queue_priority_routing
 from chats.apps.rooms.models import Room
 from chats.apps.rooms.views import close_room
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -117,6 +116,9 @@ def get_room_user(
         # If the queue is not empty, the room must stay in the queue,
         # so that, when a agent becomes available, the first room in the queue
         # will be assigned to the them. This logic is not done here.
+        return None
+
+    if queue.rooms.filter(is_active=True, user__isnull=True).exists():
         return None
 
     # General room routing type


### PR DESCRIPTION
### **What**
check if there are rooms in the queue before returning the user

### **Why**
so that new rooms are not automatically assigned to the detriment of rooms that have been in the queue for a longer time.