### PR TITLE
Fix/use queue assignment date to prioritize rooms routing

### DIFF
--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -22,20 +22,27 @@ class QueueRouterService:
         if not self.queue.sector.project.use_queue_priority_routing:
             raise ValueError("Queue priority routing is not enabled for this project")
 
-    def route_rooms(self):
+    def get_rooms_to_route(self):
         """
-        Route rooms to available agents.
+        Get rooms to route.
         """
         from chats.apps.rooms.models import Room
-        from chats.apps.queues.utils import create_room_assigned_from_queue_feedback
 
-        logger.info("Start routing rooms for queue %s", self.queue.uuid)
-
-        rooms = (
+        return (
             Room.objects.filter(queue=self.queue, is_active=True, user__isnull=True)
             .annotate(date_field=Coalesce("added_to_queue_at", "created_on"))
             .order_by("date_field")
         )
+
+    def route_rooms(self):
+        """
+        Route rooms to available agents.
+        """
+        from chats.apps.queues.utils import create_room_assigned_from_queue_feedback
+
+        logger.info("Start routing rooms for queue %s", self.queue.uuid)
+
+        rooms = self.get_rooms_to_route()
 
         if not rooms.exists():
             logger.info(

--- a/chats/apps/queues/tests/test_services.py
+++ b/chats/apps/queues/tests/test_services.py
@@ -2,6 +2,8 @@ from datetime import time
 import json
 from unittest.mock import patch
 from django.test import TestCase
+from django.utils import timezone
+from django.utils.timezone import timedelta
 
 from chats.apps.projects.models.models import (
     Project,
@@ -183,3 +185,18 @@ class QueueRouterServiceTestCase(TestCase):
                 "id": str(self.agent_2.id),
             },
         )
+
+    def test_get_rooms_to_route_order(self):
+        self.assertEqual(self.service.get_rooms_to_route().count(), 0)
+
+        now = timezone.now()
+        time_1_day_ago = now - timedelta(days=1)
+        time_2_days_ago = now - timedelta(days=2)
+
+        with patch("django.utils.timezone.now", return_value=time_1_day_ago):
+            room_1 = Room.objects.create(queue=self.queue, user=None)
+
+        with patch("django.utils.timezone.now", return_value=time_2_days_ago):
+            room_2 = Room.objects.create(queue=self.queue, user=None)
+
+        self.assertEqual(list(self.service.get_rooms_to_route()), [room_2, room_1])


### PR DESCRIPTION
### What
This pull request updates the datetime field used to order rooms in the automatic room routing service. Instead of using the room's created_on timestamp, it now uses the timestamp from when the room was assigned to the queue.

### Why
This change ensures that room transfers are handled more fairly. Using created_on can give older rooms higher priority—even if they were added to the queue more recently. By ordering based on the time a room entered the queue, we ensure rooms are processed in a way that better reflects their actual wait time.

### Notes
The created_on field is still used as a fallback to ensure backward compatibility, because older rooms do not have the queue_assigned_at field, as it was added recently.