### PR TITLE
Feature/added-to-queue-at-room-order

### DIFF
--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -94,7 +94,7 @@ class RoomViewset(
     filterset_class = room_filters.RoomFilter
     search_fields = ["contact__name", "urn", "protocol", "service_chat"]
     ordering_fields = "__all__"
-    ordering = ["user", "-last_interaction", "created_on"]
+    ordering = ["user", "-last_interaction", "created_on", "added_to_queue_at"]
     pagination_class = RoomListPagination
 
     def get_permissions(self):


### PR DESCRIPTION
### What
Adding added_to_queue_at filter to room view

### Why
This order is the correct one for the is_waiting status (active rooms without user).