### PR TITLE
fix/filter-last-custom-status-by-project

### DIFF
--- a/chats/apps/api/v1/projects/serializers.py
+++ b/chats/apps/api/v1/projects/serializers.py
@@ -145,3 +145,7 @@ class CustomStatusSerializer(serializers.ModelSerializer):
         ]
 
     break_time = serializers.IntegerField(required=False)
+
+
+class LastStatusQueryParamsSerializer(serializers.Serializer):
+    project_uuid = serializers.UUIDField(required=True)

--- a/chats/apps/dashboard/tests/test_custom_status_viewset.py
+++ b/chats/apps/dashboard/tests/test_custom_status_viewset.py
@@ -45,7 +45,9 @@ class TestCustomStatusViewSet(TestCase):
 
     def test_last_status_with_active_status(self):
         """Tests the return of user's last active status"""
-        request = self.factory.get("/custom-status/last-status/")
+        request = self.factory.get(
+            "/custom-status/last-status/", data={"project_uuid": self.project.uuid}
+        )
         force_authenticate(request, user=self.user)
         request = Request(request)
         request.user = self.user
@@ -60,7 +62,9 @@ class TestCustomStatusViewSet(TestCase):
         """Tests the return when there is no active status"""
         CustomStatus.objects.all().update(is_active=False)
 
-        request = self.factory.get("/custom-status/last-status/")
+        request = self.factory.get(
+            "/custom-status/last-status/", data={"project_uuid": self.project.uuid}
+        )
         force_authenticate(request, user=self.user)
         request = Request(request)
         request.user = self.user


### PR DESCRIPTION
### What
This pull request adds a project uuid filter to the last_status endpoint.

### Why
So that the last status returned is from the intended project.

### Notes
This should only be merged once the frontend application has added this filter as well.