### PR TITLE
Feature/add rooms contacts external id filter for metrics

### DIFF
--- a/chats/apps/api/v1/external/rooms/filters.py
+++ b/chats/apps/api/v1/external/rooms/filters.py
@@ -11,11 +11,6 @@ class RoomFilter(filters.FilterSet):
         required=False,
         method="filter_sector",
     )
-    urns_list = filters.CharFilter(
-        field_name="urn",
-        required=False,
-        method="filter_urns_list",
-    )
 
     class Meta:
         model = Room
@@ -27,15 +22,15 @@ class RoomFilter(filters.FilterSet):
         )
         return queryset.filter(sector_filter)
 
-    def filter_urns_list(self, queryset, name, value):
-        urns = value.split(",")
-
-        return queryset.filter(urn__in=urns)
-
 
 class RoomMetricsFilter(RoomFilter):
     created_on__lte = filters.DateTimeFilter(field_name="created_on", lookup_expr="lte")
     created_on__gte = filters.DateTimeFilter(field_name="created_on", lookup_expr="gte")
+    urns_list = filters.CharFilter(
+        field_name="urn",
+        required=False,
+        method="filter_urns_list",
+    )
 
     class Meta(RoomFilter.Meta):
         fields = RoomFilter.Meta.fields + ["created_on__lte", "created_on__gte"]
@@ -52,3 +47,8 @@ class RoomMetricsFilter(RoomFilter):
             )
 
         return queryset
+
+    def filter_urns_list(self, queryset, name, value):
+        urns = value.split(",")
+
+        return queryset.filter(urn__in=urns)

--- a/chats/apps/api/v1/external/rooms/filters.py
+++ b/chats/apps/api/v1/external/rooms/filters.py
@@ -26,10 +26,10 @@ class RoomFilter(filters.FilterSet):
 class RoomMetricsFilter(RoomFilter):
     created_on__lte = filters.DateTimeFilter(field_name="created_on", lookup_expr="lte")
     created_on__gte = filters.DateTimeFilter(field_name="created_on", lookup_expr="gte")
-    urns_list = filters.CharFilter(
+    external_ids = filters.CharFilter(
         field_name="urn",
         required=False,
-        method="filter_urns_list",
+        method="filter_external_ids",
     )
 
     class Meta(RoomFilter.Meta):
@@ -48,7 +48,7 @@ class RoomMetricsFilter(RoomFilter):
 
         return queryset
 
-    def filter_urns_list(self, queryset, name, value):
-        urns = value.split(",")
+    def filter_external_ids(self, queryset, name, value):
+        external_ids = value.split(",")
 
-        return queryset.filter(urn__in=urns)
+        return queryset.filter(contact__external_id__in=external_ids)

--- a/chats/apps/api/v1/external/rooms/filters.py
+++ b/chats/apps/api/v1/external/rooms/filters.py
@@ -11,6 +11,11 @@ class RoomFilter(filters.FilterSet):
         required=False,
         method="filter_sector",
     )
+    urns_list = filters.CharFilter(
+        field_name="urn",
+        required=False,
+        method="filter_urns_list",
+    )
 
     class Meta:
         model = Room
@@ -21,6 +26,11 @@ class RoomFilter(filters.FilterSet):
             queue__sector__name__icontains=value
         )
         return queryset.filter(sector_filter)
+
+    def filter_urns_list(self, queryset, name, value):
+        urns = value.split(",")
+
+        return queryset.filter(urn__in=urns)
 
 
 class RoomMetricsFilter(RoomFilter):


### PR DESCRIPTION
### **What**
Add contacts' external ids filter rooms metrics.

### **Why**
This endpoint is used by an internal service and this filter will be used by it to get specific rooms based on these ids.
