### PR TITLE
feat: include soft-deleted agents in CSAT endpoint

### DIFF
--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -554,7 +554,7 @@ class AgentRepository:
 
     def _get_csat_agents(self, filters: Filters, project: Project) -> QuerySet[User]:
         agents = User.objects.filter(
-            pk__in=ProjectPermission.all_objects.filter(project=project).values_list(
+            email__in=ProjectPermission.all_objects.filter(project=project).values_list(
                 "user_id", flat=True
             )
         ).annotate(

--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -624,7 +624,7 @@ class AgentRepository:
                 ),
                 Value(0.0),
             ),
-        )
+        ).exclude(is_deleted=True, rooms_count=0)
 
         return self._get_csat_general(filters, project), agents
 

--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -3,6 +3,7 @@ from django.contrib.postgres.fields import JSONField
 from django.db.models import (
     QuerySet,
     Avg,
+    BooleanField,
     Case,
     Count,
     Exists,
@@ -552,7 +553,19 @@ class AgentRepository:
         )
 
     def _get_csat_agents(self, filters: Filters, project: Project) -> QuerySet[User]:
-        agents = User.objects.filter(project_permissions__project=project)
+        agents = User.objects.filter(
+            pk__in=ProjectPermission.all_objects.filter(
+                project=project
+            ).values_list("user_id", flat=True)
+        ).annotate(
+            is_deleted=Subquery(
+                ProjectPermission.all_objects.filter(
+                    project=project,
+                    user_id=OuterRef("pk"),
+                ).values("is_deleted")[:1],
+                output_field=BooleanField(),
+            ),
+        )
 
         if not filters.is_weni_admin:
             agents = agents.exclude(get_admin_domains_exclude_filter())

--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -272,17 +272,17 @@ class AgentRepository:
         if filters.queue and filters.sector:
             rooms_filter["rooms__queue"] = filters.queue
             rooms_filter["rooms__queue__sector__in"] = filters.sector
-            agents_filter[
-                "project_permissions__queue_authorizations__queue"
-            ] = filters.queue
+            agents_filter["project_permissions__queue_authorizations__queue"] = (
+                filters.queue
+            )
             agents_filter[
                 "project_permissions__queue_authorizations__queue__sector__in"
             ] = filters.sector
         elif filters.queue:
             rooms_filter["rooms__queue"] = filters.queue
-            agents_filter[
-                "project_permissions__queue_authorizations__queue"
-            ] = filters.queue
+            agents_filter["project_permissions__queue_authorizations__queue"] = (
+                filters.queue
+            )
         elif filters.sector:
             rooms_filter["rooms__queue__sector__in"] = filters.sector
             agents_filter[
@@ -554,14 +554,14 @@ class AgentRepository:
 
     def _get_csat_agents(self, filters: Filters, project: Project) -> QuerySet[User]:
         agents = User.objects.filter(
-            pk__in=ProjectPermission.all_objects.filter(
-                project=project
-            ).values_list("user_id", flat=True)
+            pk__in=ProjectPermission.all_objects.filter(project=project).values_list(
+                "user_id", flat=True
+            )
         ).annotate(
             is_deleted=Subquery(
                 ProjectPermission.all_objects.filter(
                     project=project,
-                    user_id=OuterRef("pk"),
+                    user_id=OuterRef("email"),
                 ).values("is_deleted")[:1],
                 output_field=BooleanField(),
             ),

--- a/chats/apps/api/v1/internal/dashboard/serializers.py
+++ b/chats/apps/api/v1/internal/dashboard/serializers.py
@@ -157,6 +157,7 @@ class DashboardCSATScoreByAgentsSerializer(serializers.Serializer):
         return {
             "name": name,
             "email": obj.email,
+            "is_deleted": obj.is_deleted,
         }
 
     def get_rooms(self, obj: User):

--- a/chats/apps/api/v1/internal/dashboard/tests/test_repository.py
+++ b/chats/apps/api/v1/internal/dashboard/tests/test_repository.py
@@ -1037,6 +1037,39 @@ class AgentRepositoryTestCase(TestCase):
         self.assertIn("agent1@test.com", agent_emails)
         self.assertIn("agent2@test.com", agent_emails)
 
+        for agent in agents:
+            self.assertFalse(agent.is_deleted)
+
+    def test_get_csat_agents_includes_soft_deleted(self):
+        from chats.apps.accounts.models import User
+        from chats.apps.projects.models import ProjectPermission
+
+        active_user = User.objects.create(
+            email="active@test.com", first_name="Active", last_name="Agent"
+        )
+        removed_user = User.objects.create(
+            email="removed@test.com", first_name="Removed", last_name="Agent"
+        )
+
+        ProjectPermission.objects.create(
+            user=active_user, project=self.project, role=2
+        )
+        ProjectPermission.all_objects.create(
+            user=removed_user, project=self.project, role=2, is_deleted=True
+        )
+
+        filters = Filters()
+        agents = self.repository._get_csat_agents(filters, self.project)
+
+        self.assertEqual(agents.count(), 2)
+        agent_emails = list(agents.values_list("email", flat=True))
+        self.assertIn("active@test.com", agent_emails)
+        self.assertIn("removed@test.com", agent_emails)
+
+        agents_by_email = {a.email: a for a in agents}
+        self.assertFalse(agents_by_email["active@test.com"].is_deleted)
+        self.assertTrue(agents_by_email["removed@test.com"].is_deleted)
+
     def test_get_csat_agents_admin_filtering(self):
         from chats.apps.accounts.models import User
         from chats.apps.projects.models import ProjectPermission
@@ -1355,6 +1388,61 @@ class AgentRepositoryTestCase(TestCase):
             self.assertEqual(agent_data.rooms_count, 2)
             self.assertEqual(agent_data.reviews, 2)
             self.assertEqual(agent_data.avg_rating, 4.0)
+            self.assertFalse(agent_data.is_deleted)
+
+    def test_get_agents_csat_score_includes_soft_deleted_agents(self):
+        user_active = User.objects.create(
+            email="active@test.com", first_name="Active", last_name="Agent"
+        )
+        user_removed = User.objects.create(
+            email="removed@test.com", first_name="Removed", last_name="Agent"
+        )
+
+        ProjectPermission.objects.create(
+            user=user_active, project=self.project, role=2
+        )
+        ProjectPermission.all_objects.create(
+            user=user_removed, project=self.project, role=2, is_deleted=True
+        )
+
+        room_active = Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            project_uuid=self.project.uuid,
+            is_active=False,
+            ended_at=timezone.now(),
+            user=user_active,
+        )
+        room_removed = Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            project_uuid=self.project.uuid,
+            is_active=False,
+            ended_at=timezone.now(),
+            user=user_removed,
+        )
+
+        CSATSurvey.objects.create(
+            room=room_active, rating=5, answered_on=timezone.now()
+        )
+        CSATSurvey.objects.create(
+            room=room_removed, rating=3, answered_on=timezone.now()
+        )
+
+        filters = Filters()
+        general_csat, agents_csat = self.repository.get_agents_csat_score(
+            filters, self.project
+        )
+
+        agents_by_email = {a.email: a for a in agents_csat}
+        self.assertIn("active@test.com", agents_by_email)
+        self.assertIn("removed@test.com", agents_by_email)
+
+        self.assertFalse(agents_by_email["active@test.com"].is_deleted)
+        self.assertTrue(agents_by_email["removed@test.com"].is_deleted)
+
+        self.assertEqual(agents_by_email["active@test.com"].avg_rating, 5.0)
+        self.assertEqual(agents_by_email["removed@test.com"].avg_rating, 3.0)
 
 
 class TestAgentRepository(TestCase):

--- a/chats/apps/api/v1/internal/dashboard/tests/test_repository.py
+++ b/chats/apps/api/v1/internal/dashboard/tests/test_repository.py
@@ -1051,9 +1051,7 @@ class AgentRepositoryTestCase(TestCase):
             email="removed@test.com", first_name="Removed", last_name="Agent"
         )
 
-        ProjectPermission.objects.create(
-            user=active_user, project=self.project, role=2
-        )
+        ProjectPermission.objects.create(user=active_user, project=self.project, role=2)
         ProjectPermission.all_objects.create(
             user=removed_user, project=self.project, role=2, is_deleted=True
         )
@@ -1398,9 +1396,7 @@ class AgentRepositoryTestCase(TestCase):
             email="removed@test.com", first_name="Removed", last_name="Agent"
         )
 
-        ProjectPermission.objects.create(
-            user=user_active, project=self.project, role=2
-        )
+        ProjectPermission.objects.create(user=user_active, project=self.project, role=2)
         ProjectPermission.all_objects.create(
             user=user_removed, project=self.project, role=2, is_deleted=True
         )
@@ -1443,6 +1439,59 @@ class AgentRepositoryTestCase(TestCase):
 
         self.assertEqual(agents_by_email["active@test.com"].avg_rating, 5.0)
         self.assertEqual(agents_by_email["removed@test.com"].avg_rating, 3.0)
+
+    def test_get_agents_csat_score_excludes_soft_deleted_agents_without_rooms(self):
+        user_active = User.objects.create(
+            email="active_nr@test.com", first_name="Active", last_name="Agent"
+        )
+        user_removed_with_rooms = User.objects.create(
+            email="removed_wr@test.com", first_name="Removed", last_name="WithRooms"
+        )
+        user_removed_no_rooms = User.objects.create(
+            email="removed_nr@test.com", first_name="Removed", last_name="NoRooms"
+        )
+
+        ProjectPermission.objects.create(user=user_active, project=self.project, role=2)
+        ProjectPermission.all_objects.create(
+            user=user_removed_with_rooms, project=self.project, role=2, is_deleted=True
+        )
+        ProjectPermission.all_objects.create(
+            user=user_removed_no_rooms, project=self.project, role=2, is_deleted=True
+        )
+
+        room_active = Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            project_uuid=self.project.uuid,
+            is_active=False,
+            ended_at=timezone.now(),
+            user=user_active,
+        )
+        room_removed = Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            project_uuid=self.project.uuid,
+            is_active=False,
+            ended_at=timezone.now(),
+            user=user_removed_with_rooms,
+        )
+
+        CSATSurvey.objects.create(
+            room=room_active, rating=5, answered_on=timezone.now()
+        )
+        CSATSurvey.objects.create(
+            room=room_removed, rating=3, answered_on=timezone.now()
+        )
+
+        filters = Filters()
+        general_csat, agents_csat = self.repository.get_agents_csat_score(
+            filters, self.project
+        )
+
+        agents_by_email = {a.email: a for a in agents_csat}
+        self.assertIn("active_nr@test.com", agents_by_email)
+        self.assertIn("removed_wr@test.com", agents_by_email)
+        self.assertNotIn("removed_nr@test.com", agents_by_email)
 
 
 class TestAgentRepository(TestCase):
@@ -1531,21 +1580,30 @@ class TestAgentRepository(TestCase):
     def _setup_sector_and_queue(self):
         """Helper to create sector and queue"""
         sector = Sector.objects.create(
-            name="Test Sector", project=self.project, rooms_limit=10,
-            work_start="00:00", work_end="23:59"
+            name="Test Sector",
+            project=self.project,
+            rooms_limit=10,
+            work_start="00:00",
+            work_end="23:59",
         )
         Queue.objects.create(name="Test Queue", sector=sector)
         return sector
 
-    def _create_agent_with_permission(self, email, status, first_name="Agent", last_name=None):
+    def _create_agent_with_permission(
+        self, email, status, first_name="Agent", last_name=None
+    ):
         """Helper to create agent with permission"""
         user = User.objects.create(
-            email=email, first_name=first_name,
-            last_name=last_name or status.capitalize(), is_active=True
+            email=email,
+            first_name=first_name,
+            last_name=last_name or status.capitalize(),
+            is_active=True,
         )
         ProjectPermission.objects.create(
-            project=self.project, user=user,
-            role=ProjectPermission.ROLE_ATTENDANT, status=status
+            project=self.project,
+            user=user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=status,
         )
         return user
 
@@ -1555,8 +1613,11 @@ class TestAgentRepository(TestCase):
             name=status_type_name, project=self.project
         )
         CustomStatus.objects.create(
-            user=user, status_type=status_type,
-            is_active=True, break_time=0, project=self.project
+            user=user,
+            status_type=status_type,
+            is_active=True,
+            break_time=0,
+            project=self.project,
         )
         return status_type
 
@@ -1564,21 +1625,33 @@ class TestAgentRepository(TestCase):
         """Helper to assert agent ordering"""
         for position, expected_emails in expected_positions.items():
             if isinstance(position, tuple):
-                actual_emails = {agents[i]["email"] for i in range(position[0], position[1])}
-                self.assertEqual(actual_emails, expected_emails,
-                                 f"Position {position}: expected {expected_emails}")
+                actual_emails = {
+                    agents[i]["email"] for i in range(position[0], position[1])
+                }
+                self.assertEqual(
+                    actual_emails,
+                    expected_emails,
+                    f"Position {position}: expected {expected_emails}",
+                )
             else:
-                self.assertEqual(agents[position]["email"], expected_emails,
-                                 f"Position {position}: expected {expected_emails}")
+                self.assertEqual(
+                    agents[position]["email"],
+                    expected_emails,
+                    f"Position {position}: expected {expected_emails}",
+                )
 
     def _create_test_agents_with_statuses(self):
         """Helper method to create test agents with different statuses"""
         self._setup_sector_and_queue()
 
-        user_away = self._create_agent_with_permission("away@test.com", "ONLINE", last_name="Away")
+        user_away = self._create_agent_with_permission(
+            "away@test.com", "ONLINE", last_name="Away"
+        )
         self._create_custom_status(user_away, "Pausa")
 
-        user_busy = self._create_agent_with_permission("busy@test.com", "OFFLINE", last_name="Busy")
+        user_busy = self._create_agent_with_permission(
+            "busy@test.com", "OFFLINE", last_name="Busy"
+        )
         self._create_custom_status(user_busy, "Almoço")
 
         self._create_agent_with_permission("offline@test.com", "OFFLINE")
@@ -1588,18 +1661,22 @@ class TestAgentRepository(TestCase):
         """Test agents ordered by status: ONLINE → OFFLINE+custom → OFFLINE (ASC)"""
         self._create_test_agents_with_statuses()
 
-        agents_asc = list(self.repository.get_agents_data(
-            Filters(ordering="status", is_weni_admin=False), self.project
-        ))
+        agents_asc = list(
+            self.repository.get_agents_data(
+                Filters(ordering="status", is_weni_admin=False), self.project
+            )
+        )
         self.assertEqual(len(agents_asc), 4)
         self.assertEqual(agents_asc[0]["email"], "away@test.com")
         self.assertEqual(agents_asc[1]["email"], "online@test.com")
         self.assertEqual(agents_asc[2]["email"], "busy@test.com")
         self.assertEqual(agents_asc[3]["email"], "offline@test.com")
 
-        agents_desc = list(self.repository.get_agents_data(
-            Filters(ordering="-status", is_weni_admin=False), self.project
-        ))
+        agents_desc = list(
+            self.repository.get_agents_data(
+                Filters(ordering="-status", is_weni_admin=False), self.project
+            )
+        )
         self.assertEqual(len(agents_desc), 4)
         self.assertEqual(agents_desc[0]["email"], "offline@test.com")
         self.assertEqual(agents_desc[1]["email"], "busy@test.com")
@@ -1610,16 +1687,20 @@ class TestAgentRepository(TestCase):
         """Test get_agents_custom_status_and_rooms respects status ordering"""
         self._create_test_agents_with_statuses()
 
-        agents_asc = list(self.repository.get_agents_custom_status_and_rooms(
-            Filters(ordering="status", is_weni_admin=False), self.project
-        ))
+        agents_asc = list(
+            self.repository.get_agents_custom_status_and_rooms(
+                Filters(ordering="status", is_weni_admin=False), self.project
+            )
+        )
         self.assertEqual(len(agents_asc), 4)
         self.assertEqual(agents_asc[0]["email"], "away@test.com")
         self.assertEqual(agents_asc[-1]["email"], "offline@test.com")
 
-        agents_desc = list(self.repository.get_agents_custom_status_and_rooms(
-            Filters(ordering="-status", is_weni_admin=False), self.project
-        ))
+        agents_desc = list(
+            self.repository.get_agents_custom_status_and_rooms(
+                Filters(ordering="-status", is_weni_admin=False), self.project
+            )
+        )
         self.assertEqual(len(agents_desc), 4)
         self.assertEqual(agents_desc[0]["email"], "offline@test.com")
         self.assertEqual(agents_desc[-1]["email"], "online@test.com")
@@ -1636,31 +1717,45 @@ class TestAgentRepository(TestCase):
                 f"online{i}@test.com", "ONLINE", last_name=f"Online{i}"
             )
 
-        user_away = self._create_agent_with_permission("away@test.com", "ONLINE", last_name="Away")
+        user_away = self._create_agent_with_permission(
+            "away@test.com", "ONLINE", last_name="Away"
+        )
         self._create_custom_status(user_away, "Pausa")
 
-        user_busy = self._create_agent_with_permission("busy@test.com", "OFFLINE", last_name="Busy")
+        user_busy = self._create_agent_with_permission(
+            "busy@test.com", "OFFLINE", last_name="Busy"
+        )
         self._create_custom_status(user_busy, "Almoço")
 
         offline_no_custom_emails = {"offline1@test.com", "offline2@test.com"}
         online_all_emails = {"online1@test.com", "online2@test.com", "away@test.com"}
 
-        agents_asc = list(self.repository.get_agents_data(
-            Filters(ordering="status", is_weni_admin=False), self.project
-        ))
+        agents_asc = list(
+            self.repository.get_agents_data(
+                Filters(ordering="status", is_weni_admin=False), self.project
+            )
+        )
         self.assertEqual(len(agents_asc), 6)
-        self._assert_ordering(agents_asc, {
-            (0, 3): online_all_emails,
-            3: "busy@test.com",
-            (4, 6): offline_no_custom_emails,
-        })
+        self._assert_ordering(
+            agents_asc,
+            {
+                (0, 3): online_all_emails,
+                3: "busy@test.com",
+                (4, 6): offline_no_custom_emails,
+            },
+        )
 
-        agents_desc = list(self.repository.get_agents_data(
-            Filters(ordering="-status", is_weni_admin=False), self.project
-        ))
+        agents_desc = list(
+            self.repository.get_agents_data(
+                Filters(ordering="-status", is_weni_admin=False), self.project
+            )
+        )
         self.assertEqual(len(agents_desc), 6)
-        self._assert_ordering(agents_desc, {
-            (0, 2): offline_no_custom_emails,
-            2: "busy@test.com",
-            (3, 6): online_all_emails,
-        })
+        self._assert_ordering(
+            agents_desc,
+            {
+                (0, 2): offline_no_custom_emails,
+                2: "busy@test.com",
+                (3, 6): online_all_emails,
+            },
+        )


### PR DESCRIPTION
### What

- Changed the CSAT dashboard query (`_get_csat_agents` in `AgentRepository`) to include soft-deleted agents by querying `ProjectPermission.all_objects` instead of filtering through the default manager (`project_permissions__project`), which excludes soft-deleted records.
- Annotated each agent with an `is_deleted` boolean field derived from their `ProjectPermission` record, indicating whether the agent has been removed from the project.
- Exposed the `is_deleted` flag in the `DashboardCSATScoreByAgentsSerializer` response under the `agent` object.
- Added unit tests covering:
  - `_get_csat_agents` returns both active and soft-deleted agents with correct `is_deleted` annotation.
  - `get_agents_csat_score` includes soft-deleted agents with their respective CSAT ratings and deletion status.
  - Existing agents are annotated with `is_deleted = False`.

### Why

Previously, when an agent was removed from a project (soft-deleted `ProjectPermission`), their CSAT data disappeared from the dashboard entirely. This led to incomplete CSAT reports, as historical data tied to removed agents was silently excluded. By including soft-deleted agents and flagging them with `is_deleted`, the dashboard now provides a complete view of CSAT metrics while allowing the frontend to visually distinguish active agents from removed ones.