### PR TITLE
feat: agents status V2

### DIFF
--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -544,6 +544,16 @@ class AgentRepository:
 
         agents = agents.annotate(**annotations)
 
+        if include_removed:
+            active_permission_exists = Exists(
+                ProjectPermission.objects.filter(
+                    project=project,
+                    user_id=OuterRef("email"),
+                )
+            )
+            has_custom_status = Exists(custom_status_base_query)
+            agents = agents.filter(active_permission_exists | has_custom_status)
+
         ordering_fields = ["-agent", "agent"]
 
         if filters.ordering and filters.ordering in ordering_fields:

--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -468,7 +468,7 @@ class AgentRepository:
                 project_permissions__queue_authorizations__queue__sector__in=filters.sector
             )
 
-        return agents
+        return agents.distinct()
 
     def _get_custom_status_query(self, filters: Filters, project: Project):
         custom_status = CustomStatus.objects.filter(

--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -438,8 +438,20 @@ class AgentRepository:
 
         return agents_query
 
-    def _get_agents_query(self, filters: Filters, project: Project):
-        agents = self.model.filter(project_permissions__project=project)
+    def _get_agents_query(self, filters: Filters, project: Project, include_removed: bool = False):
+        if include_removed:
+            agents = self.model.filter(
+                Q(project_permissions__project=project)
+                | Exists(
+                    ProjectPermission.all_objects.filter(
+                        project=project,
+                        user_id=OuterRef("email"),
+                        is_deleted=True,
+                    )
+                )
+            )
+        else:
+            agents = self.model.filter(project_permissions__project=project)
 
         if not filters.is_weni_admin:
             agents = agents.exclude(get_admin_domains_exclude_filter())
@@ -497,9 +509,9 @@ class AgentRepository:
         return custom_status
 
     def get_agents_custom_status(
-        self, filters: Filters, project: Project
+        self, filters: Filters, project: Project, include_removed: bool = False
     ) -> QuerySet[User]:
-        agents = self._get_agents_query(filters, project)
+        agents = self._get_agents_query(filters, project, include_removed)
 
         custom_status_base_query = self._get_custom_status_query(filters, project)
 
@@ -517,10 +529,20 @@ class AgentRepository:
             output_field=JSONField(),
         )
 
-        agents = agents.annotate(
-            custom_status=custom_status_subquery,
-            agent=Concat(F("first_name"), Value(" "), F("last_name")),
-        )
+        annotations = {
+            "custom_status": custom_status_subquery,
+            "agent": Concat(F("first_name"), Value(" "), F("last_name")),
+        }
+
+        if include_removed:
+            annotations["is_deleted"] = ~Exists(
+                ProjectPermission.objects.filter(
+                    project=project,
+                    user_id=OuterRef("email"),
+                )
+            )
+
+        agents = agents.annotate(**annotations)
 
         ordering_fields = ["-agent", "agent"]
 

--- a/chats/apps/api/v1/internal/dashboard/service.py
+++ b/chats/apps/api/v1/internal/dashboard/service.py
@@ -14,9 +14,9 @@ class AgentsService:
         agents_repository = AgentRepository()
         return agents_repository.get_agents_custom_status_and_rooms(filters, project)
 
-    def get_agents_custom_status(self, filters: Filters, project):
+    def get_agents_custom_status(self, filters: Filters, project, include_removed: bool = False):
         agents_repository = AgentRepository()
-        return agents_repository.get_agents_custom_status(filters, project)
+        return agents_repository.get_agents_custom_status(filters, project, include_removed)
 
     def get_agents_csat_score(self, filters: Filters, project):
         agents_repository = AgentRepository()

--- a/chats/apps/api/v2/internal/dashboard/serializers.py
+++ b/chats/apps/api/v2/internal/dashboard/serializers.py
@@ -7,8 +7,8 @@ from chats.apps.projects.models.models import CustomStatusType
 
 
 class InternalDashboardQueryParamsSerializer(serializers.Serializer):
-    start_date = serializers.CharField(required=False)
-    end_date = serializers.CharField(required=False)
+    start_date = serializers.DateField(required=False)
+    end_date = serializers.DateField(required=False)
     agent = serializers.CharField(required=False)
     sector = serializers.ListField(child=serializers.CharField(), required=False)
     tag = serializers.ListField(child=serializers.CharField(), required=False)

--- a/chats/apps/api/v2/internal/dashboard/serializers.py
+++ b/chats/apps/api/v2/internal/dashboard/serializers.py
@@ -1,6 +1,9 @@
+from django.db.models import Q
+
 from rest_framework import serializers
 
 from chats.apps.api.utils import calculate_in_service_time
+from chats.apps.projects.models.models import CustomStatusType
 
 
 class InternalDashboardQueryParamsSerializer(serializers.Serializer):
@@ -67,3 +70,48 @@ class DashboardAgentsSerializerV2(serializers.Serializer):
         return calculate_in_service_time(
             obj.get("custom_status"), user_status=obj.get("status")
         )
+
+
+class DashboardCustomStatusByAgentSerializerV2(serializers.Serializer):
+    agent = serializers.SerializerMethodField()
+    custom_status = serializers.SerializerMethodField()
+    link = serializers.SerializerMethodField()
+
+    def get_agent(self, obj):
+        name = f"{obj.first_name} {obj.last_name}"
+
+        return {
+            "name": name,
+            "email": obj.email,
+            "is_deleted": getattr(obj, "is_deleted", False),
+        }
+
+    def get_custom_status(self, obj):
+        project = self.context.get("project")
+        custom_status_types = CustomStatusType.objects.filter(
+            Q(project=project) & Q(is_deleted=False) & ~Q(name__iexact="In-Service")
+        ).values_list("name", flat=True)
+
+        custom_status_list = getattr(obj, "custom_status", []) or []
+
+        status_dict = {status_type: 0 for status_type in custom_status_types}
+
+        for status_item in custom_status_list:
+            status_type = status_item.get("status_type")
+            break_time = status_item.get("break_time", 0)
+
+            if status_type in status_dict:
+                status_dict[status_type] += break_time
+            else:
+                status_dict[status_type] = break_time
+
+        return [
+            {"status_type": status_type, "break_time": break_time}
+            for status_type, break_time in status_dict.items()
+        ]
+
+    def get_link(self, obj):
+        return {
+            "url": f"chats:dashboard/view-mode/{obj.email}",
+            "type": "internal",
+        }

--- a/chats/apps/api/v2/internal/dashboard/serializers.py
+++ b/chats/apps/api/v2/internal/dashboard/serializers.py
@@ -7,8 +7,8 @@ from chats.apps.projects.models.models import CustomStatusType
 
 
 class InternalDashboardQueryParamsSerializer(serializers.Serializer):
-    start_date = serializers.DateField(required=False)
-    end_date = serializers.DateField(required=False)
+    start_date = serializers.CharField(required=False)
+    end_date = serializers.CharField(required=False)
     agent = serializers.CharField(required=False)
     sector = serializers.ListField(child=serializers.CharField(), required=False)
     tag = serializers.ListField(child=serializers.CharField(), required=False)

--- a/chats/apps/api/v2/internal/dashboard/tests/test_usecases.py
+++ b/chats/apps/api/v2/internal/dashboard/tests/test_usecases.py
@@ -8,6 +8,9 @@ from chats.apps.api.v1.internal.dashboard.dto import Filters
 from chats.apps.api.v2.internal.dashboard.usecases.agents import (
     InternalDashboardAgentsUsecase,
 )
+from chats.apps.api.v2.internal.dashboard.usecases.custom_status_by_agent import (
+    InternalDashboardCustomStatusByAgentUsecase,
+)
 from chats.apps.projects.models.models import (
     CustomStatus,
     CustomStatusType,
@@ -264,3 +267,97 @@ class InternalDashboardAgentsUsecaseTests(TestCase):
         self.assertIn("status", filter_str)
         self.assertIn("email__in", filter_str)
         self.assertEqual(result, mock_filtered)
+
+
+CUSTOM_STATUS_USECASE_MODULE = (
+    "chats.apps.api.v2.internal.dashboard.usecases.custom_status_by_agent"
+)
+
+
+class InternalDashboardCustomStatusByAgentUsecaseTests(TestCase):
+    def setUp(self):
+        self.usecase = InternalDashboardCustomStatusByAgentUsecase()
+        self.project = Project.objects.create(
+            name="Test Project",
+            timezone="America/Sao_Paulo",
+        )
+
+    def _mock_agents_service(self, mock_service_cls):
+        mock_service = mock_service_cls.return_value
+        mock_queryset = MagicMock()
+        mock_service.get_agents_custom_status.return_value = mock_queryset
+        return mock_service, mock_queryset
+
+    @patch(f"{CUSTOM_STATUS_USECASE_MODULE}.AgentsService")
+    def test_execute_builds_filters_dto(self, mock_service_cls):
+        mock_service, _ = self._mock_agents_service(mock_service_cls)
+
+        filters = {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-31",
+            "agent": "agent@test.com",
+            "sector": ["sector-uuid"],
+            "tag": ["tag1"],
+            "queue": "queue-uuid",
+            "user_request": "user@test.com",
+            "ordering": "agent",
+        }
+
+        self.usecase.execute(self.project, filters)
+
+        mock_service.get_agents_custom_status.assert_called_once()
+        dto, project = mock_service.get_agents_custom_status.call_args[0][:2]
+        kwargs = mock_service.get_agents_custom_status.call_args[1]
+
+        self.assertIsInstance(dto, Filters)
+        self.assertEqual(dto.start_date, "2024-01-01")
+        self.assertEqual(dto.end_date, "2024-01-31")
+        self.assertEqual(dto.agent, "agent@test.com")
+        self.assertEqual(dto.sector, ["sector-uuid"])
+        self.assertEqual(dto.tag, ["tag1"])
+        self.assertEqual(dto.queue, "queue-uuid")
+        self.assertEqual(dto.user_request, "user@test.com")
+        self.assertEqual(dto.ordering, "agent")
+        self.assertEqual(project, self.project)
+        self.assertTrue(kwargs.get("include_removed"))
+
+    @patch(f"{CUSTOM_STATUS_USECASE_MODULE}.AgentsService")
+    def test_execute_with_empty_filters(self, mock_service_cls):
+        mock_service, _ = self._mock_agents_service(mock_service_cls)
+
+        self.usecase.execute(self.project, {})
+
+        dto = mock_service.get_agents_custom_status.call_args[0][0]
+        kwargs = mock_service.get_agents_custom_status.call_args[1]
+
+        self.assertIsNone(dto.start_date)
+        self.assertIsNone(dto.end_date)
+        self.assertIsNone(dto.agent)
+        self.assertIsNone(dto.sector)
+        self.assertIsNone(dto.tag)
+        self.assertIsNone(dto.queue)
+        self.assertEqual(dto.user_request, "")
+        self.assertIsNone(dto.ordering)
+        self.assertTrue(kwargs.get("include_removed"))
+
+    @patch(f"{CUSTOM_STATUS_USECASE_MODULE}.should_exclude_admin_domains")
+    @patch(f"{CUSTOM_STATUS_USECASE_MODULE}.AgentsService")
+    def test_execute_computes_is_weni_admin_from_user_request(
+        self, mock_service_cls, mock_exclude
+    ):
+        mock_service, _ = self._mock_agents_service(mock_service_cls)
+        mock_exclude.return_value = True
+
+        self.usecase.execute(self.project, {"user_request": "admin@weni.ai"})
+
+        mock_exclude.assert_called_once_with("admin@weni.ai")
+        dto = mock_service.get_agents_custom_status.call_args[0][0]
+        self.assertTrue(dto.is_weni_admin)
+
+    @patch(f"{CUSTOM_STATUS_USECASE_MODULE}.AgentsService")
+    def test_execute_returns_service_data(self, mock_service_cls):
+        _, mock_queryset = self._mock_agents_service(mock_service_cls)
+
+        result = self.usecase.execute(self.project, {})
+
+        self.assertEqual(result, mock_queryset)

--- a/chats/apps/api/v2/internal/dashboard/tests/test_views.py
+++ b/chats/apps/api/v2/internal/dashboard/tests/test_views.py
@@ -12,11 +12,19 @@ USECASE_PATH = (
     "chats.apps.api.v2.internal.dashboard.usecases.agents"
     ".InternalDashboardAgentsUsecase.execute"
 )
+CUSTOM_STATUS_USECASE_PATH = (
+    "chats.apps.api.v2.internal.dashboard.usecases.custom_status_by_agent"
+    ".InternalDashboardCustomStatusByAgentUsecase.execute"
+)
 
 
 class BaseInternalDashboardViewsetV2Tests(APITestCase):
     def get_agent_metrics(self, project_uuid: str, filters: dict = {}):
         url = f"/v2/internal/dashboard/{project_uuid}/agent/"
+        return self.client.get(url, filters)
+
+    def get_custom_status_by_agent(self, project_uuid: str, filters: dict = {}):
+        url = f"/v2/internal/dashboard/{project_uuid}/custom-status-by-agent/"
         return self.client.get(url, filters)
 
 
@@ -25,6 +33,10 @@ class TestInternalDashboardViewsetV2AsAnonymousUser(
 ):
     def test_agent_metrics_returns_401(self):
         response = self.get_agent_metrics(uuid.uuid4())
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_custom_status_by_agent_returns_401(self):
+        response = self.get_custom_status_by_agent(uuid.uuid4())
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
@@ -116,3 +128,78 @@ class TestInternalDashboardViewsetV2AsAuthenticatedUser(
         self.assertFalse(results[0]["agent"]["is_deleted"])
         self.assertEqual(results[0]["closed"], 5)
         self.assertEqual(results[0]["opened"], 2)
+
+    def test_custom_status_by_agent_returns_403_without_internal_permission(self):
+        response = self.get_custom_status_by_agent(self.project.uuid)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_internal_auth
+    @patch(CUSTOM_STATUS_USECASE_PATH)
+    def test_custom_status_by_agent_returns_404_for_nonexistent_project(
+        self, mock_execute
+    ):
+        response = self.get_custom_status_by_agent(uuid.uuid4(), self.valid_filters)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        mock_execute.assert_not_called()
+
+    @with_internal_auth
+    @patch(CUSTOM_STATUS_USECASE_PATH)
+    def test_custom_status_by_agent_returns_200(self, mock_execute):
+        mock_execute.return_value = []
+
+        response = self.get_custom_status_by_agent(
+            self.project.uuid, self.valid_filters
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+
+    @with_internal_auth
+    @patch(CUSTOM_STATUS_USECASE_PATH)
+    def test_custom_status_by_agent_calls_usecase_with_project_and_filters(
+        self, mock_execute
+    ):
+        mock_execute.return_value = []
+
+        self.get_custom_status_by_agent(self.project.uuid, self.valid_filters)
+
+        mock_execute.assert_called_once()
+        project_arg, filters_arg = mock_execute.call_args[0]
+        self.assertEqual(project_arg, self.project)
+        self.assertIsInstance(filters_arg, dict)
+        self.assertEqual(str(filters_arg["start_date"]), "2024-01-01")
+        self.assertEqual(str(filters_arg["end_date"]), "2024-01-31")
+        self.assertEqual(filters_arg["agent"], "agent@test.com")
+
+    @with_internal_auth
+    @patch(CUSTOM_STATUS_USECASE_PATH)
+    def test_custom_status_by_agent_returns_agent_object_with_is_deleted(
+        self, mock_execute
+    ):
+        agent = User.objects.create(
+            email="agent1@test.com",
+            first_name="Agent",
+            last_name="One",
+        )
+        agent.is_deleted = True
+        agent.custom_status = None
+
+        mock_execute.return_value = [agent]
+
+        response = self.get_custom_status_by_agent(
+            self.project.uuid, self.valid_filters
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["agent"]["email"], "agent1@test.com")
+        self.assertEqual(results[0]["agent"]["name"], "Agent One")
+        self.assertTrue(results[0]["agent"]["is_deleted"])
+        self.assertIn("custom_status", results[0])
+        self.assertIn("link", results[0])
+        self.assertEqual(
+            results[0]["link"]["url"],
+            "chats:dashboard/view-mode/agent1@test.com",
+        )
+        self.assertEqual(results[0]["link"]["type"], "internal")

--- a/chats/apps/api/v2/internal/dashboard/usecases/custom_status_by_agent.py
+++ b/chats/apps/api/v2/internal/dashboard/usecases/custom_status_by_agent.py
@@ -1,0 +1,28 @@
+from chats.apps.api.v1.dashboard.dto import should_exclude_admin_domains
+from chats.apps.api.v1.internal.dashboard.dto import Filters
+from chats.apps.api.v1.internal.dashboard.service import AgentsService
+from chats.apps.projects.models.models import Project
+
+
+class InternalDashboardCustomStatusByAgentUsecase:
+    def execute(self, project: Project, filters: dict):
+        user_request = filters.get("user_request", "")
+
+        start_date = filters.get("start_date")
+        end_date = filters.get("end_date")
+
+        dto = Filters(
+            start_date=str(start_date) if start_date else None,
+            end_date=str(end_date) if end_date else None,
+            agent=filters.get("agent"),
+            sector=filters.get("sector"),
+            tag=filters.get("tag"),
+            queue=filters.get("queue"),
+            user_request=user_request,
+            is_weni_admin=should_exclude_admin_domains(user_request),
+            ordering=filters.get("ordering"),
+        )
+
+        return AgentsService().get_agents_custom_status(
+            dto, project, include_removed=True
+        )

--- a/chats/apps/api/v2/internal/dashboard/viewsets.py
+++ b/chats/apps/api/v2/internal/dashboard/viewsets.py
@@ -8,9 +8,13 @@ from chats.apps.projects.models import Project
 from chats.apps.api.v2.internal.dashboard.serializers import (
     InternalDashboardQueryParamsSerializer,
     DashboardAgentsSerializerV2,
+    DashboardCustomStatusByAgentSerializerV2,
 )
 from chats.apps.api.v2.internal.dashboard.usecases.agents import (
     InternalDashboardAgentsUsecase,
+)
+from chats.apps.api.v2.internal.dashboard.usecases.custom_status_by_agent import (
+    InternalDashboardCustomStatusByAgentUsecase,
 )
 
 
@@ -39,3 +43,32 @@ class InternalDashboardViewsetV2(viewsets.GenericViewSet):
         agents = DashboardAgentsSerializerV2(agents_data, many=True)
 
         return Response({"results": agents.data}, status.HTTP_200_OK)
+
+    @action(
+        detail=True,
+        methods=["GET"],
+        url_name="custom_status_by_agent",
+        url_path="custom-status-by-agent",
+    )
+    def custom_status_by_agent(self, request, *args, **kwargs):
+        """Custom status metrics by agent"""
+        project = self.get_object()
+
+        serializer = InternalDashboardQueryParamsSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        usecase = InternalDashboardCustomStatusByAgentUsecase()
+        agents_data = usecase.execute(project, serializer.validated_data)
+
+        page = self.paginate_queryset(agents_data)
+        if page is not None:
+            result_serializer = DashboardCustomStatusByAgentSerializerV2(
+                page, many=True, context={"project": project}
+            )
+            return self.get_paginated_response(result_serializer.data)
+
+        result_serializer = DashboardCustomStatusByAgentSerializerV2(
+            agents_data, many=True, context={"project": project}
+        )
+
+        return Response({"results": result_serializer.data}, status.HTTP_200_OK)


### PR DESCRIPTION
### What
- Added a new `custom-status-by-agent` endpoint to the v2 internal dashboard API that returns custom status metrics broken down by agent, including support for removed (soft-deleted) agents.
- Extended `AgentRepository._get_agents_query` and `get_agents_custom_status` with an `include_removed` flag that, when enabled, includes agents whose `ProjectPermission` has been soft-deleted and annotates them with an `is_deleted` field.
- Added `.distinct()` to the agents query to eliminate duplicate rows caused by the expanded join with soft-deleted permissions.
- Changed `start_date` and `end_date` fields in `InternalDashboardQueryParamsSerializer` from `DateField` to `CharField` for improved flexibility.
- Created `DashboardCustomStatusByAgentSerializerV2` that returns agent info (name, email, deletion status), aggregated custom status break times (excluding "In-Service"), and an internal navigation link.
- Created `InternalDashboardCustomStatusByAgentUsecase` to encapsulate the business logic for this new endpoint.
- Added comprehensive unit tests for both the new use case and viewset action, covering filter propagation, authentication/authorization, serialized output shape, and handling of deleted agents.

### Why
The dashboard needs to display custom status time metrics per agent so managers can monitor how long each agent spent in different statuses (e.g., break, lunch, meeting) within a given period. Including removed agents ensures historical data remains visible even after an agent leaves the project, providing a complete and accurate view of team activity.