### PR TITLE
feat: notify queue on room update

### DIFF
--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -151,7 +151,13 @@ class RoomViewset(
         if isinstance(is_active, str):
             is_active = is_active.lower() == "true"
 
-        if not project or is_active is False:
+        room_status = request.query_params.get("room_status", None)
+
+        if (
+            not project
+            or is_active is False
+            or (room_status is not None and room_status != "ongoing")
+        ):
             filtered_qs = self.filter_queryset(qs)
             return self._get_paginated_response(filtered_qs)
 

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -566,6 +566,7 @@ class RoomViewset(
                 else:
                     room.notify_user("update", user=transfer_user)
                 room.notify_user("update")
+                room.notify_queue("update")
 
                 room.update_ticket()
 


### PR DESCRIPTION
### **What**
This pull request introduces a notification, in the websocket, when a room is transfered from the queue to a specific user.

### **Why**
So that another in the queue sees the change in the queue in real time.
