### PR TITLE
Fix/repeated rooms routing feedback message

### DIFF
--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -71,7 +71,12 @@ class QueueRouterService:
         rooms_routed = 0
 
         for room in rooms:
-            agent = self.queue.available_agents.first()
+            room.refresh_from_db(fields=["user"])
+
+            if room.user:
+                continue
+
+            agent = self.queue.get_available_agent()
 
             if not agent:
                 break

--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -71,6 +71,9 @@ class QueueRouterService:
         rooms_routed = 0
 
         for room in rooms:
+            # Checking if the room was already routed
+            # This is to avoid routing the same room multiple times
+            # (race condition)
             room.refresh_from_db(fields=["user"])
 
             if room.user:

--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -53,16 +53,7 @@ class QueueRouterService:
             )
             return
 
-        available_agents = self.queue.available_agents.all()
-        available_agents_count = available_agents.count()
-
-        logger.info(
-            "Available agents count: %s for queue %s",
-            available_agents_count,
-            self.queue.uuid,
-        )
-
-        if available_agents_count == 0:
+        if self.queue.available_agents.exists():
             logger.info(
                 "No available agents for queue %s, ending routing", self.queue.uuid
             )


### PR DESCRIPTION
### What
Adding a verification that checks weather a room is still without a user assigned before proceeding with the routing of agents to it. This is done by fetching the room one more time before assigning a user to it.

### Why
Sometimes, in projects with many rooms, the same room is selected to user assignment more than once, causing the system to create more than one feedback message.

### Notes
- This is race condition case that only occurs in big projects. It is not easy to reproduce the issue in production, as it depends in the volume of rooms and online users at a particular moment.
- **For now**, other methods, such as locking the room for updates, are **not** being applied to avoid causing side effects, but are not being completely discarded and can be implemented in the future.
- A feedback message is a special formatted chat message that is shown only to the users of Weni Chats. In this case, it's a message that informs that a user was assigned to the room automatically.

