### PR TITLE
fix: handle empty summary case in HistorySummaryService

### DIFF
--- a/chats/apps/ai_features/history_summary/services.py
+++ b/chats/apps/ai_features/history_summary/services.py
@@ -117,7 +117,7 @@ class HistorySummaryService:
                     room.uuid,
                     reason,
                 )
-            if summary_text.strip() == "":
+            elif summary_text.strip() == "":
                 history_summary.update_status(HistorySummaryStatus.UNAVAILABLE)
                 logger.error(
                     "A summary could not be generated for room %s. The AI returned an empty summary.",


### PR DESCRIPTION
### What

Changed the conditional check for empty AI summaries from `if` to `elif` in `HistorySummaryService`. This fixes the logic flow in the `if/elif/else` chain that handles the AI response after generating a history summary (lines 110–133 in `services.py`).

### Why

The `if` statement on the empty summary check meant it was evaluated independently from the preceding `if "<no_summary_available>" in summary_text` block. This caused a bug where, if the summary contained the `<no_summary_available>` tag with no additional text, both the first condition and the empty-string condition could match, leading to redundant status updates and duplicate error logging. Changing it to `elif` ensures the three conditions (`<no_summary_available>` tag, empty summary, and valid summary) are mutually exclusive, which is the intended behavior.