### PR TITLE
Fix/Allow admins to view full rooms history

### DIFF
--- a/chats/apps/history/filters/rooms_filter.py
+++ b/chats/apps/history/filters/rooms_filter.py
@@ -70,16 +70,17 @@ class HistoryRoomFilter(filters.FilterSet):
                 contact__external_id__in=contacts_blocklist
             )
 
-        if (
-            user_permission.is_admin is False
-            and project.agents_can_see_queue_history is False
-        ):
-            return base_queryset.filter(user=user, queue__sector__project=value)
+        base_queryset = base_queryset.filter(queue__sector__project=value)
 
-        queue_ids = user_permission.queue_ids
-        return base_queryset.filter(
-            Q(queue__in=queue_ids) | Q(user=user, queue__sector__project=value)
-        )
+        if user_permission.is_admin is False:
+            if project.agents_can_see_queue_history is False:
+                return base_queryset.filter(user=user)
+
+            return base_queryset.filter(
+                Q(queue__in=user_permission.queue_ids) | Q(user=user)
+            )
+
+        return base_queryset
 
     def filter_tags(self, queryset, name, value):
         if not value:


### PR DESCRIPTION
### What
Change rooms history project filter logic to allow admins to view the full history of rooms, even from deleted queues and sectors.

### Why
The rooms history should only be limited of non admins users.