### PR TITLE
Feature/evaluate feature flags by user and project

### DIFF
--- a/chats/apps/feature_flags/integrations/growthbook/clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/clients.py
@@ -85,9 +85,16 @@ class BaseGrowthbookClient(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def evaluate_features_by_attributes(self, attributes: dict) -> list[str]:
+    def get_active_feature_flags_for_attributes(self, attributes: dict) -> list[str]:
         """
         Evaluate features by attributes.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def evaluate_feature_flag_by_attributes(self, key: str, attributes: dict) -> bool:
+        """
+        Evaluate feature flag by attributes.
         """
         raise NotImplementedError
 
@@ -278,7 +285,7 @@ class GrowthbookClient(BaseGrowthbookClient):
 
         return updated_feature_flags
 
-    def evaluate_features_by_attributes(self, attributes: dict) -> list[str]:
+    def get_active_feature_flags_for_attributes(self, attributes: dict) -> list[str]:
         """
         Evaluate features by attributes.
         """
@@ -296,3 +303,16 @@ class GrowthbookClient(BaseGrowthbookClient):
                 active_features.append(key)
 
         return active_features
+
+    def evaluate_feature_flag_by_attributes(self, key: str, attributes: dict) -> bool:
+        """
+        Evaluate feature flag by attributes.
+        """
+        all_features = self.get_feature_flags()
+
+        gb = GrowthBook(
+            attributes=attributes,
+            features=all_features,
+        )
+
+        return gb.eval_feature(key).on

--- a/chats/apps/feature_flags/integrations/growthbook/clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/clients.py
@@ -291,8 +291,8 @@ class GrowthbookClient(BaseGrowthbookClient):
 
         active_features = []
 
-        for feature in all_features:
-            if gb.eval_feature(feature["key"]):
-                active_features.append(feature)
+        for key in all_features.keys():
+            if gb.eval_feature(key).on:
+                active_features.append(key)
 
         return active_features

--- a/chats/apps/feature_flags/integrations/growthbook/clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/clients.py
@@ -112,9 +112,10 @@ class GrowthbookClient(BaseGrowthbookClient):
         short_cache_ttl: int,
         long_cache_key: str,
         long_cache_ttl: int,
+        is_singleton: bool = False,
     ):
         with cls._lock:
-            if cls._instance is None:
+            if cls._instance is None or is_singleton is False:
                 cls._instance = super().__new__(cls)
                 cls._instance.host_base_url = host_base_url
                 cls._instance.client_key = client_key
@@ -123,6 +124,7 @@ class GrowthbookClient(BaseGrowthbookClient):
                 cls._instance.short_cache_ttl = short_cache_ttl
                 cls._instance.long_cache_key = long_cache_key
                 cls._instance.long_cache_ttl = long_cache_ttl
+                cls._instance.is_singleton = is_singleton
         return cls._instance
 
     def __init__(
@@ -134,13 +136,14 @@ class GrowthbookClient(BaseGrowthbookClient):
         short_cache_ttl: int,
         long_cache_key: str,
         long_cache_ttl: int,
+        is_singleton: bool = False,
     ):
-        if not hasattr(self, "_initialized"):
+        if getattr(self, "_initialized", False) is False:
             assert (
                 short_cache_ttl < long_cache_ttl
             ), "Short cache TTL must be less than long cache TTL"
 
-            self._initialized = True
+            self._initialized = True if is_singleton is True else False
             self.host_base_url = host_base_url
             self.client_key = client_key
             self.cache_client: CacheClient = cache_client

--- a/chats/apps/feature_flags/integrations/growthbook/clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/clients.py
@@ -85,7 +85,7 @@ class BaseGrowthbookClient(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_active_feature_flags_for_attributes(self, attributes: dict) -> list[str]:
+    def get_active_feature_flags_for_attributes(self, attributes: dict):
         """
         Evaluate features by attributes.
         """
@@ -288,7 +288,7 @@ class GrowthbookClient(BaseGrowthbookClient):
 
         return updated_feature_flags
 
-    def get_active_feature_flags_for_attributes(self, attributes: dict) -> list[str]:
+    def get_active_feature_flags_for_attributes(self, attributes: dict):
         """
         Evaluate features by attributes.
         """

--- a/chats/apps/feature_flags/integrations/growthbook/instance.py
+++ b/chats/apps/feature_flags/integrations/growthbook/instance.py
@@ -12,4 +12,5 @@ GROWTHBOOK_CLIENT = GrowthbookClient(
     short_cache_ttl=settings.GROWTHBOOK_SHORT_CACHE_TTL,
     long_cache_key=settings.GROWTHBOOK_LONG_CACHE_KEY,
     long_cache_ttl=settings.GROWTHBOOK_LONG_CACHE_TTL,
+    is_singleton=True,
 )

--- a/chats/apps/feature_flags/integrations/growthbook/tests/mock.py
+++ b/chats/apps/feature_flags/integrations/growthbook/tests/mock.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock
+
+from chats.apps.feature_flags.integrations.growthbook.clients import (
+    BaseGrowthbookClient,
+)
+
+
+class MockGrowthbookClient(BaseGrowthbookClient):
+    """
+    Mock growthbook client.
+    """
+
+    def get_feature_flags_from_short_cache(self) -> dict:
+        return {}
+
+    def get_feature_flags_from_long_cache(self) -> dict:
+        return {}
+
+    def get_feature_flags_from_cache(self) -> dict:
+        return {}
+
+    def set_feature_flags_to_short_cache(self, feature_flags: dict) -> None:
+        pass
+
+    def flush_short_cache(self) -> None:
+        pass
+
+    def set_feature_flags_to_long_cache(self, feature_flags: dict) -> None:
+        pass
+
+    def set_feature_flags_to_cache(self, feature_flags: dict) -> None:
+        pass
+
+    def update_feature_flags_definitions(self) -> dict:
+        return {}
+
+    def get_feature_flags(self) -> dict:
+        return {}
+
+    def evaluate_features_by_attributes(self, attributes: dict) -> list[str]:
+        return []
+
+    def __init__(self):
+        # Create mock methods that can be used for assertions
+        self.get_feature_flags_from_short_cache = MagicMock(return_value={})
+        self.get_feature_flags_from_long_cache = MagicMock(return_value={})
+        self.get_feature_flags_from_cache = MagicMock(return_value={})
+        self.set_feature_flags_to_short_cache = MagicMock()
+        self.flush_short_cache = MagicMock()
+        self.set_feature_flags_to_long_cache = MagicMock()
+        self.set_feature_flags_to_cache = MagicMock()
+        self.update_feature_flags_definitions = MagicMock(return_value={})
+        self.get_feature_flags = MagicMock(return_value={})
+        self.evaluate_features_by_attributes = MagicMock(return_value=[])

--- a/chats/apps/feature_flags/integrations/growthbook/tests/mock.py
+++ b/chats/apps/feature_flags/integrations/growthbook/tests/mock.py
@@ -37,8 +37,11 @@ class MockGrowthbookClient(BaseGrowthbookClient):
     def get_feature_flags(self) -> dict:
         return {}
 
-    def evaluate_features_by_attributes(self, attributes: dict) -> list[str]:
+    def get_active_feature_flags_for_attributes(self, attributes: dict) -> list[str]:
         return []
+
+    def evaluate_feature_flag_by_attributes(self, key: str, attributes: dict) -> bool:
+        return False
 
     def __init__(self):
         # Create mock methods that can be used for assertions
@@ -51,4 +54,5 @@ class MockGrowthbookClient(BaseGrowthbookClient):
         self.set_feature_flags_to_cache = MagicMock()
         self.update_feature_flags_definitions = MagicMock(return_value={})
         self.get_feature_flags = MagicMock(return_value={})
-        self.evaluate_features_by_attributes = MagicMock(return_value=[])
+        self.get_active_feature_flags_for_attributes = MagicMock(return_value=[])
+        self.evaluate_feature_flag_by_attributes = MagicMock(return_value=False)

--- a/chats/apps/feature_flags/integrations/growthbook/tests/mock.py
+++ b/chats/apps/feature_flags/integrations/growthbook/tests/mock.py
@@ -37,7 +37,7 @@ class MockGrowthbookClient(BaseGrowthbookClient):
     def get_feature_flags(self) -> dict:
         return {}
 
-    def get_active_feature_flags_for_attributes(self, attributes: dict) -> list[str]:
+    def get_active_feature_flags_for_attributes(self, attributes: dict):
         return []
 
     def evaluate_feature_flag_by_attributes(self, key: str, attributes: dict) -> bool:

--- a/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
@@ -249,7 +249,7 @@ class TestGrowthbookClient(TestCase):
     )
     def test_evaluate_features_by_attributes(self, mock_get_feature_flags):
         attributes = {
-            "userEmail": "test@test.com",
+            "userEmail": "test@vtex.com",
             "projectUUID": str(uuid.uuid4()),
         }
 

--- a/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
@@ -322,31 +322,31 @@ class TestGrowthbookClient(TestCase):
             },
             # Active if user email is the same as the one in the attributes
             # It is expected to be active because the user email is the same as the one in the attributes
-            "exampleByUserEmailTrue": {
+            "exampleByEmailInTrue": {
                 "defaultValue": False,
                 "rules": [
                     {
                         "id": "fr_40644z1tmdrec3rs",
-                        "condition": {"userEmail": attributes["userEmail"]},
+                        "condition": {"userEmail": {"$in": [attributes["userEmail"]]}},
                         "force": True,
                     }
                 ],
             },
             # Active if user email is not the same as the one in the attributes
             # It is expected to be inactive because the user email is not the same as the one in the attributes
-            "exampleByUserEmailFalse": {
+            "exampleByEmailInFalse": {
                 "defaultValue": False,
                 "rules": [
                     {
                         "id": "fr_40644z1tmdrec3rs",
-                        "condition": {"userEmail": "other@test.com"},
+                        "condition": {"userEmail": {"$in": ["other@test.com"]}},
                         "force": True,
                     }
                 ],
             },
             # Active if user email domain is vtex.com
             # It is expected to be active because the user email domain is vtex.com
-            "exampleByUserEmailDomainTrue": {
+            "exampleByEmailInDomainTrue": {
                 "defaultValue": False,
                 "rules": [
                     {
@@ -362,7 +362,7 @@ class TestGrowthbookClient(TestCase):
             },
             # Active if user email domain is weni.ai
             # It is expected to be inactive because the user email domain is not weni.ai
-            "exampleByUserEmailDomainFalse": {
+            "exampleByEmailInDomainFalse": {
                 "defaultValue": False,
                 "rules": [
                     {
@@ -386,7 +386,7 @@ class TestGrowthbookClient(TestCase):
                 "exampleWithoutRulesTrue",
                 "exampleByProjectInTrue",
                 "exampleByProjectNotInTrue",
-                "exampleByUserEmailTrue",
-                "exampleByUserEmailDomainTrue",
+                "exampleByEmailInTrue",
+                "exampleByEmailInDomainTrue",
             ],
         )

--- a/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
@@ -254,7 +254,15 @@ class TestGrowthbookClient(TestCase):
         }
 
         mock_get_feature_flags.return_value = {
-            "exampleByProject1": {
+            "exampleWithoutRulesTrue": {
+                "defaultValue": True,
+                "rules": [],
+            },
+            "exampleWithoutRulesFalse": {
+                "defaultValue": False,
+                "rules": [],
+            },
+            "exampleByProjectTrue": {
                 "defaultValue": False,
                 "rules": [
                     {
@@ -264,7 +272,7 @@ class TestGrowthbookClient(TestCase):
                     }
                 ],
             },
-            "exampleByProject2": {
+            "exampleByProjectFalse": {
                 "defaultValue": False,
                 "rules": [
                     {
@@ -274,7 +282,7 @@ class TestGrowthbookClient(TestCase):
                     }
                 ],
             },
-            "exampleByUser1": {
+            "exampleByUserEmailTrue": {
                 "defaultValue": False,
                 "rules": [
                     {
@@ -284,7 +292,7 @@ class TestGrowthbookClient(TestCase):
                     }
                 ],
             },
-            "exampleByUser2": {
+            "exampleByUserEmailFalse": {
                 "defaultValue": False,
                 "rules": [
                     {
@@ -294,8 +302,44 @@ class TestGrowthbookClient(TestCase):
                     }
                 ],
             },
+            "exampleByUserEmailDomainTrue": {
+                "defaultValue": False,
+                "rules": [
+                    {
+                        "id": "fr_40644z1tmdrec3rs",
+                        "condition": {
+                            "userEmail": {
+                                "$regex": "^[\\w.+-]+@([\\w-]+\\.)*vtex\\.com$"
+                            }
+                        },
+                        "force": True,
+                    },
+                ],
+            },
+            "exampleByUserEmailDomainFalse": {
+                "defaultValue": False,
+                "rules": [
+                    {
+                        "id": "fr_40644z1tmdrec3rs",
+                        "condition": {
+                            "userEmail": {
+                                "$regex": "^[\\w.+-]+@([\\w-]+\\.)*weni\\.ai$"
+                            }
+                        },
+                        "force": True,
+                    },
+                ],
+            },
         }
 
         features = self.client.evaluate_features_by_attributes(attributes)
 
-        self.assertEqual(features, ["exampleByProject1", "exampleByUser1"])
+        self.assertEqual(
+            features,
+            [
+                "exampleWithoutRules",
+                "exampleByProjectTrue",
+                "exampleByUserEmailTrue",
+                "exampleByUserEmailDomainTrue",
+            ],
+        )

--- a/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
@@ -247,7 +247,7 @@ class TestGrowthbookClient(TestCase):
     @patch(
         "chats.apps.feature_flags.integrations.growthbook.clients.GrowthbookClient.get_feature_flags"
     )
-    def test_evaluate_features_by_attributes(self, mock_get_feature_flags):
+    def test_get_active_feature_flags_for_attributes(self, mock_get_feature_flags):
         attributes = {
             "userEmail": "test@vtex.com",
             "projectUUID": str(uuid.uuid4()),
@@ -378,7 +378,7 @@ class TestGrowthbookClient(TestCase):
             },
         }
 
-        features = self.client.evaluate_features_by_attributes(attributes)
+        features = self.client.get_active_feature_flags_for_attributes(attributes)
 
         self.assertEqual(
             features,
@@ -390,3 +390,30 @@ class TestGrowthbookClient(TestCase):
                 "exampleByEmailInDomainTrue",
             ],
         )
+
+    @patch(
+        "chats.apps.feature_flags.integrations.growthbook.clients.GrowthbookClient.get_feature_flags"
+    )
+    def test_evaluate_feature_flag_by_attributes(self, mock_get_feature_flags):
+        attributes = {
+            "projectUUID": str(uuid.uuid4()),
+        }
+
+        mock_get_feature_flags.return_value = {
+            "example": {
+                "defaultValue": False,
+                "rules": [
+                    {
+                        "id": "fr_40644z1tmdrec3rs",
+                        "condition": {
+                            "projectUUID": {"$in": [attributes["projectUUID"]]}
+                        },
+                        "force": True,
+                    }
+                ],
+            },
+        }
+
+        result = self.client.evaluate_feature_flag_by_attributes("example", attributes)
+
+        self.assertTrue(result)

--- a/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/tests/test_clients.py
@@ -254,34 +254,74 @@ class TestGrowthbookClient(TestCase):
         }
 
         mock_get_feature_flags.return_value = {
+            # Always active while set to True in Growthbook
             "exampleWithoutRulesTrue": {
                 "defaultValue": True,
                 "rules": [],
             },
+            # Always inactive while set to False in Growthbook
             "exampleWithoutRulesFalse": {
                 "defaultValue": False,
                 "rules": [],
             },
-            "exampleByProjectTrue": {
+            # Active if project is in the list
+            # It is expected to be active because the project is in the list
+            # in the attributes above
+            "exampleByProjectInTrue": {
                 "defaultValue": False,
                 "rules": [
                     {
                         "id": "fr_40644z1tmdqamcpe",
-                        "condition": {"projectUUID": attributes["projectUUID"]},
+                        "condition": {
+                            "projectUUID": {"$in": [attributes["projectUUID"]]}
+                        },
                         "force": True,
                     }
                 ],
             },
-            "exampleByProjectFalse": {
+            # Active if project is not in the list
+            # It is expected to be inactive because the project is not in the list
+            # in the attributes above
+            "exampleByProjectInFalse": {
                 "defaultValue": False,
                 "rules": [
                     {
                         "id": "fr_40644z1tmdrec3rs",
-                        "condition": {"projectUUID": str(uuid.uuid4())},
+                        "condition": {"projectUUID": {"$in": [str(uuid.uuid4())]}},
                         "force": True,
                     }
                 ],
             },
+            # Active if project is not in the list
+            # It is expected to be active because the project is not in the list
+            # in the attributes above
+            "exampleByProjectNotInTrue": {
+                "defaultValue": False,
+                "rules": [
+                    {
+                        "id": "fr_40644z1tmdrec3rs",
+                        "condition": {"projectUUID": {"$nin": [str(uuid.uuid4())]}},
+                        "force": True,
+                    }
+                ],
+            },
+            # Active if project is not in the list
+            # It is expected to be inactive because the project is in the list
+            # in the attributes above
+            "exampleByProjectNotInFalse": {
+                "defaultValue": False,
+                "rules": [
+                    {
+                        "id": "fr_40644z1tmdrec3rs",
+                        "condition": {
+                            "projectUUID": {"$nin": [attributes["projectUUID"]]}
+                        },
+                        "force": True,
+                    }
+                ],
+            },
+            # Active if user email is the same as the one in the attributes
+            # It is expected to be active because the user email is the same as the one in the attributes
             "exampleByUserEmailTrue": {
                 "defaultValue": False,
                 "rules": [
@@ -292,6 +332,8 @@ class TestGrowthbookClient(TestCase):
                     }
                 ],
             },
+            # Active if user email is not the same as the one in the attributes
+            # It is expected to be inactive because the user email is not the same as the one in the attributes
             "exampleByUserEmailFalse": {
                 "defaultValue": False,
                 "rules": [
@@ -302,6 +344,8 @@ class TestGrowthbookClient(TestCase):
                     }
                 ],
             },
+            # Active if user email domain is vtex.com
+            # It is expected to be active because the user email domain is vtex.com
             "exampleByUserEmailDomainTrue": {
                 "defaultValue": False,
                 "rules": [
@@ -316,6 +360,8 @@ class TestGrowthbookClient(TestCase):
                     },
                 ],
             },
+            # Active if user email domain is weni.ai
+            # It is expected to be inactive because the user email domain is not weni.ai
             "exampleByUserEmailDomainFalse": {
                 "defaultValue": False,
                 "rules": [
@@ -337,8 +383,9 @@ class TestGrowthbookClient(TestCase):
         self.assertEqual(
             features,
             [
-                "exampleWithoutRules",
-                "exampleByProjectTrue",
+                "exampleWithoutRulesTrue",
+                "exampleByProjectInTrue",
+                "exampleByProjectNotInTrue",
                 "exampleByUserEmailTrue",
                 "exampleByUserEmailDomainTrue",
             ],

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 from chats.apps.accounts.models import User
 from chats.apps.projects.models.models import Project
-from chats.apps.feature_flags.integrations.growthbook.instance import GROWTHBOOK_CLIENT
 from chats.apps.feature_flags.integrations.growthbook.clients import (
     BaseGrowthbookClient,
 )

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+
+from chats.apps.accounts.models import User
+from chats.apps.projects.models.models import Project
+from chats.apps.feature_flags.integrations.growthbook.instance import GROWTHBOOK_CLIENT
+
+
+class BaseFeatureFlagService(ABC):
+    """
+    Base service for feature flags.
+    """
+
+    @abstractmethod
+    def get_feature_flags_list(self) -> list[str]:
+        """
+        Get feature flags list.
+        """
+        raise NotImplementedError
+
+
+class FeatureFlagService(BaseFeatureFlagService):
+    """
+    Service for getting feature flags list.
+    """
+
+    def get_feature_flags_list_for_user_and_project(
+        self, user: User, project: Project
+    ) -> list[str]:
+        """
+        Get feature flags list for user and project.
+        """
+        attributes = {
+            "userEmail": user.email,
+            "projectUUID": project.uuid,
+        }
+
+        return GROWTHBOOK_CLIENT.evaluate_features_by_attributes(attributes)

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -28,8 +28,8 @@ class FeatureFlagService(BaseFeatureFlagService):
     Service for getting feature flags list.
     """
 
-    def __init__(self, growthbook_client: BaseGrowthbookClient = GROWTHBOOK_CLIENT):
-        self.growthbook_client = growthbook_client
+    def __init__(self, growthbook_client: BaseGrowthbookClient = None):
+        self.growthbook_client = growthbook_client or GROWTHBOOK_CLIENT
 
     def get_feature_flags_list_for_user_and_project(
         self, user: User, project: Project

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -17,9 +17,7 @@ class BaseFeatureFlagService(ABC):
     """
 
     @abstractmethod
-    def get_feature_flags_list_for_user_and_project(
-        self, user: User, project: Project
-    ) -> list[str]:
+    def get_feature_flags_list_for_user_and_project(self, user: User, project: Project):
         """
         Get feature flags list.
         """

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -14,7 +14,9 @@ class BaseFeatureFlagService(ABC):
     """
 
     @abstractmethod
-    def get_feature_flags_list_for_user_and_project(self) -> list[str]:
+    def get_feature_flags_list_for_user_and_project(
+        self, user: User, project: Project
+    ) -> list[str]:
         """
         Get feature flags list.
         """

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -42,4 +42,18 @@ class FeatureFlagService(BaseFeatureFlagService):
             "projectUUID": project.uuid,
         }
 
-        return self.growthbook_client.evaluate_features_by_attributes(attributes)
+        return self.growthbook_client.get_active_feature_flags_for_attributes(
+            attributes
+        )
+
+    def evaluate_feature_flag_by_project(self, key: str, project: Project) -> bool:
+        """
+        Evaluate feature flag by project.
+        """
+        attributes = {
+            "projectUUID": project.uuid,
+        }
+
+        return self.growthbook_client.evaluate_feature_flag_by_attributes(
+            key, attributes
+        )

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -3,6 +3,9 @@ from abc import ABC, abstractmethod
 from chats.apps.accounts.models import User
 from chats.apps.projects.models.models import Project
 from chats.apps.feature_flags.integrations.growthbook.instance import GROWTHBOOK_CLIENT
+from chats.apps.feature_flags.integrations.growthbook.clients import (
+    BaseGrowthbookClient,
+)
 
 
 class BaseFeatureFlagService(ABC):
@@ -11,7 +14,7 @@ class BaseFeatureFlagService(ABC):
     """
 
     @abstractmethod
-    def get_feature_flags_list(self) -> list[str]:
+    def get_feature_flags_list_for_user_and_project(self) -> list[str]:
         """
         Get feature flags list.
         """
@@ -22,6 +25,9 @@ class FeatureFlagService(BaseFeatureFlagService):
     """
     Service for getting feature flags list.
     """
+
+    def __init__(self, growthbook_client: BaseGrowthbookClient = GROWTHBOOK_CLIENT):
+        self.growthbook_client = growthbook_client
 
     def get_feature_flags_list_for_user_and_project(
         self, user: User, project: Project
@@ -34,4 +40,4 @@ class FeatureFlagService(BaseFeatureFlagService):
             "projectUUID": project.uuid,
         }
 
-        return GROWTHBOOK_CLIENT.evaluate_features_by_attributes(attributes)
+        return self.growthbook_client.evaluate_features_by_attributes(attributes)

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -28,8 +28,8 @@ class FeatureFlagService(BaseFeatureFlagService):
     Service for getting feature flags list.
     """
 
-    def __init__(self, growthbook_client: BaseGrowthbookClient = None):
-        self.growthbook_client = growthbook_client or GROWTHBOOK_CLIENT
+    def __init__(self, growthbook_client: BaseGrowthbookClient):
+        self.growthbook_client = growthbook_client
 
     def get_feature_flags_list_for_user_and_project(
         self, user: User, project: Project

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -47,7 +47,7 @@ class FeatureFlagService(BaseFeatureFlagService):
         """
         attributes = {
             "userEmail": user.email,
-            "projectUUID": project.uuid,
+            "projectUUID": str(project.uuid),
         }
 
         return self.growthbook_client.get_active_feature_flags_for_attributes(
@@ -65,7 +65,7 @@ class FeatureFlagService(BaseFeatureFlagService):
         if user:
             attributes["userEmail"] = user.email
         if project:
-            attributes["projectUUID"] = project.uuid
+            attributes["projectUUID"] = str(project.uuid)
 
         if not attributes:
             raise ValueError("No attributes provided to evaluate feature flag")

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -1,10 +1,14 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from chats.apps.accounts.models import User
 from chats.apps.projects.models.models import Project
-from chats.apps.feature_flags.integrations.growthbook.clients import (
-    BaseGrowthbookClient,
-)
+
+
+if TYPE_CHECKING:
+    from chats.apps.feature_flags.integrations.growthbook.clients import (
+        BaseGrowthbookClient,
+    )
 
 
 class BaseFeatureFlagService(ABC):
@@ -27,7 +31,7 @@ class FeatureFlagService(BaseFeatureFlagService):
     Service for getting feature flags list.
     """
 
-    def __init__(self, growthbook_client: BaseGrowthbookClient):
+    def __init__(self, growthbook_client: "BaseGrowthbookClient"):
         self.growthbook_client = growthbook_client
 
     def get_feature_flags_list_for_user_and_project(

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -23,6 +23,15 @@ class BaseFeatureFlagService(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def evaluate_feature_flag(
+        self, key: str, user: User = None, project: Project = None
+    ) -> bool:
+        """
+        Evaluate feature flag by project.
+        """
+        raise NotImplementedError
+
 
 class FeatureFlagService(BaseFeatureFlagService):
     """
@@ -45,13 +54,21 @@ class FeatureFlagService(BaseFeatureFlagService):
             attributes
         )
 
-    def evaluate_feature_flag_by_project(self, key: str, project: Project) -> bool:
+    def evaluate_feature_flag(
+        self, key: str, user: User = None, project: Project = None
+    ) -> bool:
         """
         Evaluate feature flag by project.
         """
-        attributes = {
-            "projectUUID": project.uuid,
-        }
+        attributes = {}
+
+        if user:
+            attributes["userEmail"] = user.email
+        if project:
+            attributes["projectUUID"] = project.uuid
+
+        if not attributes:
+            raise ValueError("No attributes provided to evaluate feature flag")
 
         return self.growthbook_client.evaluate_feature_flag_by_attributes(
             key, attributes

--- a/chats/apps/feature_flags/services.py
+++ b/chats/apps/feature_flags/services.py
@@ -32,9 +32,7 @@ class FeatureFlagService(BaseFeatureFlagService):
     def __init__(self, growthbook_client: "BaseGrowthbookClient"):
         self.growthbook_client = growthbook_client
 
-    def get_feature_flags_list_for_user_and_project(
-        self, user: User, project: Project
-    ) -> list[str]:
+    def get_feature_flags_list_for_user_and_project(self, user: User, project: Project):
         """
         Get feature flags list for user and project.
         """

--- a/chats/apps/feature_flags/tests/test_services.py
+++ b/chats/apps/feature_flags/tests/test_services.py
@@ -27,8 +27,14 @@ class TestFeatureFlagService(TestCase):
             }
         )
 
-    def test_evaluate_feature_flag_by_project(self):
-        self.service.evaluate_feature_flag_by_project(
+    def test_cannot_evaluate_feature_flag_without_attributes(self):
+        with self.assertRaises(ValueError):
+            self.service.evaluate_feature_flag(
+                key="example",
+            )
+
+    def test_evaluate_feature_flag_for_project(self):
+        self.service.evaluate_feature_flag(
             key="example",
             project=self.project,
         )
@@ -36,6 +42,34 @@ class TestFeatureFlagService(TestCase):
         self.service.growthbook_client.evaluate_feature_flag_by_attributes.assert_called_once_with(
             "example",
             {
+                "projectUUID": self.project.uuid,
+            },
+        )
+
+    def test_evaluate_feature_flag_for_user(self):
+        self.service.evaluate_feature_flag(
+            key="example",
+            user=self.user,
+        )
+
+        self.service.growthbook_client.evaluate_feature_flag_by_attributes.assert_called_once_with(
+            "example",
+            {
+                "userEmail": "test@test.com",
+            },
+        )
+
+    def test_evaluate_feature_flag_for_user_and_project(self):
+        self.service.evaluate_feature_flag(
+            key="example",
+            user=self.user,
+            project=self.project,
+        )
+
+        self.service.growthbook_client.evaluate_feature_flag_by_attributes.assert_called_once_with(
+            "example",
+            {
+                "userEmail": "test@test.com",
                 "projectUUID": self.project.uuid,
             },
         )

--- a/chats/apps/feature_flags/tests/test_services.py
+++ b/chats/apps/feature_flags/tests/test_services.py
@@ -23,7 +23,7 @@ class TestFeatureFlagService(TestCase):
         self.service.growthbook_client.get_active_feature_flags_for_attributes.assert_called_once_with(
             {
                 "userEmail": "test@test.com",
-                "projectUUID": self.project.uuid,
+                "projectUUID": str(self.project.uuid),
             }
         )
 
@@ -42,7 +42,7 @@ class TestFeatureFlagService(TestCase):
         self.service.growthbook_client.evaluate_feature_flag_by_attributes.assert_called_once_with(
             "example",
             {
-                "projectUUID": self.project.uuid,
+                "projectUUID": str(self.project.uuid),
             },
         )
 
@@ -70,6 +70,6 @@ class TestFeatureFlagService(TestCase):
             "example",
             {
                 "userEmail": "test@test.com",
-                "projectUUID": self.project.uuid,
+                "projectUUID": str(self.project.uuid),
             },
         )

--- a/chats/apps/feature_flags/tests/test_services.py
+++ b/chats/apps/feature_flags/tests/test_services.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+
+from chats.apps.feature_flags.services import FeatureFlagService
+from chats.apps.feature_flags.integrations.growthbook.tests.mock import (
+    MockGrowthbookClient,
+)
+from chats.apps.accounts.models import User
+from chats.apps.projects.models.models import Project
+
+
+class TestFeatureFlagService(TestCase):
+    def setUp(self):
+        self.service = FeatureFlagService(growthbook_client=MockGrowthbookClient())
+        self.user = User.objects.create(email="test@test.com")
+        self.project = Project.objects.create()
+
+    def test_get_feature_flags_list_for_user_and_project(self):
+        self.service.get_feature_flags_list_for_user_and_project(
+            user=self.user,
+            project=self.project,
+        )
+
+        self.service.growthbook_client.evaluate_features_by_attributes.assert_called_once_with(
+            {
+                "userEmail": "test@test.com",
+                "projectUUID": self.project.uuid,
+            }
+        )

--- a/chats/apps/feature_flags/tests/test_services.py
+++ b/chats/apps/feature_flags/tests/test_services.py
@@ -20,9 +20,22 @@ class TestFeatureFlagService(TestCase):
             project=self.project,
         )
 
-        self.service.growthbook_client.evaluate_features_by_attributes.assert_called_once_with(
+        self.service.growthbook_client.get_active_feature_flags_for_attributes.assert_called_once_with(
             {
                 "userEmail": "test@test.com",
                 "projectUUID": self.project.uuid,
             }
+        )
+
+    def test_evaluate_feature_flag_by_project(self):
+        self.service.evaluate_feature_flag_by_project(
+            key="example",
+            project=self.project,
+        )
+
+        self.service.growthbook_client.evaluate_feature_flag_by_attributes.assert_called_once_with(
+            "example",
+            {
+                "projectUUID": self.project.uuid,
+            },
         )

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -502,8 +502,8 @@ GROWTHBOOK_SHORT_CACHE_KEY = env.str(
     "GROWTHBOOK_SHORT_CACHE_KEY", default="growthbook:feature_flags:short"
 )
 GROWTHBOOK_SHORT_CACHE_TTL = env.int(
-    "GROWTHBOOK_SHORT_CACHE_TTL", default=(60 * 60)
-)  # 1 hour
+    "GROWTHBOOK_SHORT_CACHE_TTL", default=300
+)  # 5 minutes
 GROWTHBOOK_LONG_CACHE_KEY = env.str(
     "GROWTHBOOK_LONG_CACHE_KEY", default="growthbook:feature_flags:long"
 )


### PR DESCRIPTION
### What
This pull request adds a service to
- retrieve the active feature flags for a specific user and project
- evaluate a single feature flag for a project and/or user

### Why
- The first case will be useful for the frontend application. In a future implementation, there will be an endpoint that the client can request a list of active features for the authenticated user and in the context of a specific project
- The second case is useful for checking if a single feature is active for a specific user and/or project internally in the backend app