### PR TITLE
Feature/return automatic message flag in message serialized data

### DIFF
--- a/chats/apps/api/v1/msgs/serializers.py
+++ b/chats/apps/api/v1/msgs/serializers.py
@@ -209,6 +209,7 @@ class MessageSerializer(BaseMessageSerializer):
             "replied_message",
             "is_read",
             "is_delivered",
+            "is_automatic_message",
         ]
         read_only_fields = [
             "uuid",

--- a/chats/apps/msgs/models.py
+++ b/chats/apps/msgs/models.py
@@ -176,6 +176,10 @@ class Message(BaseModelWithManualCreatedOn):
     def project(self):
         return self.room.project
 
+    @property
+    def is_automatic_message(self):
+        return hasattr(self, "automatic_message") and self.automatic_message is not None
+
 
 class MessageMedia(BaseModelWithManualCreatedOn):
     message = models.ForeignKey(

--- a/chats/apps/msgs/tests/test_models.py
+++ b/chats/apps/msgs/tests/test_models.py
@@ -6,7 +6,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.timezone import timedelta
 
-from chats.apps.msgs.models import Message, MessageMedia
+from chats.apps.msgs.models import Message, MessageMedia, AutomaticMessage
 from chats.apps.projects.models import Project
 from chats.apps.queues.models import Queue
 from chats.apps.rooms.models import Room
@@ -122,6 +122,15 @@ class TestMessageModel(TestCase):
 
         self.assertIsNone(msg.metadata["context"]["from"])
         self.assertIsNone(msg.metadata["context"]["id"])
+
+    def test_message_without_automatic_message(self):
+        msg = Message.objects.create(room=self.room)
+        self.assertFalse(msg.is_automatic_message)
+
+    def test_message_with_automatic_message(self):
+        msg = Message.objects.create(room=self.room)
+        AutomaticMessage.objects.create(message=msg, room=self.room)
+        self.assertTrue(msg.is_automatic_message)
 
 
 class TestMessageMediaModel(TestCase):


### PR DESCRIPTION
### **What**
Adding the "is_automatic_message" field in messages' serialized data, that is returned to the frontend via websocket and listing view.

### **Why**
The frontend application will use this information to render this message with the indication that it was created automatically, so users in the platform know this. This does not affect the message in the other end (contact).
