### PR TITLE
feat: reverify user room count before set

### DIFF
--- a/chats/apps/api/v1/external/rooms/serializers.py
+++ b/chats/apps/api/v1/external/rooms/serializers.py
@@ -21,6 +21,9 @@ from chats.apps.dashboard.models import RoomMetrics
 from chats.apps.msgs.models import Message, MessageMedia
 from chats.apps.projects.models.models import FlowStart, Project
 from chats.apps.queues.models import Queue
+from chats.apps.queues.usecases.can_agent_receive_room import (
+    CanAgentReceiveRoomUseCase,
+)
 from chats.apps.queues.utils import start_queue_priority_routing
 from chats.apps.rooms.models import Room
 from chats.apps.rooms.views import close_room
@@ -118,8 +121,21 @@ def get_room_user(
 
         if current_queue_size == 0:
             # If the queue is empty, the available user with the least number
-            # of rooms will be selected, if any.
-            return queue.get_available_agent()
+            # of rooms will be selected, if any, subject to a last-moment
+            # capacity recheck to close the race with concurrent assignments.
+            agent = queue.get_available_agent()
+            if agent is None:
+                return None
+
+            capacity = CanAgentReceiveRoomUseCase(queue).execute(agent)
+            if capacity.can_receive:
+                return agent
+
+            # Agent was picked but failed the recheck: leave the room in the
+            # queue and trigger routing so it is retried on the next
+            # opportunity.
+            start_queue_priority_routing(queue)
+            return None
 
         logger.info(
             "Calling start_queue_priority_routing for queue %s from get_room_user because the queue is not empty",
@@ -135,8 +151,14 @@ def get_room_user(
     if queue.rooms.filter(is_active=True, user__isnull=True).exists():
         return None
 
-    # General room routing type
-    return queue.get_available_agent()
+    # General room routing type. The last-moment capacity recheck is applied
+    # as well; if the picked agent fails it, the room stays unassigned.
+    agent = queue.get_available_agent()
+    if agent is None:
+        return None
+
+    capacity = CanAgentReceiveRoomUseCase(queue).execute(agent)
+    return agent if capacity.can_receive else None
 
 
 class RoomListSerializer(serializers.ModelSerializer):

--- a/chats/apps/api/v1/external/rooms/serializers.py
+++ b/chats/apps/api/v1/external/rooms/serializers.py
@@ -127,6 +127,13 @@ def get_room_user(
             if agent is None:
                 return None
 
+            if not is_feature_active(
+                settings.AGENT_CAPACITY_RECHECK_FEATURE_FLAG_KEY,
+                None,
+                str(project.uuid),
+            ):
+                return agent
+
             capacity = CanAgentReceiveRoomUseCase(queue).execute(agent)
             if capacity.can_receive:
                 return agent
@@ -156,6 +163,13 @@ def get_room_user(
     agent = queue.get_available_agent()
     if agent is None:
         return None
+
+    if not is_feature_active(
+        settings.AGENT_CAPACITY_RECHECK_FEATURE_FLAG_KEY,
+        None,
+        str(project.uuid),
+    ):
+        return agent
 
     capacity = CanAgentReceiveRoomUseCase(queue).execute(agent)
     return agent if capacity.can_receive else None

--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -8,6 +8,9 @@ from django.utils import timezone
 from chats.apps.dashboard.models import RoomMetrics
 from chats.apps.dashboard.utils import calculate_last_queue_waiting_time
 from chats.apps.queues.models import LAST_SEEN_THRESHOLD_SECONDS
+from chats.apps.queues.usecases.can_agent_receive_room import (
+    CanAgentReceiveRoomUseCase,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +115,13 @@ class QueueRouterService:
                     agent.email,
                     room.uuid,
                 )
+                continue
+
+            # Last-moment capacity recheck to close the race between
+            # get_available_agent() and room.save(), where concurrent
+            # assignments could push the agent above the sector's limit.
+            capacity = CanAgentReceiveRoomUseCase(self.queue).execute(agent)
+            if not capacity.can_receive:
                 continue
 
             old_user_assigned_at = room.user_assigned_at

--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -2,8 +2,10 @@ import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.db.models.functions import Coalesce
 from django.utils import timezone
+from weni.feature_flags import is_feature_active_for_attributes
 
 from chats.apps.dashboard.models import RoomMetrics
 from chats.apps.dashboard.utils import calculate_last_queue_waiting_time
@@ -120,9 +122,13 @@ class QueueRouterService:
             # Last-moment capacity recheck to close the race between
             # get_available_agent() and room.save(), where concurrent
             # assignments could push the agent above the sector's limit.
-            capacity = CanAgentReceiveRoomUseCase(self.queue).execute(agent)
-            if not capacity.can_receive:
-                continue
+            if is_feature_active_for_attributes(
+                settings.AGENT_CAPACITY_RECHECK_FEATURE_FLAG_KEY,
+                {"projectUUID": str(self.queue.sector.project.uuid)},
+            ):
+                capacity = CanAgentReceiveRoomUseCase(self.queue).execute(agent)
+                if not capacity.can_receive:
+                    continue
 
             old_user_assigned_at = room.user_assigned_at
 

--- a/chats/apps/queues/services.py
+++ b/chats/apps/queues/services.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.db.models.functions import Coalesce
 from django.utils import timezone
-from weni.feature_flags import is_feature_active_for_attributes
+from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from chats.apps.dashboard.models import RoomMetrics
 from chats.apps.dashboard.utils import calculate_last_queue_waiting_time

--- a/chats/apps/queues/tests/test_can_agent_receive_room.py
+++ b/chats/apps/queues/tests/test_can_agent_receive_room.py
@@ -1,0 +1,163 @@
+from datetime import time
+
+from django.test import TestCase
+
+from chats.apps.accounts.models import User
+from chats.apps.projects.models.models import (
+    Project,
+    ProjectPermission,
+    RoomRoutingType,
+)
+from chats.apps.queues.models import Queue, QueueAuthorization
+from chats.apps.queues.usecases.can_agent_receive_room import (
+    AgentCapacityResult,
+    CanAgentReceiveRoomUseCase,
+)
+from chats.apps.rooms.models import Room
+from chats.apps.sectors.models import GroupSector, Sector, SectorGroupSector
+
+
+class CanAgentReceiveRoomUseCaseTestCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project",
+            room_routing_type=RoomRoutingType.QUEUE_PRIORITY,
+        )
+        self.sector = Sector.objects.create(
+            name="Test Sector",
+            project=self.project,
+            rooms_limit=3,
+            work_start=time(hour=0, minute=0),
+            work_end=time(hour=23, minute=59),
+        )
+        self.other_sector = Sector.objects.create(
+            name="Other Sector",
+            project=self.project,
+            rooms_limit=3,
+            work_start=time(hour=0, minute=0),
+            work_end=time(hour=23, minute=59),
+        )
+        self.queue = Queue.objects.create(name="Test Queue", sector=self.sector)
+        self.other_queue = Queue.objects.create(
+            name="Other Queue", sector=self.other_sector
+        )
+
+        self.agent = User.objects.create(email="agent@example.com")
+        permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=permission,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        self.usecase = CanAgentReceiveRoomUseCase(self.queue)
+
+    def test_returns_true_when_agent_has_no_active_rooms(self):
+        result = self.usecase.execute(self.agent)
+
+        self.assertIsInstance(result, AgentCapacityResult)
+        self.assertTrue(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 0)
+        self.assertEqual(result.limit, 3)
+        self.assertIsNone(result.reason)
+
+    def test_returns_true_when_agent_is_below_limit(self):
+        Room.objects.create(queue=self.queue, user=self.agent, is_active=True)
+        Room.objects.create(queue=self.queue, user=self.agent, is_active=True)
+
+        result = self.usecase.execute(self.agent)
+
+        self.assertTrue(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 2)
+        self.assertEqual(result.limit, 3)
+
+    def test_returns_false_when_agent_reached_limit(self):
+        for _ in range(3):
+            Room.objects.create(queue=self.queue, user=self.agent, is_active=True)
+
+        result = self.usecase.execute(self.agent)
+
+        self.assertFalse(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 3)
+        self.assertEqual(result.limit, 3)
+        self.assertIsNotNone(result.reason)
+
+    def test_returns_false_when_agent_exceeded_limit(self):
+        """
+        Scenario that motivated this usecase: somehow the agent
+        ended up with more rooms than the limit (race condition).
+        """
+        for _ in range(5):
+            Room.objects.create(queue=self.queue, user=self.agent, is_active=True)
+
+        result = self.usecase.execute(self.agent)
+
+        self.assertFalse(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 5)
+        self.assertEqual(result.limit, 3)
+
+    def test_closed_rooms_do_not_count(self):
+        for _ in range(3):
+            Room.objects.create(queue=self.queue, user=self.agent, is_active=False)
+
+        result = self.usecase.execute(self.agent)
+
+        self.assertTrue(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 0)
+
+    def test_rooms_from_other_sectors_do_not_count(self):
+        for _ in range(3):
+            Room.objects.create(
+                queue=self.other_queue, user=self.agent, is_active=True
+            )
+
+        result = self.usecase.execute(self.agent)
+
+        self.assertTrue(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 0)
+
+    def test_rooms_from_sibling_queues_in_same_sector_do_count(self):
+        sibling_queue = Queue.objects.create(
+            name="Sibling Queue", sector=self.sector
+        )
+        for _ in range(3):
+            Room.objects.create(
+                queue=sibling_queue, user=self.agent, is_active=True
+            )
+
+        result = self.usecase.execute(self.agent)
+
+        self.assertFalse(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 3)
+
+    def test_group_sector_limit_overrides_sector_limit(self):
+        group_sector = GroupSector.objects.create(
+            name="Group", project=self.project, rooms_limit=1
+        )
+        SectorGroupSector.objects.create(
+            sector_group=group_sector, sector=self.sector
+        )
+        Room.objects.create(queue=self.queue, user=self.agent, is_active=True)
+
+        result = self.usecase.execute(self.agent)
+
+        self.assertFalse(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 1)
+        self.assertEqual(result.limit, 1)
+
+    def test_rooms_assigned_to_other_agents_do_not_count(self):
+        other_agent = User.objects.create(email="other@example.com")
+        for _ in range(3):
+            Room.objects.create(
+                queue=self.queue, user=other_agent, is_active=True
+            )
+
+        result = self.usecase.execute(self.agent)
+
+        self.assertTrue(result.can_receive)
+        self.assertEqual(result.active_rooms_count, 0)

--- a/chats/apps/queues/tests/test_services.py
+++ b/chats/apps/queues/tests/test_services.py
@@ -445,9 +445,10 @@ class CapacityRecheckRaceConditionTestCase(TestCase):
             role=QueueAuthorization.ROLE_AGENT,
         )
 
+    @patch("chats.apps.queues.services.is_feature_active_for_attributes", return_value=True)
     @patch("chats.apps.queues.services.logger")
     def test_room_not_assigned_when_agent_reaches_limit_during_routing(
-        self, mock_logger
+        self, mock_logger, mock_flag
     ):
         """
         Race condition: agent is picked by get_available_agent() but other
@@ -478,8 +479,9 @@ class CapacityRecheckRaceConditionTestCase(TestCase):
         room.refresh_from_db()
         self.assertIsNone(room.user)
 
+    @patch("chats.apps.queues.services.is_feature_active_for_attributes", return_value=True)
     @patch("chats.apps.queues.services.logger")
-    def test_room_not_assigned_when_agent_already_above_limit(self, mock_logger):
+    def test_room_not_assigned_when_agent_already_above_limit(self, mock_logger, mock_flag):
         """
         Agent that somehow is already above the sector limit must not
         receive another room (this is the exact scenario observed in prod).

--- a/chats/apps/queues/tests/test_services.py
+++ b/chats/apps/queues/tests/test_services.py
@@ -407,3 +407,108 @@ class RaceConditionTestCase(TestCase):
             self.agent.email,
             room.uuid,
         )
+
+
+class CapacityRecheckRaceConditionTestCase(TestCase):
+    """
+    Tests for capacity recheck protection in route_rooms.
+
+    Validates that when an agent reaches or exceeds the sector rooms limit
+    between get_available_agent() and room.save(), the room is NOT assigned.
+    """
+
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project Capacity",
+            room_routing_type=RoomRoutingType.QUEUE_PRIORITY,
+        )
+        self.sector = Sector.objects.create(
+            name="Test Sector",
+            project=self.project,
+            rooms_limit=2,
+            work_start=time(hour=0, minute=0),
+            work_end=time(hour=23, minute=59),
+        )
+        self.queue = Queue.objects.create(name="Test Queue", sector=self.sector)
+
+        self.agent = User.objects.create(email="capacity@example.com")
+        permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+            last_seen=timezone.now(),
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=permission,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+    @patch("chats.apps.queues.services.logger")
+    def test_room_not_assigned_when_agent_reaches_limit_during_routing(
+        self, mock_logger
+    ):
+        """
+        Race condition: agent is picked by get_available_agent() but other
+        concurrent requests bring his active rooms up to the limit
+        before route_rooms calls room.save().
+        """
+        room = Room.objects.create(queue=self.queue, user=None)
+        service = QueueRouterService(self.queue)
+
+        original_get_available_agent = self.queue.get_available_agent
+
+        def get_available_agent_and_fill_up():
+            agent = original_get_available_agent()
+            if agent:
+                for _ in range(self.sector.rooms_limit):
+                    Room.objects.create(
+                        queue=self.queue, user=agent, is_active=True
+                    )
+            return agent
+
+        with patch.object(
+            self.queue,
+            "get_available_agent",
+            side_effect=get_available_agent_and_fill_up,
+        ):
+            service.route_rooms()
+
+        room.refresh_from_db()
+        self.assertIsNone(room.user)
+
+    @patch("chats.apps.queues.services.logger")
+    def test_room_not_assigned_when_agent_already_above_limit(self, mock_logger):
+        """
+        Agent that somehow is already above the sector limit must not
+        receive another room (this is the exact scenario observed in prod).
+        """
+        for _ in range(self.sector.rooms_limit + 2):
+            Room.objects.create(
+                queue=self.queue, user=self.agent, is_active=True
+            )
+
+        room = Room.objects.create(queue=self.queue, user=None)
+        service = QueueRouterService(self.queue)
+
+        with patch.object(
+            self.queue, "get_available_agent", return_value=self.agent
+        ):
+            service.route_rooms()
+
+        room.refresh_from_db()
+        self.assertIsNone(room.user)
+
+    @patch("chats.apps.queues.services.logger")
+    def test_room_assigned_when_agent_stays_below_limit(self, mock_logger):
+        """
+        Happy path: agent remains below limit during routing, room is assigned.
+        """
+        room = Room.objects.create(queue=self.queue, user=None)
+        service = QueueRouterService(self.queue)
+
+        service.route_rooms()
+
+        room.refresh_from_db()
+        self.assertEqual(room.user, self.agent)

--- a/chats/apps/queues/usecases/can_agent_receive_room.py
+++ b/chats/apps/queues/usecases/can_agent_receive_room.py
@@ -1,0 +1,70 @@
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from chats.apps.accounts.models import User
+    from chats.apps.queues.models import Queue
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AgentCapacityResult:
+    can_receive: bool
+    active_rooms_count: int
+    limit: int
+
+    @property
+    def reason(self) -> Optional[str]:
+        if self.can_receive:
+            return None
+        return (
+            f"agent has {self.active_rooms_count} active rooms in the sector, "
+            f"which reached the limit of {self.limit}"
+        )
+
+
+class CanAgentReceiveRoomUseCase:
+    """
+    Last-moment verification, performed right before assigning a room to an
+    agent, that the agent is still under the sector's rooms limit.
+
+    Closes a race condition between Queue.available_agents / get_available_agent()
+    and Room.save() that actually materializes the assignment, where concurrent
+    assignments could push an agent above the sector's rooms limit.
+
+    Counting semantics mirror Queue.available_agents:
+    - Scope: active rooms in the same sector as the queue.
+    - Limit: queue.limit (GroupSector.rooms_limit or Sector.rooms_limit).
+    """
+
+    def __init__(self, queue: "Queue"):
+        self.queue = queue
+
+    def execute(self, agent: "User") -> AgentCapacityResult:
+        from chats.apps.rooms.models import Room
+
+        limit = self.queue.limit
+
+        active_rooms_count = Room.objects.filter(
+            user=agent,
+            queue__sector=self.queue.sector,
+            is_active=True,
+        ).count()
+
+        result = AgentCapacityResult(
+            can_receive=active_rooms_count < limit,
+            active_rooms_count=active_rooms_count,
+            limit=limit,
+        )
+
+        if not result.can_receive:
+            logger.info(
+                "Agent %s blocked by capacity recheck on queue %s: %s",
+                agent.email,
+                self.queue.uuid,
+                result.reason,
+            )
+
+        return result

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -456,6 +456,55 @@ class RoomsQueuePriorityExternalTests(APITestCase):
             self.queue.uuid,
         )
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
+    @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
+    def test_create_room_with_queue_priority_when_agent_fails_capacity_recheck(
+        self,
+        mock_get_room,
+        mock_start_queue_priority_routing,
+    ):
+        """
+        Queue is empty and there is an ONLINE agent, but the agent is already
+        at/above the sector rooms limit. The last-moment capacity recheck must
+        block the assignment: the room stays unassigned and routing is
+        triggered to retry later.
+        """
+        mock_get_room.return_value = None
+        mock_start_queue_priority_routing.return_value = None
+
+        user = User.objects.create(email="overloaded@email.com")
+        permission = self.project.permissions.create(user=user, status="ONLINE")
+        self.queue.authorizations.create(permission=permission, role=1)
+
+        # sector.rooms_limit == 1 (from setUp); pre-populate above the limit
+        for i in range(2):
+            Room.objects.create(
+                queue=self.queue,
+                contact=Contact.objects.create(external_id=f"overloaded-{i}"),
+                user=user,
+                is_active=True,
+            )
+
+        # Force get_available_agent to return the overloaded agent even though
+        # available_agents' annotate filter would normally exclude him. This
+        # simulates a race between the annotate query and Room.save().
+        with patch.object(Queue, "get_available_agent", return_value=user):
+            data = {
+                "queue_uuid": str(self.queue.uuid),
+                "contact": {
+                    "external_id": "new-contact-001",
+                    "name": "kallil",
+                    "email": "kallil@email.com",
+                    "phone": "+5511985543332",
+                    "custom_fields": {},
+                },
+            }
+            response = self.create_room(data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIsNone(response.data.get("user"))
+        mock_start_queue_priority_routing.assert_called_once_with(self.queue)
+
 
 class RoomsFlowStartExternalTests(APITestCase):
     fixtures = ["chats/fixtures/fixture_app.json"]

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -456,12 +456,14 @@ class RoomsQueuePriorityExternalTests(APITestCase):
             self.queue.uuid,
         )
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=True)
     @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_queue_priority_when_agent_fails_capacity_recheck(
         self,
         mock_get_room,
         mock_start_queue_priority_routing,
+        mock_flag,
     ):
         """
         Queue is empty and there is an ONLINE agent, but the agent is already

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -761,6 +761,12 @@ USE_FLOWS_MEDIA_URL_FEATURE_FLAG_KEY = env.str(
 
 FLOWS_BASE_URL = env.str("FLOWS_BASE_URL", default="https://flows.weni.ai")
 
+# Agent Capacity Recheck
+AGENT_CAPACITY_RECHECK_FEATURE_FLAG_KEY = env.str(
+    "AGENT_CAPACITY_RECHECK_FEATURE_FLAG_KEY",
+    default="weniChatsAgentCapacityRecheck",
+)
+
 # Improve User Message
 IMPROVE_USER_MESSAGE_FEATURE_FLAG_KEY = env.str(
     "IMPROVE_USER_MESSAGE_FEATURE_FLAG_KEY",


### PR DESCRIPTION
### **What**
Adds a last-moment capacity recheck before assigning a room to an agent, and wraps it behind a feature flag (weniChatsAgentCapacityRecheck). The recheck queries the agent's current active room count in the sector immediately before room.save(), blocking the assignment if the agent is at or above the sector limit. When the flag is off, the routing behavior is identical to before.

### **Why**
A race condition between Queue.available_agents (which uses an annotated queryset snapshot) and Room.save() was allowing concurrent assignments to push an agent above Sector.rooms_limit. By the time the assignment was persisted, the agent's actual room count was already at or above the limit. The feature flag allows the fix to be enabled per project in production without risk, keeping the original behavior as the default until validated.