### PR TITLE
refactor: remove time sleep based tests

### DIFF
--- a/chats/apps/api/v1/tests/test_dashboard.py
+++ b/chats/apps/api/v1/tests/test_dashboard.py
@@ -1,8 +1,9 @@
-import time
 import uuid
+from datetime import datetime, timedelta, timezone as dt_timezone
 from unittest.mock import patch
 
 from django.urls import reverse
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
@@ -69,109 +70,123 @@ class DashboardTests(APITestCase):
         """
         Verify if the interaction_time of a room metric its calculated correctly.
         """
-        url = reverse("external_rooms-list")
-        client = self.client
-        client.credentials(
-            HTTP_AUTHORIZATION="Bearer f3ce543e-d77e-4508-9140-15c95752a380"
-        )
+        initial = datetime(2024, 1, 1, 12, 0, 0, tzinfo=dt_timezone.utc)
+        with freeze_time(initial) as frozen:
+            url = reverse("external_rooms-list")
+            client = self.client
+            client.credentials(
+                HTTP_AUTHORIZATION="Bearer f3ce543e-d77e-4508-9140-15c95752a380"
+            )
 
-        data = {
-            "queue_uuid": "f341417b-5143-4469-a99d-f141a0676bd4",
-            "contact": {
-                "external_id": str(uuid.uuid4()),
-                "name": "Test Contact",
-                "email": "test@example.com",
-                "phone": "+1234567890",
-                "custom_fields": {},
-            },
-        }
+            data = {
+                "queue_uuid": "f341417b-5143-4469-a99d-f141a0676bd4",
+                "contact": {
+                    "external_id": str(uuid.uuid4()),
+                    "name": "Test Contact",
+                    "email": "test@example.com",
+                    "phone": "+1234567890",
+                    "custom_fields": {},
+                },
+            }
 
-        response = client.post(url, data=data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            response = client.post(url, data=data, format="json")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        room_created = Room.objects.get(uuid=response.data["uuid"])
-        room_created.user = self.manager_user
-        room_created.save()
+            room_created = Room.objects.get(uuid=response.data["uuid"])
+            room_created.user = self.manager_user
+            room_created.save()
 
-        time.sleep(3)
+            frozen.move_to(initial + timedelta(seconds=3))
 
-        url_close = f"/v1/room/{room_created.uuid}/close/"
-        close_client = self.client
-        close_client.credentials(HTTP_AUTHORIZATION="Token " + self.login_token.key)
-        data_close = {"tags": []}
-        client.patch(url_close, data=data_close, format="json")
+            url_close = f"/v1/room/{room_created.uuid}/close/"
+            close_client = self.client
+            close_client.credentials(
+                HTTP_AUTHORIZATION="Token " + self.login_token.key
+            )
+            data_close = {"tags": []}
+            client.patch(url_close, data=data_close, format="json")
 
-        room_closed = Room.objects.get(queue_id=data["queue_uuid"])
-        metric = RoomMetrics.objects.get(room=room_closed)
+            room_closed = Room.objects.get(queue_id=data["queue_uuid"])
+            metric = RoomMetrics.objects.get(room=room_closed)
 
-        self.assertEqual(metric.interaction_time, 3)
+            self.assertEqual(metric.interaction_time, 3)
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
     def test_message_response_time_metric_calc(self, mock_is_attending):
         """
         Verify if the message_response_time of a room metric its calculated correctly.
         """
-        url = reverse("external_rooms-list")
-        client = self.client
-        client.credentials(
-            HTTP_AUTHORIZATION="Bearer f3ce543e-d77e-4508-9140-15c95752a380"
-        )
+        initial = datetime(2024, 1, 1, 12, 0, 0, tzinfo=dt_timezone.utc)
+        with freeze_time(initial) as frozen:
+            url = reverse("external_rooms-list")
+            client = self.client
+            client.credentials(
+                HTTP_AUTHORIZATION="Bearer f3ce543e-d77e-4508-9140-15c95752a380"
+            )
 
-        data = {
-            "queue_uuid": "f341417b-5143-4469-a99d-f141a0676bd4",
-            "contact": {
-                "external_id": str(uuid.uuid4()),
-                "name": "Test Message Response",
-                "email": "test@example.com",
-                "phone": "+1234567890",
-                "custom_fields": {},
-            },
-        }
+            data = {
+                "queue_uuid": "f341417b-5143-4469-a99d-f141a0676bd4",
+                "contact": {
+                    "external_id": str(uuid.uuid4()),
+                    "name": "Test Message Response",
+                    "email": "test@example.com",
+                    "phone": "+1234567890",
+                    "custom_fields": {},
+                },
+            }
 
-        response = client.post(url, data=data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            response = client.post(url, data=data, format="json")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        room_created = Room.objects.get(uuid=response.data["uuid"])
-        room_created.user = self.manager_user
-        room_created.save()
+            room_created = Room.objects.get(uuid=response.data["uuid"])
+            room_created.user = self.manager_user
+            room_created.save()
 
-        msg_contact_client = self.client
-        msg_contact_client.credentials(
-            HTTP_AUTHORIZATION="Bearer f3ce543e-d77e-4508-9140-15c95752a380"
-        )
-        url_contact_message = "/v1/external/msgs/"
+            msg_contact_client = self.client
+            msg_contact_client.credentials(
+                HTTP_AUTHORIZATION="Bearer f3ce543e-d77e-4508-9140-15c95752a380"
+            )
+            url_contact_message = "/v1/external/msgs/"
 
-        message_data = {
-            "room": str(room_created.uuid),
-            "text": "teste criação",
-            "direction": "incoming",
-            "attachments": [],
-        }
-        msg_contact_client.post(url_contact_message, data=message_data, format="json")
+            message_data = {
+                "room": str(room_created.uuid),
+                "text": "teste criação",
+                "direction": "incoming",
+                "attachments": [],
+            }
+            msg_contact_client.post(
+                url_contact_message, data=message_data, format="json"
+            )
 
-        time.sleep(3)
+            frozen.move_to(initial + timedelta(seconds=3))
 
-        msg_user_client = self.client
-        msg_user_client.credentials(HTTP_AUTHORIZATION="Token " + self.login_token.key)
-        url_user_message = "/v1/msg/"
+            msg_user_client = self.client
+            msg_user_client.credentials(
+                HTTP_AUTHORIZATION="Token " + self.login_token.key
+            )
+            url_user_message = "/v1/msg/"
 
-        message_user_data = {
-            "room": str(room_created.pk),
-            "user_email": str(self.manager_user),
-            "text": "teste criação resposta",
-        }
-        msg_user_client.post(url_user_message, data=message_user_data, format="json")
+            message_user_data = {
+                "room": str(room_created.pk),
+                "user_email": str(self.manager_user),
+                "text": "teste criação resposta",
+            }
+            msg_user_client.post(
+                url_user_message, data=message_user_data, format="json"
+            )
 
-        url_close = f"/v1/room/{room_created.uuid}/close/"
-        close_client = self.client
-        close_client.credentials(HTTP_AUTHORIZATION="Token " + self.login_token.key)
-        data_close = {"tags": []}
-        client.patch(url_close, data=data_close, format="json")
+            url_close = f"/v1/room/{room_created.uuid}/close/"
+            close_client = self.client
+            close_client.credentials(
+                HTTP_AUTHORIZATION="Token " + self.login_token.key
+            )
+            data_close = {"tags": []}
+            client.patch(url_close, data=data_close, format="json")
 
-        room_closed = Room.objects.get(queue_id=data["queue_uuid"])
-        metric = RoomMetrics.objects.get(room=room_closed)
+            room_closed = Room.objects.get(queue_id=data["queue_uuid"])
+            metric = RoomMetrics.objects.get(room=room_closed)
 
-        self.assertEqual(metric.message_response_time, 3)
+            self.assertEqual(metric.message_response_time, 3)
 
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
     def test_waiting_time_metric_calc(self, mock_is_attending):

--- a/chats/apps/dashboard/tests/test_utils.py
+++ b/chats/apps/dashboard/tests/test_utils.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
-import time
 
 from django.test import TestCase
+from freezegun import freeze_time
 
 from chats.apps.accounts.models import User
 from chats.apps.contacts.models import Contact
@@ -189,58 +189,46 @@ class CalculateWaitingTimeTests(TestCase):
         )
 
     def test_last_queue_waiting_time_when_user_is_assigned(self):
+        base = self.room.added_to_queue_at
+
         self.assertEqual(
-            self.room.added_to_queue_at.strftime("%Y-%m-%d %H:%M:%S"),
+            base.strftime("%Y-%m-%d %H:%M:%S"),
             self.room.created_on.strftime("%Y-%m-%d %H:%M:%S"),
         )
 
-        time.sleep(1)
-        # Room spent 1 second in the queue
+        with freeze_time(base + timedelta(seconds=1)) as frozen:
+            self.room.user = self.user
+            self.room.save()
+            self.room.refresh_from_db()
 
-        self.room.user = self.user
-        self.room.save()
+            self.assertEqual(
+                self.room.added_to_queue_at.strftime("%Y-%m-%d %H:%M:%S"),
+                self.room.created_on.strftime("%Y-%m-%d %H:%M:%S"),
+            )
 
-        self.room.refresh_from_db()
+            waiting_time = calculate_last_queue_waiting_time(self.room)
+            self.assertEqual(waiting_time, 1)
 
-        self.assertEqual(
-            self.room.added_to_queue_at.strftime("%Y-%m-%d %H:%M:%S"),
-            self.room.created_on.strftime("%Y-%m-%d %H:%M:%S"),
-        )
+            self.room.user = None
+            self.room.save()
+            self.room.refresh_from_db()
 
-        waiting_time = calculate_last_queue_waiting_time(self.room)
+            frozen.move_to(base + timedelta(seconds=3))
 
-        # Assert that the waiting time is 1 second
-        self.assertEqual(waiting_time, 1)
+            waiting_time = calculate_last_queue_waiting_time(self.room)
+            self.assertEqual(waiting_time, 2)
 
-        self.room.user = None
-        self.room.save()
+            frozen.move_to(base + timedelta(seconds=4))
 
-        time.sleep(2)
-        # Room spent 2 seconds in the queue
+            self.room.user = self.user
+            self.room.save()
+            self.room.refresh_from_db()
 
-        self.room.refresh_from_db()
-
-        waiting_time = calculate_last_queue_waiting_time(self.room)
-
-        # Assert that the waiting time is 2 seconds
-        self.assertEqual(waiting_time, 2)
-
-        # One more second before user is assigned
-        time.sleep(1)
-
-        self.room.user = self.user
-        self.room.save()
-
-        self.room.refresh_from_db()
-
-        waiting_time = calculate_last_queue_waiting_time(self.room)
-
-        # Assert that the waiting time is 3 seconds
-        self.assertEqual(waiting_time, 3)
+            waiting_time = calculate_last_queue_waiting_time(self.room)
+            self.assertEqual(waiting_time, 3)
 
     def test_last_queue_waiting_time_when_room_is_ended_and_user_is_not_assigned(self):
-        # Room spent 1 second in the queue
-        time.sleep(1)
-        waiting_time = calculate_last_queue_waiting_time(self.room)
-
+        end_time = self.room.added_to_queue_at + timedelta(seconds=1)
+        with freeze_time(end_time):
+            waiting_time = calculate_last_queue_waiting_time(self.room)
         self.assertEqual(waiting_time, 1)

--- a/chats/apps/rooms/tests/test_models.py
+++ b/chats/apps/rooms/tests/test_models.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 from unittest.mock import patch
 
@@ -8,6 +7,7 @@ from django.db import IntegrityError
 from django.test import TransactionTestCase, override_settings
 from django.utils import timezone
 from django.utils.timezone import timedelta
+from freezegun import freeze_time
 from rest_framework.test import APITestCase
 
 from chats.apps.accounts.models import User
@@ -217,35 +217,35 @@ class TestRoomModel(TransactionTestCase):
 
     def test_add_to_queue_at_field(self):
         user = User.objects.create(email="a@user.com")
-        room = Room.objects.create(queue=self.queue)
+        base = timezone.now()
 
-        added_to_queue_at = room.added_to_queue_at
+        with freeze_time(base) as frozen:
+            room = Room.objects.create(queue=self.queue)
+            added_to_queue_at = room.added_to_queue_at
 
-        self.assertEqual(
-            added_to_queue_at.strftime("%Y-%m-%d %H:%M:%S"),
-            room.created_on.strftime("%Y-%m-%d %H:%M:%S"),
-        )
+            self.assertEqual(
+                added_to_queue_at.strftime("%Y-%m-%d %H:%M:%S"),
+                room.created_on.strftime("%Y-%m-%d %H:%M:%S"),
+            )
 
-        time.sleep(1)
+            frozen.move_to(base + timedelta(seconds=1))
 
-        room.user = user
-        room.save()
+            room.user = user
+            room.save()
+            room.refresh_from_db()
 
-        room.refresh_from_db()
+            # added_to_queue_at should not change
+            self.assertEqual(room.added_to_queue_at, added_to_queue_at)
 
-        # added_to_queue_at should not change
-        self.assertEqual(room.added_to_queue_at, added_to_queue_at)
+            frozen.move_to(base + timedelta(seconds=2))
 
-        time.sleep(1)
+            room.user = None
+            room.save()
+            room.refresh_from_db()
 
-        room.user = None
-        room.save()
-
-        room.refresh_from_db()
-
-        # added_to_queue_at should change when user is removed
-        # as, in practice, the room is added to the queue
-        self.assertNotEqual(room.added_to_queue_at, added_to_queue_at)
+            # added_to_queue_at should change when user is removed
+            # as, in practice, the room is added to the queue
+            self.assertNotEqual(room.added_to_queue_at, added_to_queue_at)
 
     def test_add_transfer_to_history(self):
         user = User.objects.create(email="a@user.com")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1474,6 +1474,20 @@ pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+description = "Let your Python tests travel through time"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2"},
+    {file = "freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "frozenlist"
 version = "1.5.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -4646,4 +4660,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f2be56796c39ec2ce982c80b81ad9042ca55eea633b7d7ac88cc1715f53b283b"
+content-hash = "d6b8ee484e4bcefd479d7df4af98ba8f0613de73f10b1fb69cc70621a6b76dea"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4660,4 +4660,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d6b8ee484e4bcefd479d7df4af98ba8f0613de73f10b1fb69cc70621a6b76dea"
+content-hash = "246cf42082e95d0e170ba48f5ad771171ddb81821f54b4933d3faf68e8eea5fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ pyjwt = "2.9.0"
 weni-commons = "^1.1.2"
 
 [tool.poetry.dev-dependencies]
+freezegun = "^1.5.5"
 pytest = "^5.2"
 flake8 = "^4.0.1"
 coverage = "^7.2.2"


### PR DESCRIPTION
### What
- Added [`freezegun`](https://pypi.org/project/freezegun/) as a dev dependency to replace all `time.sleep()` calls in tests with deterministic time manipulation.
- Refactored tests in `test_dashboard.py`, `test_utils.py`, and `test_models.py` to use `freeze_time` and `frozen.move_to()` instead of `time.sleep()` for simulating elapsed time.
- Removed the `import time` statements from the affected test files.

### Why
Using `time.sleep()` in tests introduces real wall-clock delays, making the test suite slower and prone to flaky results due to timing inconsistencies. By using `freezegun`, time is frozen and advanced deterministically, which makes the tests faster, more reliable, and fully reproducible.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Test as Test Case
    participant FG as freezegun
    participant Clock as System Clock
    participant App as Application Code

    Test->>FG: freeze_time(initial_time)
    FG->>Clock: Override to initial_time
    Test->>App: Create room / Send message
    App->>Clock: Read current time
    Clock-->>App: initial_time
    App-->>Test: Room created at initial_time

    Test->>FG: frozen.move_to(initial_time + 3s)
    FG->>Clock: Advance to initial_time + 3s
    Test->>App: Close room / Send reply
    App->>Clock: Read current time
    Clock-->>App: initial_time + 3s
    App-->>Test: Metric calculated (delta = 3s)

    Test->>Test: assertEqual(metric, 3) ✓
    FG->>Clock: Restore real clock
```