### PR TITLE
Fix/send automatic messages errors

### DIFF
--- a/chats/apps/api/v1/external/rooms/viewsets.py
+++ b/chats/apps/api/v1/external/rooms/viewsets.py
@@ -234,7 +234,8 @@ class RoomFlowViewSet(viewsets.ModelViewSet):
                 )  # 30 seconds delay
 
         if (
-            instance.queue.sector.is_automatic_message_active
+            instance.user
+            and instance.queue.sector.is_automatic_message_active
             and instance.queue.sector.automatic_message_text
         ):
             instance.send_automatic_message(delay=1)

--- a/chats/apps/api/v1/external/rooms/viewsets.py
+++ b/chats/apps/api/v1/external/rooms/viewsets.py
@@ -218,12 +218,6 @@ class RoomFlowViewSet(viewsets.ModelViewSet):
         if instance.user:
             create_room_assigned_from_queue_feedback(instance, instance.user)
 
-            if (
-                instance.queue.sector.is_automatic_message_active
-                and instance.queue.sector.automatic_message_text
-            ):
-                instance.send_automatic_message()
-
         room.notify_billing()
 
         if room.queue.sector.project.has_chats_summary:
@@ -238,6 +232,12 @@ class RoomFlowViewSet(viewsets.ModelViewSet):
                 cancel_history_summary_generation.apply_async(
                     args=[history_summary.uuid], countdown=30
                 )  # 30 seconds delay
+
+        if (
+            instance.queue.sector.is_automatic_message_active
+            and instance.queue.sector.automatic_message_text
+        ):
+            instance.send_automatic_message(delay=1)
 
     def perform_update(self, serializer):
         serializer.save()

--- a/chats/apps/api/v1/external/rooms/viewsets.py
+++ b/chats/apps/api/v1/external/rooms/viewsets.py
@@ -213,6 +213,8 @@ class RoomFlowViewSet(viewsets.ModelViewSet):
         notification_method = getattr(instance, f"notify_{notify_level}")
         notification_method(notification_type)
 
+        instance.refresh_from_db()
+
         if instance.user:
             create_room_assigned_from_queue_feedback(instance, instance.user)
 

--- a/chats/apps/msgs/models.py
+++ b/chats/apps/msgs/models.py
@@ -115,7 +115,7 @@ class Message(BaseModelWithManualCreatedOn):
                 status_forcelist=getattr(
                     settings,
                     "CALLBACK_RETRYABLE_STATUS_CODES",
-                    [429, 500, 502, 503, 504],
+                    [429, 500, 502, 503, 504, 404],
                 ),
                 method_whitelist=["POST"],
             )

--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -223,7 +223,7 @@ class Room(BaseModel, BaseConfigurableModel):
 
         self._update_agent_service_status(is_new)
 
-    def send_automatic_message(self):
+    def send_automatic_message(self, delay: int = 0):
         from chats.apps.sectors.tasks import send_automatic_message
 
         if (
@@ -232,8 +232,13 @@ class Room(BaseModel, BaseConfigurableModel):
             and self.queue.sector.is_automatic_message_active
             and self.queue.sector.automatic_message_text
         ):
-            send_automatic_message.delay(
-                self.uuid, self.queue.sector.automatic_message_text, self.user.id
+            send_automatic_message.apply_async(
+                args=[
+                    self.uuid,
+                    self.queue.sector.automatic_message_text,
+                    self.user.id,
+                ],
+                countdown=delay,
             )
 
     def get_permission(self, user):

--- a/chats/apps/rooms/tests/test_models.py
+++ b/chats/apps/rooms/tests/test_models.py
@@ -267,7 +267,7 @@ class TestRoomModel(TransactionTestCase):
         self.assertEqual(room.full_transfer_history, [feedback, other_feedback])
         self.assertEqual(room.transfer_history, other_feedback)
 
-    @patch("chats.apps.sectors.tasks.send_automatic_message.delay")
+    @patch("chats.apps.sectors.tasks.send_automatic_message.apply_async")
     def test_send_automatic_message_when_room_is_created_with_user(
         self, mock_send_automatic_message
     ):
@@ -287,7 +287,7 @@ class TestRoomModel(TransactionTestCase):
             room.uuid, self.sector.automatic_message_text, user.id
         )
 
-    @patch("chats.apps.sectors.tasks.send_automatic_message.delay")
+    @patch("chats.apps.sectors.tasks.send_automatic_message.apply_async")
     def test_send_automatic_message_when_room_is_updated_with_user(
         self, mock_send_automatic_message
     ):
@@ -309,10 +309,11 @@ class TestRoomModel(TransactionTestCase):
         room.send_automatic_message()
 
         mock_send_automatic_message.assert_called_once_with(
-            room.uuid, self.sector.automatic_message_text, user.id
+            args=[room.uuid, self.sector.automatic_message_text, user.id],
+            countdown=0,
         )
 
-    @patch("chats.apps.sectors.tasks.send_automatic_message.delay")
+    @patch("chats.apps.sectors.tasks.send_automatic_message.apply_async")
     def test_do_not_send_automatic_message_when_sector_automatic_message_is_not_active(
         self, mock_send_automatic_message
     ):

--- a/chats/apps/rooms/tests/test_models.py
+++ b/chats/apps/rooms/tests/test_models.py
@@ -284,7 +284,8 @@ class TestRoomModel(TransactionTestCase):
         room.send_automatic_message()
 
         mock_send_automatic_message.assert_called_once_with(
-            room.uuid, self.sector.automatic_message_text, user.id
+            args=[room.uuid, self.sector.automatic_message_text, user.id],
+            countdown=0,
         )
 
     @patch("chats.apps.sectors.tasks.send_automatic_message.apply_async")

--- a/chats/apps/sectors/services.py
+++ b/chats/apps/sectors/services.py
@@ -50,7 +50,8 @@ class AutomaticMessagesService:
                     message=message,
                 )
 
-                message.notify_room("create", True)
+                transaction.on_commit(lambda: message.notify_room("create", True))
+
                 logger.info(
                     "[AUTOMATIC MESSAGES SERVICE] Automatic message sent to room %s",
                     room.pk,


### PR DESCRIPTION
### What
Adding optional delay (in seconds) to sending automatic message, as well as adding 404 to the retries in notify room (callback to mailroom). To ensure that the automatic message that is created in chats actually arrives in the requesting client.

### Why
If the message is created and sent before the return of the response of the room creation, some erros may occur related to the fact that the requesting client didn't receive the creation response.