### PR TITLE
feat: call archive messages task more than once per day

### DIFF
--- a/chats/apps/archive_chats/tasks.py
+++ b/chats/apps/archive_chats/tasks.py
@@ -28,8 +28,10 @@ def start_archive_rooms_messages():
     now = datetime.now(timezone.utc)
     limit_date = now - rdelta(years=1)
 
-    rooms_query = Room.objects.filter(is_active=False, ended_at__lt=limit_date).exclude(
-        archived_conversations__status=ArchiveConversationsJobStatus.FINISHED
+    rooms_query = (
+        Room.objects.filter(is_active=False, ended_at__lt=limit_date)
+        .exclude(archived_conversations__status=ArchiveConversationsJobStatus.FINISHED)
+        .exclude(archived_conversations__job__started_at__date=now.date())
     )
 
     if not settings.ARCHIVE_CHATS_IS_ACTIVE_FOR_ALL_PROJECTS:
@@ -47,15 +49,28 @@ def start_archive_rooms_messages():
         rooms_query = rooms_query.filter(queue__sector__project__in=projects)
 
     rooms = rooms_query.order_by("ended_at")[: settings.ARCHIVE_CHATS_MAX_ROOMS]
+    rooms_count = rooms_query.count()
 
     expiration_dt = calculate_archive_task_expiration_dt(
         settings.ARCHIVE_CHATS_MAX_HOUR
     )
 
+    logger.info(
+        f"[start_archive_rooms_messages] Starting archive {rooms_count} rooms with job {job.uuid}"
+    )
+    logger.info(f"[start_archive_rooms_messages] Expiration date: {expiration_dt}")
+
+    async_applied_count = 0
+
     for room in rooms:
         archive_room_messages.apply_async(
             args=[room.uuid, job.uuid], expires=expiration_dt
         )
+        async_applied_count += 1
+
+    logger.info(
+        f"[start_archive_rooms_messages] Applied {async_applied_count} async tasks"
+    )
 
 
 @shared_task(queue="archive-chats")

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -487,7 +487,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "start-archive-rooms-messages": {
         "task": "start_archive_rooms_messages",
-        "schedule": crontab(hour="0-5", minute=0),
+        "schedule": crontab(hour="0-4", minute=0),
     },
 }
 

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -487,7 +487,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "start-archive-rooms-messages": {
         "task": "start_archive_rooms_messages",
-        "schedule": crontab(hour=0, minute=0),
+        "schedule": crontab(hour="0-5", minute=0),
     },
 }
 
@@ -704,7 +704,7 @@ ROOM_24H_VALID_CACHE_TTL = env.int(
 
 
 # Archive chats
-ARCHIVE_CHATS_MAX_ROOMS = env.int("ARCHIVE_CHATS_MAX_ROOMS", default=10000)
+ARCHIVE_CHATS_MAX_ROOMS = env.int("ARCHIVE_CHATS_MAX_ROOMS", default=5000)
 ARCHIVE_CHATS_MAX_HOUR = env.str("ARCHIVE_CHATS_MAX_HOUR", default="08:59")  # UTC-0
 ARCHIVE_CHATS_PROJECTS_LIST_FEATURE_FLAG_KEY = env.str(
     "ARCHIVE_CHATS_PROJECTS_LIST_FEATURE_FLAG_KEY",


### PR DESCRIPTION
### What

- Changed the Celery Beat schedule for the `start-archive-rooms-messages` task from running once at midnight (`hour=0, minute=0`) to running every hour from midnight to 4 AM (`hour="0-4", minute=0`), resulting in 5 executions per night instead of 1.
- Reduced the `ARCHIVE_CHATS_MAX_ROOMS` default from `10000` to `5000` rooms per execution (this can be changed to a different value in production).
- Added a query filter to exclude rooms that already have an archive job started on the current day (`.exclude(archived_conversations__job__started_at__date=now.date())`), preventing the same rooms from being re-queued across multiple runs within the same night.
- Added logging to track the number of eligible rooms, the task expiration datetime, and how many async tasks were dispatched per run.

### Why

By spreading the work across 5 hourly runs (00:00–04:00) with a smaller batch size each, the system archives rooms with a more even load distribution, reducing the risk of timeouts, memory pressure, and missed deadlines. The same-day exclusion filter ensures each hourly run picks up a fresh batch of rooms rather than re-processing what a previous run already dispatched.

### Sequence diagram

```mermaid
sequenceDiagram
    participant CB as Celery Beat
    participant T as start_archive_rooms_messages Task
    participant DB as Database
    participant W as archive_room_messages Worker
    participant S as Storage/Archive

    loop Every hour from 00:00 to 04:00 UTC
        CB->>T: Trigger task (crontab hour 0-4, minute 0)
        T->>T: Check current time < ARCHIVE_CHATS_MAX_HOUR (08:59 UTC)
        alt Within allowed window
            T->>DB: Query up to 5000 rooms (inactive, ended >1y ago,<br/>not yet archived, no job started today)
            DB-->>T: Return room batch
            T->>T: Log room count, expiration date
            loop For each room in batch
                T->>W: apply_async(archive_room_messages, [room_uuid, job_uuid])
            end
            T->>T: Log async tasks applied count
        else Past max hour
            T->>T: Skip execution
        end
    end

    loop Workers process queued tasks
        W->>DB: Fetch room messages
        DB-->>W: Return messages
        W->>S: Archive messages to storage
        S-->>W: Confirm archived
        W->>DB: Mark room as archived
    end