### PR TITLE
Fix/removing generic errors

### DIFF
--- a/chats/apps/accounts/tests/decorators.py
+++ b/chats/apps/accounts/tests/decorators.py
@@ -1,0 +1,23 @@
+import functools
+
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+def with_internal_auth(func):
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        content_type = ContentType.objects.get_for_model(User)
+        user = self.user
+        permission, _ = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            content_type=content_type,
+        )
+        user.user_permissions.add(permission)
+
+        return func(self, *args, **kwargs)
+
+    return wrapper

--- a/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
+++ b/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
@@ -5,7 +5,6 @@ from rest_framework import status
 from unittest.mock import patch, MagicMock
 from django.core.cache import cache
 from django.test import override_settings
-from django.db import IntegrityError
 
 from chats.apps.accounts.tests.decorators import with_internal_auth
 from chats.apps.projects.models.models import Project, User, ProjectPermission

--- a/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
+++ b/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
@@ -309,7 +309,7 @@ class TestProjectPermissionViewSetAsAuthenticatedUser(BaseTestProjectPermissionV
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @with_internal_auth
-    @override_settings(OIDC_ENABLED=True)
+    @override_settings(OIDC_ENABLED=False)
     @patch(
         "chats.apps.api.v1.internal.projects.viewsets.persist_keycloak_user_by_email"
     )
@@ -319,9 +319,8 @@ class TestProjectPermissionViewSetAsAuthenticatedUser(BaseTestProjectPermissionV
             "user": self.user.email,
             "role": ProjectPermission.ROLE_ATTENDANT,
         }
-        with self.assertRaises(IntegrityError):
-            self.update(str(self.permission.uuid), data)
-        mock_persist_keycloak.assert_not_called()
+        response = self.update(str(self.permission.uuid), data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_cannot_destroy_permission_without_internal_auth(self):
         response = self.destroy(self.permission.uuid)

--- a/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
+++ b/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
@@ -4,9 +4,11 @@ from rest_framework.response import Response
 from rest_framework import status
 from unittest.mock import patch, MagicMock
 from django.core.cache import cache
+from django.test import override_settings
+from django.db import IntegrityError
 
 from chats.apps.accounts.tests.decorators import with_internal_auth
-from chats.apps.projects.models.models import Project, User
+from chats.apps.projects.models.models import Project, User, ProjectPermission
 
 
 class BaseTestProjectViewSet(APITestCase):
@@ -159,3 +161,200 @@ class TestProjectViewSetAsAuthenticatedUser(BaseTestProjectViewSet):
         response = self.destroy(self.project.uuid)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(Project.objects.count(), 0)
+
+
+class BaseTestProjectPermissionViewSet(APITestCase):
+    def list(self, project_uuid: str = None) -> Response:
+        url = reverse("project_permission_internal-list")
+        params = {}
+        if project_uuid:
+            params["project"] = project_uuid
+        return self.client.get(url, params)
+
+    def create(self, data: dict) -> Response:
+        url = reverse("project_permission_internal-list")
+        return self.client.post(url, data, format="json")
+
+    def retrieve(self, permission_uuid: str) -> Response:
+        url = reverse(
+            "project_permission_internal-detail", kwargs={"uuid": permission_uuid}
+        )
+        return self.client.get(url)
+
+    def update(self, permission_uuid: str, data: dict) -> Response:
+        url = reverse(
+            "project_permission_internal-detail", kwargs={"uuid": permission_uuid}
+        )
+        return self.client.put(url, data, format="json")
+
+    def partial_update(self, permission_uuid: str, data: dict) -> Response:
+        url = reverse(
+            "project_permission_internal-detail", kwargs={"uuid": permission_uuid}
+        )
+        return self.client.patch(url, data, format="json")
+
+    def destroy(self, permission_uuid: str) -> Response:
+        url = reverse(
+            "project_permission_internal-detail", kwargs={"uuid": permission_uuid}
+        )
+        return self.client.delete(url)
+
+    def status(self, data: dict, method: str = "post") -> Response:
+        url = reverse("project_permission_internal-status")
+        if method.lower() == "post":
+            return self.client.post(url, data, format="json")
+        return self.client.get(url, data)
+
+
+class TestProjectPermissionViewSetAsAnonymousUser(BaseTestProjectPermissionViewSet):
+    def test_list_permissions_as_anonymous_user(self):
+        response = self.list()
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_create_permission_as_anonymous_user(self):
+        response = self.create({})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_retrieve_permission_as_anonymous_user(self):
+        response = self.retrieve("123")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_update_permission_as_anonymous_user(self):
+        response = self.update("123", {})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_partial_update_permission_as_anonymous_user(self):
+        response = self.partial_update("123", {})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_destroy_permission_as_anonymous_user(self):
+        response = self.destroy("123")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_status_as_anonymous_user(self):
+        response = self.status({}, method="post")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        response = self.status({}, method="get")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestProjectPermissionViewSetAsAuthenticatedUser(BaseTestProjectPermissionViewSet):
+    def setUp(self):
+        self.user = User.objects.create(email="testuser@test.com")
+        self.project = Project.objects.create(name="Test Project")
+        self.permission = ProjectPermission.objects.create(
+            project=self.project, user=self.user, role=ProjectPermission.ROLE_ADMIN
+        )
+        self.client.force_authenticate(self.user)
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_cannot_list_permissions_without_internal_auth(self):
+        response = self.list()
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_internal_auth
+    def test_list_permissions(self):
+        response = self.list()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+
+    @with_internal_auth
+    def test_list_permissions_with_project_filter(self):
+        other_project = Project.objects.create(name="Other Project")
+        response = self.list(project_uuid=str(other_project.uuid))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 0)
+        response = self.list(project_uuid=str(self.project.uuid))
+        self.assertEqual(len(response.data["results"]), 1)
+
+    def test_cannot_create_permission_without_internal_auth(self):
+        response = self.create({})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_internal_auth
+    @override_settings(OIDC_ENABLED=True)
+    @patch(
+        "chats.apps.api.v1.internal.projects.viewsets.persist_keycloak_user_by_email"
+    )
+    def test_create_permission(self, mock_persist_keycloak):
+        new_user = User.objects.create(email="newuser@test.com")
+        data = {
+            "project": str(self.project.uuid),
+            "user": new_user.email,
+            "role": ProjectPermission.ROLE_ADMIN,
+        }
+        response = self.create(data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        mock_persist_keycloak.assert_called_once_with(new_user.email)
+        self.assertTrue(
+            ProjectPermission.objects.filter(
+                project=self.project, user=new_user
+            ).exists()
+        )
+
+    def test_cannot_retrieve_permission_without_internal_auth(self):
+        response = self.retrieve(self.permission.uuid)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_internal_auth
+    def test_retrieve_permission(self):
+        response = self.retrieve(self.permission.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["uuid"], str(self.permission.uuid))
+
+    def test_cannot_update_permission_without_internal_auth(self):
+        response = self.update(self.permission.uuid, {})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_internal_auth
+    @override_settings(OIDC_ENABLED=True)
+    @patch(
+        "chats.apps.api.v1.internal.projects.viewsets.persist_keycloak_user_by_email"
+    )
+    def test_update_permission_with_put(self, mock_persist_keycloak):
+        data = {
+            "project": str(self.project.uuid),
+            "user": self.user.email,
+            "role": ProjectPermission.ROLE_ATTENDANT,
+        }
+        with self.assertRaises(IntegrityError):
+            self.update(str(self.permission.uuid), data)
+        mock_persist_keycloak.assert_not_called()
+
+    def test_cannot_destroy_permission_without_internal_auth(self):
+        response = self.destroy(self.permission.uuid)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_internal_auth
+    def test_destroy_permission(self):
+        response = self.destroy(self.permission.uuid)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(ProjectPermission.objects.count(), 0)
+
+    def test_cannot_use_status_action_without_internal_auth(self):
+        response = self.status({}, method="post")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        response = self.status({}, method="get")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch(
+        "chats.apps.api.v1.internal.projects.viewsets.start_queue_priority_routing_for_all_queues_in_project"
+    )
+    def test_status_action_post(self, mock_start_routing):
+        data = {"project": str(self.project.uuid), "status": "online"}
+        response = self.status(data, method="post")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["connection_status"], "ONLINE")
+        self.permission.refresh_from_db()
+        self.assertEqual(self.permission.status, ProjectPermission.STATUS_ONLINE)
+        mock_start_routing.assert_called_once_with(self.project)
+
+    def test_status_action_get(self):
+        self.permission.status = ProjectPermission.STATUS_AWAY
+        self.permission.save()
+        data = {"project": str(self.project.uuid)}
+        response = self.status(data, method="get")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["connection_status"], "AWAY")

--- a/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
+++ b/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
@@ -329,6 +329,7 @@ class TestProjectPermissionViewSetAsAuthenticatedUser(BaseTestProjectPermissionV
 
     @with_internal_auth
     def test_destroy_permission(self):
+        self.assertEqual(ProjectPermission.objects.count(), 1)
         response = self.destroy(self.permission.uuid)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(ProjectPermission.objects.count(), 0)

--- a/chats/apps/api/v1/internal/projects/viewsets.py
+++ b/chats/apps/api/v1/internal/projects/viewsets.py
@@ -68,7 +68,7 @@ class ProjectPermissionViewset(viewsets.ModelViewSet):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-    def put(
+    def update(
         self, request, *args, **kwargs
     ):  # TODO: GAMBIARRA ALERT! MOVE THIS LOGIC TO THE SERIALIZER or somewhere else
         qs = self.queryset

--- a/chats/apps/api/v1/internal/projects/viewsets.py
+++ b/chats/apps/api/v1/internal/projects/viewsets.py
@@ -134,16 +134,12 @@ class ProjectPermissionViewset(viewsets.ModelViewSet):
         )
 
     def delete(self, request):
-        try:
-            user_permission = ProjectPermission.objects.get(
-                project_id=request.data["project"], user=request.data["user"]
-            )
-            user_permission.delete()
-            return Response(
-                status.HTTP_204_NO_CONTENT,
-            )
-        except Exception as error:
-            return Response(
-                {"error": f"{type(error)}: {error}"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        permission = get_object_or_404(
+            ProjectPermission,
+            project_id=request.data["project"],
+            user=request.data["user"],
+        )
+        permission.delete()
+        return Response(
+            status.HTTP_204_NO_CONTENT,
+        )

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -437,89 +437,81 @@ class RoomViewset(
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        try:
-            if user_email:
-                user = User.objects.get(email=user_email)
+        if user_email:
+            user = User.objects.get(email=user_email)
 
-                for room in rooms_list:
-                    old_user = room.user
-                    project = room.queue.project
-                    if not project.permissions.filter(user=user).exists():
-                        return Response(
-                            {
-                                "error": (
-                                    f"User {user.email} has no permission on the project "
-                                    f"{project.name} <{project.uuid}>"
-                                )
-                            },
-                            status=status.HTTP_400_BAD_REQUEST,
-                        )
-
-                    transfer_user = verify_user_room(room, user_request)
-
-                    feedback = create_transfer_json(
-                        action="transfer",
-                        from_=transfer_user,
-                        to=user,
+            for room in rooms_list:
+                old_user = room.user
+                project = room.queue.project
+                if not project.permissions.filter(user=user).exists():
+                    return Response(
+                        {
+                            "error": (
+                                f"User {user.email} has no permission on the project "
+                                f"{project.name} <{project.uuid}>"
+                            )
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
                     )
-                    room.user = user
-                    room.save()
 
-                    logger.info(
-                        "Starting queue priority routing for room %s from bulk transfer to user %s",
-                        room.uuid,
-                        user.email,
-                    )
-                    start_queue_priority_routing(room.queue)
+                transfer_user = verify_user_room(room, user_request)
 
-                    create_room_feedback_message(
-                        room, feedback, method=RoomFeedbackMethods.ROOM_TRANSFER
-                    )
-                    if old_user:
-                        room.notify_user("update", user=old_user)
-                    else:
-                        room.notify_user("update", user=transfer_user)
-                    room.notify_user("update")
+                feedback = create_transfer_json(
+                    action="transfer",
+                    from_=transfer_user,
+                    to=user,
+                )
+                room.user = user
+                room.save()
 
-                    room.update_ticket()
+                logger.info(
+                    "Starting queue priority routing for room %s from bulk transfer to user %s",
+                    room.uuid,
+                    user.email,
+                )
+                start_queue_priority_routing(room.queue)
 
-            if queue_uuid:
-                queue = Queue.objects.get(uuid=queue_uuid)
-                for room in rooms_list:
-                    if queue.project != room.project:
-                        return Response(
-                            {
-                                "error": "Cannot transfer rooms from a project to another"
-                            },
-                            status=status.HTTP_400_BAD_REQUEST,
-                        )
-                    transfer_user = verify_user_room(room, user_request)
-                    feedback = create_transfer_json(
-                        action="transfer",
-                        from_=transfer_user,
-                        to=queue,
-                    )
-                    room.user = None
-                    room.queue = queue
-                    room.save()
-
-                    create_room_feedback_message(
-                        room, feedback, method=RoomFeedbackMethods.ROOM_TRANSFER
-                    )
+                create_room_feedback_message(
+                    room, feedback, method=RoomFeedbackMethods.ROOM_TRANSFER
+                )
+                if old_user:
+                    room.notify_user("update", user=old_user)
+                else:
                     room.notify_user("update", user=transfer_user)
-                    room.notify_queue("update")
+                room.notify_user("update")
 
-                    logger.info(
-                        "Starting queue priority routing for room %s from bulk transfer to queue %s",
-                        room.uuid,
-                        queue.uuid,
+                room.update_ticket()
+
+        if queue_uuid:
+            queue = Queue.objects.get(uuid=queue_uuid)
+            for room in rooms_list:
+                if queue.project != room.project:
+                    return Response(
+                        {"error": "Cannot transfer rooms from a project to another"},
+                        status=status.HTTP_400_BAD_REQUEST,
                     )
-                    start_queue_priority_routing(queue)
+                transfer_user = verify_user_room(room, user_request)
+                feedback = create_transfer_json(
+                    action="transfer",
+                    from_=transfer_user,
+                    to=queue,
+                )
+                room.user = None
+                room.queue = queue
+                room.save()
 
-        except Exception as error:
-            return Response(
-                {"error": {error}}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+                create_room_feedback_message(
+                    room, feedback, method=RoomFeedbackMethods.ROOM_TRANSFER
+                )
+                room.notify_user("update", user=transfer_user)
+                room.notify_queue("update")
+
+                logger.info(
+                    "Starting queue priority routing for room %s from bulk transfer to queue %s",
+                    room.uuid,
+                    queue.uuid,
+                )
+                start_queue_priority_routing(queue)
 
         return Response(
             {"success": "Mass transfer completed"},

--- a/chats/apps/discussions/views/discussion.py
+++ b/chats/apps/discussions/views/discussion.py
@@ -51,6 +51,14 @@ class DiscussionViewSet(
         return context
 
     def create(self, request, *args, **kwargs):
+        room = request.data.get("room")
+
+        if Discussion.objects.filter(room=room, is_active=True).exists():
+            return Response(
+                {"detail": "The room already have an open discussion."},
+                status.HTTP_409_CONFLICT,
+            )
+
         try:
             creation_data = self.get_serializer(data=request.data)
             creation_data.is_valid(raise_exception=True)
@@ -65,16 +73,6 @@ class DiscussionViewSet(
             return Response(
                 {"Detail": f"{err}"},
                 status.HTTP_400_BAD_REQUEST,
-            )
-        except IntegrityError:
-            return Response(
-                {"detail": "The room already have an open discussion."},
-                status.HTTP_409_CONFLICT,
-            )
-        except Exception as err:
-            return Response(
-                {"Detail": f"{err}"},
-                status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
     def perform_create(self, serializer):

--- a/chats/apps/discussions/views/discussion.py
+++ b/chats/apps/discussions/views/discussion.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import get_user_model
-from django.db.utils import IntegrityError
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, status, viewsets
 from rest_framework.permissions import IsAuthenticated

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -634,6 +634,28 @@ class RoomsBulkTransferTestCase(APITestCase):
             new_queue.uuid,
         )
 
+    def test_cannot_transfer_rooms_from_another_project(self):
+        another_project = Project.objects.create(
+            name="Another Project",
+        )
+        self.sector.project = another_project
+        self.sector.save()
+
+        response = self.client.patch(
+            reverse("room-bulk_transfer"),
+            data={
+                "rooms_list": [self.room.uuid],
+            },
+            format="json",
+            QUERY_STRING=f"user_email={self.agent_2.email}",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["error"],
+            f"User {self.agent_2.email} has no permission on the project {another_project.name} <{another_project.uuid}>",
+        )
+
 
 class CloseRoomTestCase(APITestCase):
     def setUp(self):

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -635,10 +635,10 @@ class RoomsBulkTransferTestCase(APITestCase):
         )
 
     def test_cannot_transfer_rooms_from_another_project(self):
-        another_project = Project.objects.create(
+        p = Project.objects.create(
             name="Another Project",
         )
-        self.sector.project = another_project
+        self.sector.project = p
         self.sector.save()
 
         response = self.client.patch(
@@ -653,7 +653,7 @@ class RoomsBulkTransferTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
             response.data["error"],
-            f"User {self.agent_2.email} has no permission on the project {another_project.name} <{another_project.uuid}>",
+            f"User {self.agent_2.email} has no permission on the project {p.name} <{p.uuid}>",
         )
 
 


### PR DESCRIPTION
Removing generic 500 status errors returns from discussions, project permissions and bulk transfer related endpoints.
Adding some tests as well.
