### PR TITLE
Feature/allow users to pick rooms from queue

### DIFF
--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, mixins, permissions, status
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import ValidationError
 from rest_framework.filters import OrderingFilter
 from rest_framework.request import Request
 from rest_framework.response import Response

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -385,12 +385,6 @@ class RoomViewset(
         room: Room = self.get_object()
         user: User = request.user
 
-        if not room.can_pick_queue(user):
-            raise PermissionDenied(
-                detail=_("User does not have permission to pick this room"),
-                code="user_is_not_project_admin_or_sector_manager",
-            )
-
         if room.user:
             raise ValidationError(
                 {"detail": _("Room is not queued")}, code="room_is_not_queued"

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -491,21 +491,6 @@ class RoomPickTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    @with_project_permission(role=ProjectPermission.ROLE_ATTENDANT)
-    @with_queue_authorization(role=QueueAuthorization.ROLE_AGENT)
-    def test_cannot_pick_room_if_routing_type_is_queue_priority_and_user_is_not_project_admin_or_sector_manager(
-        self,
-    ):
-        self.project.room_routing_type = RoomRoutingType.QUEUE_PRIORITY
-        self.project.save(update_fields=["room_routing_type"])
-
-        response = self.pick_room_from_queue()
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(
-            response.data["detail"].code, "user_is_not_project_admin_or_sector_manager"
-        )
-
     @with_project_permission(role=ProjectPermission.ROLE_ADMIN)
     def test_can_pick_room_if_project_routing_type_is_queue_priority_and_user_is_project_admin(
         self,


### PR DESCRIPTION
### What
Removing permission check to allow any user to pick rooms from the queue, even when the project is configured with the queue priority routing.

### Why
The rules for the features related to the queue priority routing has changed.