### PR TITLE
feature: config to separate websocket and configs for celery beat

### DIFF
--- a/chats/core/tasks.py
+++ b/chats/core/tasks.py
@@ -1,0 +1,9 @@
+from chats.celery import app
+import logging
+
+logger = logging.getLogger(__name__)
+
+@app.task
+def beat_heartbeat():
+    logger.info("celery beat heartbeat OK")
+    return "ok"

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -292,7 +292,7 @@ if OIDC_ENABLED:
     OIDC_RP_CLIENT_ID = env.str("OIDC_RP_CLIENT_ID")
     OIDC_RP_CLIENT_SECRET = env.str("OIDC_RP_CLIENT_SECRET")
     OIDC_OP_AUTHORIZATION_ENDPOINT = env.str("OIDC_OP_AUTHORIZATION_ENDPOINT")
-    OIDC_OP_TOKEN_ENDPOINT = env.str("OIDC_OP_TOKEN_ENDPOINT")
+    OIDC_OP_TOKEN_ENDPOINT = env.str("OIDC_OP_TOKEN_ENDPOINT", default="https://accounts.weni.ai/auth/realms/weni-staging/protocol/openid-connect/token")
     OIDC_OP_USER_ENDPOINT = env.str("OIDC_OP_USER_ENDPOINT")
     OIDC_OP_USERS_DATA_ENDPOINT = env.str("OIDC_OP_USERS_DATA_ENDPOINT")
     OIDC_OP_JWKS_ENDPOINT = env.str("OIDC_OP_JWKS_ENDPOINT")
@@ -399,6 +399,19 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = TIME_ZONE
 
+# celery beat
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_TIME_LIMIT = 30 * 60
+CELERY_BEAT_SCHEDULER = "celery.beat:PersistentScheduler"
+CELERY_BEAT_MAX_LOOP_INTERVAL = 10
+
+CELERY_BEAT_SCHEDULE = {
+    "beat-heartbeat-test": {
+        "task": "chats.core.tasks.beat_heartbeat",
+        "schedule": 30.0,
+        "args": (),
+    },
+}
 # Event Driven Architecture configurations
 
 USE_EDA = env.bool("USE_EDA", default=False)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,7 +44,11 @@ if [[ "start" == "$1" ]]; then
       --bind=0.0.0.0:8000 \
       -c "${GUNICORN_CONF}"
 elif [[ "start-websocket" == "$1" ]]; then
-    do_gosu "${PROJECT_USER}:${PROJECT_GROUP}" exec daphne -b 0.0.0.0 -p 8000 chats.asgi:application
+    do_gosu "${PROJECT_USER}:${PROJECT_GROUP}" exec gunicorn "${GUNICORN_APP}" \
+      --name="${APPLICATION_NAME}" \
+      --chdir="${PROJECT_PATH}" \
+      --bind=0.0.0.0:8000 \
+      -c "${GUNICORN_CONF}"
 elif [[ "celery-worker" == "$1" ]]; then
     celery_queue="celery"
     if [ "${2}" ] ; then


### PR DESCRIPTION
### **What**
config to separate ws and adding celery beat

### **Why**
run ws pods independently from engine pods and configs to use celery beat