### PR TITLE
Feature/add user info to transfer JSON message

### DIFF
--- a/chats/apps/api/v1/external/rooms/viewsets.py
+++ b/chats/apps/api/v1/external/rooms/viewsets.py
@@ -30,10 +30,10 @@ from chats.apps.queues.utils import (
 )
 from chats.apps.rooms.choices import RoomFeedbackMethods
 from chats.apps.rooms.models import Room
+from chats.apps.rooms.utils import create_transfer_json
 from chats.apps.rooms.views import (
     close_room,
     create_room_feedback_message,
-    create_transfer_json,
     get_editable_custom_fields_room,
     update_custom_fields,
     update_flows_custom_fields,

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -59,10 +59,10 @@ from chats.apps.rooms.exceptions import (
 from chats.apps.rooms.models import Room, RoomPin
 from chats.apps.rooms.services import RoomsReportService
 from chats.apps.rooms.tasks import generate_rooms_report
+from chats.apps.rooms.utils import create_transfer_json
 from chats.apps.rooms.views import (
     close_room,
     create_room_feedback_message,
-    create_transfer_json,
     get_editable_custom_fields_room,
     update_custom_fields,
     update_flows_custom_fields,

--- a/chats/apps/queues/tests/test_services.py
+++ b/chats/apps/queues/tests/test_services.py
@@ -172,9 +172,14 @@ class QueueRouterServiceTestCase(TestCase):
         )
         self.assertEqual(
             message_text.get("content", {}).get("from"),
-            {"type": "queue", "name": self.queue.name},
+            {"type": "queue", "name": self.queue.name, "uuid": str(self.queue.uuid)},
         )
         self.assertEqual(
             message_text.get("content", {}).get("to"),
-            {"type": "user", "name": self.agent_2.name},
+            {
+                "type": "user",
+                "name": self.agent_2.name,
+                "email": self.agent_2.email,
+                "id": str(self.agent_2.id),
+            },
         )

--- a/chats/apps/queues/utils.py
+++ b/chats/apps/queues/utils.py
@@ -5,6 +5,7 @@ from chats.apps.projects.models.models import Project
 from chats.apps.queues.models import Queue
 from chats.apps.queues.tasks import route_queue_rooms
 from chats.apps.rooms.choices import RoomFeedbackMethods
+from chats.apps.rooms.utils import create_transfer_json
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,6 @@ def create_room_assigned_from_queue_feedback(room: "Room", user: "User"):
     """
     from chats.apps.rooms.views import (
         create_room_feedback_message,
-        create_transfer_json,
     )
 
     feedback = create_transfer_json(

--- a/chats/apps/rooms/tests/test_utils.py
+++ b/chats/apps/rooms/tests/test_utils.py
@@ -1,0 +1,85 @@
+from django.test import TestCase
+
+from chats.apps.accounts.models import User
+from chats.apps.projects.models.models import Project
+from chats.apps.queues.models import Queue
+from chats.apps.rooms.utils import create_transfer_json, get_data_from_object
+from chats.apps.sectors.models import Sector
+
+
+class TestUtils(TestCase):
+    def setUp(self):
+        self.user_a = User.objects.create(
+            first_name="John", last_name="Doe", email="john.doe@example.com"
+        )
+        self.user_b = User.objects.create(
+            first_name="Jane", last_name="Doe", email="jane.doe@example.com"
+        )
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Test Sector",
+            project=self.project,
+            rooms_limit=20,
+            work_start="11:20",
+            work_end="23:20",
+        )
+        self.queue = Queue.objects.create(name="Test Queue", sector=self.sector)
+
+    def test_get_data_from_object_user(self):
+        assert get_data_from_object(self.user_a) == {
+            "type": "user",
+            "name": self.user_a.name,
+            "email": self.user_a.email,
+            "id": str(self.user_a.id),
+        }
+
+    def test_get_data_from_object_queue(self):
+        assert get_data_from_object(self.queue) == {
+            "type": "queue",
+            "name": self.queue.name,
+            "uuid": str(self.queue.uuid),
+        }
+
+    def test_create_transfer_json_from_user_to_queue(self):
+        assert create_transfer_json("forward", self.user_a, self.queue) == {
+            "action": "forward",
+            "from": {
+                "type": "user",
+                "name": self.user_a.name,
+                "email": self.user_a.email,
+                "id": str(self.user_a.id),
+            },
+            "to": {
+                "type": "queue",
+                "name": "Test Queue",
+                "uuid": str(self.queue.uuid),
+            },
+        }
+
+    def test_create_transfer_json_from_none_to_queue(self):
+        assert create_transfer_json("forward", None, self.queue) == {
+            "action": "forward",
+            "from": {"type": "", "name": ""},
+            "to": {
+                "type": "queue",
+                "name": self.queue.name,
+                "uuid": str(self.queue.uuid),
+            },
+        }
+
+    def test_create_transfer_json_from_user_to_user(self):
+        assert create_transfer_json("forward", self.user_a, self.user_b) == {
+            "action": "forward",
+            "from": {
+                "type": "user",
+                "name": self.user_a.name,
+                "email": self.user_a.email,
+                "id": str(self.user_a.id),
+            },
+            "to": {
+                "type": "user",
+                "name": self.user_b.name,
+                "email": self.user_b.email,
+                "id": str(self.user_b.id),
+            },
+        }

--- a/chats/apps/rooms/utils.py
+++ b/chats/apps/rooms/utils.py
@@ -1,0 +1,28 @@
+def get_data_from_object(obj):
+    data = {"type": "", "name": ""}
+
+    if hasattr(obj, "_meta"):
+        data["type"] = obj._meta.model_name
+
+        fields = {"name", "uuid"}
+
+        if data["type"] == "user":
+            fields.add("id")
+            fields.add("email")
+
+        for field in fields:
+            if value := getattr(obj, field, None):
+                data[field] = str(value)
+
+    return data
+
+
+def create_transfer_json(action: str, from_, to):
+    from_data = get_data_from_object(from_)
+    to_data = get_data_from_object(to)
+
+    return {
+        "action": action,
+        "from": from_data,
+        "to": to_data,
+    }

--- a/chats/apps/rooms/views.py
+++ b/chats/apps/rooms/views.py
@@ -54,21 +54,6 @@ def get_editable_custom_fields_room(room_filter: dict) -> Room:
     return room
 
 
-def create_transfer_json(action: str, from_, to):
-    if hasattr(from_, "_meta"):
-        return {
-            "action": action,
-            "from": {"type": from_._meta.model_name, "name": from_.name},
-            "to": {"type": to._meta.model_name, "name": to.name},
-        }
-    else:
-        return {
-            "action": action,
-            "from": {"type": "", "name": ""},
-            "to": {"type": to._meta.model_name, "name": to.name},
-        }
-
-
 def create_feedback_json(method: str, content: dict):
     return {"method": method, "content": content}
 


### PR DESCRIPTION
### What
The feedback messages, shown in the Chats history to indicate actions taken by the user and by the system, currently only stores the name of the elements. So, if a user picks a room from a queue, only the names of the queue and the first name of the user is stored in this feedback message. 

This pull request adds more information, such as IDs, UUIDs and emails.

### Why
To make it easier to identify the user, by its id and email, and to query messages by these elements, when necessary.