### PR TITLE
fix: ensure soft deletion of queues and tags when a sector is deleted

### DIFF
--- a/chats/apps/sectors/models.py
+++ b/chats/apps/sectors/models.py
@@ -339,8 +339,12 @@ class Sector(BaseSoftDeleteModel, BaseConfigurableModel, BaseModel):
 
     def delete(self):
         super().delete()
+        deleted_sufix = self.deleted_sufix()
         self.queues.filter(is_deleted=False).update(
-            is_deleted=True, name=Concat(F("name"), Value(self.deleted_sufix()))
+            is_deleted=True, name=Concat(F("name"), Value(deleted_sufix))
+        )
+        self.tags.filter(is_deleted=False).update(
+            is_deleted=True, name=Concat(F("name"), Value(deleted_sufix))
         )
 
 

--- a/chats/apps/sectors/models.py
+++ b/chats/apps/sectors/models.py
@@ -17,7 +17,7 @@ from chats.apps.queues.utils import start_queue_priority_routing
 from chats.core.models import BaseConfigurableModel, BaseModel, BaseSoftDeleteModel
 from chats.utils.websockets import send_channels_group
 
-from .sector_managers import SectorAuthorizationManager, SectorManager
+from .sector_managers import SectorAuthorizationManager, SectorManager, SectorTagManager
 
 User = get_user_model()
 
@@ -343,7 +343,7 @@ class Sector(BaseSoftDeleteModel, BaseConfigurableModel, BaseModel):
         self.queues.filter(is_deleted=False).update(
             is_deleted=True, name=Concat(F("name"), Value(deleted_sufix))
         )
-        self.tags.filter(is_deleted=False).update(
+        SectorTag.all_objects.filter(sector=self, is_deleted=False).update(
             is_deleted=True, name=Concat(F("name"), Value(deleted_sufix))
         )
 
@@ -434,6 +434,9 @@ class SectorTag(BaseSoftDeleteModel, BaseModel):
         related_name="tags",
         on_delete=models.CASCADE,
     )
+
+    objects = SectorTagManager()
+    all_objects = SectorTagManager(include_deleted=True)
 
     def get_permission(self, user):
         try:

--- a/chats/apps/sectors/sector_managers.py
+++ b/chats/apps/sectors/sector_managers.py
@@ -17,3 +17,15 @@ class SectorAuthorizationManager(models.Manager):
             return super().get_queryset()
 
         return super().get_queryset().filter(permission__is_deleted=False)
+
+
+class SectorTagManager(SoftDeletableManager):
+    def __init__(self, *args, include_deleted: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.include_deleted = include_deleted
+
+    def get_queryset(self):
+        if self.include_deleted:
+            return super().get_queryset()
+
+        return super().get_queryset().filter(is_deleted=False, sector__is_deleted=False)

--- a/chats/apps/sectors/sector_managers.py
+++ b/chats/apps/sectors/sector_managers.py
@@ -20,12 +20,8 @@ class SectorAuthorizationManager(models.Manager):
 
 
 class SectorTagManager(SoftDeletableManager):
-    def __init__(self, *args, include_deleted: bool = False, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.include_deleted = include_deleted
-
     def get_queryset(self):
         if self.include_deleted:
             return super().get_queryset()
 
-        return super().get_queryset().filter(is_deleted=False, sector__is_deleted=False)
+        return super().get_queryset().filter(sector__is_deleted=False)

--- a/chats/apps/sectors/tests/test_models.py
+++ b/chats/apps/sectors/tests/test_models.py
@@ -636,6 +636,14 @@ class SectorDeleteCascadeTests(TestCase):
         self.tag_b = SectorTag.objects.create(name="Tag B", sector=self.sector)
 
     def test_tags_are_soft_deleted_when_sector_is_deleted(self):
+        another_sector = Sector.objects.create(
+            name="Another Sector",
+            project=self.project,
+            rooms_limit=1,
+        )
+        another_tag = SectorTag.objects.create(
+            name="Another Tag", sector=another_sector
+        )
         self.sector.delete()
 
         self.tag_a.refresh_from_db()
@@ -643,8 +651,17 @@ class SectorDeleteCascadeTests(TestCase):
 
         self.assertTrue(self.tag_a.is_deleted)
         self.assertTrue(self.tag_b.is_deleted)
+        self.assertFalse(another_tag.is_deleted)
 
     def test_tags_names_receive_deleted_suffix_when_sector_is_deleted(self):
+        another_sector = Sector.objects.create(
+            name="Another Sector",
+            project=self.project,
+            rooms_limit=1,
+        )
+        another_tag = SectorTag.objects.create(
+            name="Another Tag", sector=another_sector
+        )
         self.sector.delete()
 
         self.tag_a.refresh_from_db()
@@ -652,6 +669,8 @@ class SectorDeleteCascadeTests(TestCase):
 
         self.assertTrue(self.tag_a.name.startswith("Tag A_is_deleted_"))
         self.assertTrue(self.tag_b.name.startswith("Tag B_is_deleted_"))
+        self.assertFalse(another_tag.name.startswith("Another Tag_is_deleted_"))
+        self.assertEqual(another_tag.name, "Another Tag")
 
     def test_queues_are_soft_deleted_when_sector_is_deleted(self):
         self.sector.delete()
@@ -670,3 +689,36 @@ class SectorDeleteCascadeTests(TestCase):
         self.tag_a.refresh_from_db()
 
         self.assertEqual(self.tag_a.name, original_name)
+
+
+class SectorTagManagerTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Manager Project",
+            room_routing_type=RoomRoutingType.QUEUE_PRIORITY,
+        )
+        self.sector = Sector.objects.create(
+            name="Manager Sector",
+            project=self.project,
+            rooms_limit=1,
+        )
+        self.sector_tag = SectorTag.objects.create(
+            name="Manager Sector Tag",
+            sector=self.sector,
+        )
+
+    def test_get_queryset_when_tag_and_sector_are_not_deleted(self):
+        self.assertIn(self.sector_tag, SectorTag.objects.all())
+        self.assertIn(self.sector_tag, SectorTag.all_objects.all())
+
+    def test_get_queryset_when_tag_is_deleted(self):
+        self.sector_tag.delete()
+
+        self.assertNotIn(self.sector_tag, SectorTag.objects.all())
+        self.assertIn(self.sector_tag, SectorTag.all_objects.all())
+
+    def test_get_queryset_when_sector_is_deleted(self):
+        Sector.objects.filter(uuid=self.sector.uuid).update(is_deleted=True)
+
+        self.assertNotIn(self.sector_tag, SectorTag.objects.all())
+        self.assertIn(self.sector_tag, SectorTag.all_objects.all())

--- a/chats/apps/sectors/tests/test_models.py
+++ b/chats/apps/sectors/tests/test_models.py
@@ -423,7 +423,9 @@ class WorkingHoursValidatorHolidayTests(TestCase):
         )
 
     @patch("chats.apps.sectors.utils.CacheClient")
-    def test_configurable_holiday_custom_hours_inside_window_passes(self, MockCacheClient):
+    def test_configurable_holiday_custom_hours_inside_window_passes(
+        self, MockCacheClient
+    ):
         """Configurable holiday with custom hours allows contact within the window."""
         MockCacheClient.return_value = _FakeCache()
         SectorHoliday.objects.create(
@@ -510,7 +512,11 @@ class WorkingHoursValidatorHolidayTests(TestCase):
                         "monday": {"start": "08:00", "end": "17:00"},
                     },
                     "static_holidays": {
-                        "2025-01-06": {"closed": False, "start": "08:00", "end": "12:00"},
+                        "2025-01-06": {
+                            "closed": False,
+                            "start": "08:00",
+                            "end": "12:00",
+                        },
                     },
                 }
             },
@@ -536,7 +542,11 @@ class WorkingHoursValidatorHolidayTests(TestCase):
                         "monday": {"start": "08:00", "end": "17:00"},
                     },
                     "static_holidays": {
-                        "2025-01-06": {"closed": False, "start": "14:00", "end": "18:00"},
+                        "2025-01-06": {
+                            "closed": False,
+                            "start": "14:00",
+                            "end": "18:00",
+                        },
                     },
                 }
             },
@@ -605,3 +615,58 @@ class SectorRequiredTagsTests(TransactionTestCase):
         self.sector.refresh_from_db()
 
         self.assertFalse(self.sector.required_tags)
+
+
+class SectorDeleteCascadeTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Cascade Project",
+            room_routing_type=RoomRoutingType.QUEUE_PRIORITY,
+        )
+        self.sector = Sector.objects.create(
+            name="Cascade Sector",
+            project=self.project,
+            rooms_limit=1,
+        )
+        self.queue = Queue.objects.create(
+            name="Cascade Queue",
+            sector=self.sector,
+        )
+        self.tag_a = SectorTag.objects.create(name="Tag A", sector=self.sector)
+        self.tag_b = SectorTag.objects.create(name="Tag B", sector=self.sector)
+
+    def test_tags_are_soft_deleted_when_sector_is_deleted(self):
+        self.sector.delete()
+
+        self.tag_a.refresh_from_db()
+        self.tag_b.refresh_from_db()
+
+        self.assertTrue(self.tag_a.is_deleted)
+        self.assertTrue(self.tag_b.is_deleted)
+
+    def test_tags_names_receive_deleted_suffix_when_sector_is_deleted(self):
+        self.sector.delete()
+
+        self.tag_a.refresh_from_db()
+        self.tag_b.refresh_from_db()
+
+        self.assertTrue(self.tag_a.name.startswith("Tag A_is_deleted_"))
+        self.assertTrue(self.tag_b.name.startswith("Tag B_is_deleted_"))
+
+    def test_queues_are_soft_deleted_when_sector_is_deleted(self):
+        self.sector.delete()
+
+        self.queue.refresh_from_db()
+
+        self.assertTrue(self.queue.is_deleted)
+        self.assertTrue(self.queue.name.startswith("Cascade Queue_is_deleted_"))
+
+    def test_already_deleted_tags_are_not_affected(self):
+        self.tag_a.delete()
+        self.tag_a.refresh_from_db()
+        original_name = self.tag_a.name
+
+        self.sector.delete()
+        self.tag_a.refresh_from_db()
+
+        self.assertEqual(self.tag_a.name, original_name)


### PR DESCRIPTION
### What

- Added `SectorTagManager` custom manager that filters out soft-deleted tags and tags belonging to soft-deleted sectors from the default queryset, while providing an `all_objects` manager to access all records including deleted ones.
- Updated the `Sector.delete()` method to also soft-delete associated `SectorTag` records (appending the `_is_deleted_` suffix to their names), in addition to the already existing soft-deletion of queues.
- Added comprehensive tests covering the cascade soft-deletion of tags when a sector is deleted, suffix renaming behavior, idempotency for already-deleted tags, and the `SectorTagManager` filtering logic.

### Why

When a sector was soft-deleted, its associated queues were already being soft-deleted, but tags were left in an active state. This caused orphaned tags — still visible and queryable — that belonged to logically deleted sectors. This change ensures data consistency by cascading the soft-delete to tags and by filtering them out at the manager level, so that no consumer accidentally operates on tags from deleted sectors.

### Sequence diagram

```mermaid
sequenceDiagram
    actor User
    participant Sector
    participant BaseSoftDeleteModel
    participant Queue
    participant SectorTag

    User->>Sector: delete()
    Sector->>BaseSoftDeleteModel: super().delete()
    BaseSoftDeleteModel->>BaseSoftDeleteModel: Set is_deleted=True, append suffix to name

    Sector->>Sector: Compute deleted_sufix()

    Sector->>Queue: UPDATE queues SET is_deleted=True,<br/>name = name + suffix<br/>WHERE is_deleted=False
    Queue-->>Sector: Queues soft-deleted

    Sector->>SectorTag: UPDATE tags SET is_deleted=True,<br/>name = name + suffix<br/>WHERE sector=self AND is_deleted=False
    SectorTag-->>Sector: Tags soft-deleted

    Note over SectorTag: SectorTagManager.objects filters out<br/>is_deleted=True OR sector.is_deleted=True
    Note over SectorTag: SectorTagManager.all_objects returns<br/>all records including deleted
```