### PR TITLE
feat: optimization pin logic get rooms

### DIFF
--- a/chats/apps/api/v1/rooms/serializers.py
+++ b/chats/apps/api/v1/rooms/serializers.py
@@ -241,6 +241,10 @@ class ListRoomSerializer(serializers.ModelSerializer):
         }
 
     def get_is_pinned(self, room: Room) -> bool:
+        pinned_room_ids = self.context.get("pinned_room_ids")
+        if pinned_room_ids is not None:
+            return room.pk in pinned_room_ids
+
         request = self.context.get("request")
 
         if not request:

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -280,8 +280,9 @@ class RoomViewset(
             return self._get_paginated_response(filtered_qs)
 
         combined_qs = qs.filter(
-            Q(pk__in=filtered_qs) | Q(pk__in=pinned_room_ids)
-        ).distinct()
+            Q(pk__in=filtered_qs.order_by().values("pk"))
+            | Q(pk__in=pinned_room_ids)
+        )
 
         pin_date_whens = [
             When(pk=rid, then=Value(dt)) for rid, dt in pin_dates.items()


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Do we need to implement analytics?


### **What**
Performance optimization in the listing of pinned rooms. Replaces correlated subqueries (which ran for each room) with a two-query strategy: searches for the IDs of pinned rooms (max 3) in a quick query and uses Case/When with literal values for annotation. It also eliminates the problem of N+1 queries in the serializer by passing the IDs of pinned rooms via context.


### **Why**
Users with 500-600 active rooms were experiencing response times above 40 seconds at the listing endpoint. The root cause was four correlated subqueries (Exists/Subquery) executed for each room in the database (up to 2,400 subquery evaluations) plus 20 additional queries in the serializer (N+1 in get_is_pinned). Since users can have a maximum of three pins, materializing these IDs in advance eliminates all this complexity.

Translated with [DeepL.com](https://www.deepl.com/?utm_campaign=product&utm_source=web_translator&utm_medium=web&utm_content=copy_free_translation) (free version)
