### PR TITLE
fix: add agent to discussion response errors

### DIFF
--- a/chats/apps/discussions/exceptions.py
+++ b/chats/apps/discussions/exceptions.py
@@ -1,2 +1,6 @@
 class DiscussionValidationException(Exception):
     pass
+
+
+class UserProjectPermissionNotFound(Exception):
+    pass

--- a/chats/apps/discussions/models/discussion.py
+++ b/chats/apps/discussions/models/discussion.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from chats.apps.discussions.exceptions import UserProjectPermissionNotFound
 from chats.core.models import BaseModel, BaseSoftDeleteModel, WebSocketsNotifiableMixin
 
 
@@ -136,6 +137,16 @@ class Discussion(BaseSoftDeleteModel, BaseModel, WebSocketsNotifiableMixin):
     def create_discussion_user(self, from_user, to_user, role=None):
         from_permission = self.get_permission(user=from_user)
         to_permission = self.get_permission(user=to_user)
+
+        for user, permission in [
+            (from_user, from_permission),
+            (to_user, to_permission),
+        ]:
+            if not permission:
+                raise UserProjectPermissionNotFound(
+                    f"User {user.email} not found in the project"
+                )
+
         discussion_user = None
 
         if (from_permission and to_permission) and self.can_add_user(from_permission):

--- a/chats/apps/discussions/serializers/discussions.py
+++ b/chats/apps/discussions/serializers/discussions.py
@@ -65,3 +65,7 @@ class DiscussionDetailSerializer(serializers.ModelSerializer):
             "contact",
             "created_on",
         ]
+
+
+class AddAgentToDiscussionSerializer(serializers.Serializer):
+    user_email = serializers.EmailField(required=True, allow_blank=False)

--- a/chats/apps/discussions/tests/test_add_user_usecase.py
+++ b/chats/apps/discussions/tests/test_add_user_usecase.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from rest_framework.exceptions import ValidationError
@@ -74,9 +74,7 @@ class AddUserToDiscussionUseCaseTests(TestCase):
 
     @override_settings(DISCUSSION_AGENTS_LIMIT=10)
     def test_execute_creates_feedback_message(self, _mock_ws):
-        self.usecase.execute(
-            self.discussion, self.agent_user.email, self.creator_user
-        )
+        self.usecase.execute(self.discussion, self.agent_user.email, self.creator_user)
 
         feedback_msg = self.discussion.messages.filter(user__isnull=True).first()
         self.assertIsNotNone(feedback_msg)
@@ -113,20 +111,14 @@ class AddUserToDiscussionUseCaseTests(TestCase):
 
     @override_settings(DISCUSSION_AGENTS_LIMIT=10)
     def test_execute_raises_when_from_user_has_no_project_permission(self, _mock_ws):
-        from_user = User.objects.create(
-            email="noperm@test.com", first_name="NoPerm"
-        )
+        from_user = User.objects.create(email="noperm@test.com", first_name="NoPerm")
 
         with self.assertRaises(ValidationError):
-            self.usecase.execute(
-                self.discussion, self.agent_user.email, from_user
-            )
+            self.usecase.execute(self.discussion, self.agent_user.email, from_user)
 
     @override_settings(DISCUSSION_AGENTS_LIMIT=10)
     def test_execute_does_not_duplicate_discussion_user(self, _mock_ws):
-        self.usecase.execute(
-            self.discussion, self.agent_user.email, self.creator_user
-        )
+        self.usecase.execute(self.discussion, self.agent_user.email, self.creator_user)
 
         self.assertEqual(
             DiscussionUser.objects.filter(

--- a/chats/apps/discussions/tests/test_add_user_usecase.py
+++ b/chats/apps/discussions/tests/test_add_user_usecase.py
@@ -93,7 +93,10 @@ class AddUserToDiscussionUseCaseTests(TestCase):
                 self.discussion, self.agent_user.email, self.creator_user
             )
 
-        self.assertIn("already added", str(ctx.exception.detail))
+        self.assertEqual(
+            ctx.exception.detail["error"][0],
+            f"User {self.agent_user.email} is already added to this discussion",
+        )
 
     @override_settings(DISCUSSION_AGENTS_LIMIT=10)
     def test_execute_raises_when_user_email_not_found(self, _mock_ws):

--- a/chats/apps/discussions/tests/test_add_user_usecase.py
+++ b/chats/apps/discussions/tests/test_add_user_usecase.py
@@ -1,0 +1,144 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+from rest_framework.exceptions import ValidationError
+
+from chats.apps.accounts.models import User
+from chats.apps.discussions.models import Discussion, DiscussionUser
+from chats.apps.discussions.usecases.add_user_to_discussion import (
+    AddUserToDiscussionUseCase,
+)
+from chats.apps.projects.models import Project, ProjectPermission
+from chats.apps.rooms.models import Room
+
+
+@patch("chats.utils.websockets.send_channels_group")
+class AddUserToDiscussionUseCaseTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project", timezone="UTC")
+        self.sector = self.project.sectors.create(
+            name="Test Sector",
+            rooms_limit=5,
+            work_start="08:00",
+            work_end="18:00",
+        )
+        self.queue = self.sector.queues.create(name="Test Queue")
+
+        self.creator_user = User.objects.create(
+            email="creator@test.com", first_name="Creator", last_name="User"
+        )
+        self.agent_user = User.objects.create(
+            email="agent@test.com", first_name="Agent", last_name="Smith"
+        )
+        self.outside_user = User.objects.create(
+            email="outside@test.com", first_name="Outside", last_name="Person"
+        )
+
+        self.creator_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.creator_user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        self.agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent_user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+
+        self.room = Room.objects.create(
+            queue=self.queue, project_uuid=str(self.project.pk)
+        )
+        self.discussion = Discussion.objects.create(
+            subject="Test Discussion",
+            created_by=self.creator_user,
+            room=self.room,
+            queue=self.queue,
+            is_queued=True,
+        )
+
+        self.usecase = AddUserToDiscussionUseCase()
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_execute_adds_user_and_returns_data(self, _mock_ws):
+        result = self.usecase.execute(
+            self.discussion, self.agent_user.email, self.creator_user
+        )
+
+        self.assertEqual(result["first_name"], "Agent")
+        self.assertEqual(result["last_name"], "Smith")
+        self.assertTrue(
+            DiscussionUser.objects.filter(
+                discussion=self.discussion, permission=self.agent_perm
+            ).exists()
+        )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_execute_creates_feedback_message(self, _mock_ws):
+        self.usecase.execute(
+            self.discussion, self.agent_user.email, self.creator_user
+        )
+
+        feedback_msg = self.discussion.messages.filter(user__isnull=True).first()
+        self.assertIsNotNone(feedback_msg)
+        self.assertIn("Agent", feedback_msg.text)
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_execute_raises_when_user_already_added(self, _mock_ws):
+        DiscussionUser.objects.create(
+            discussion=self.discussion,
+            permission=self.agent_perm,
+            role=DiscussionUser.Role.PARTICIPANT,
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            self.usecase.execute(
+                self.discussion, self.agent_user.email, self.creator_user
+            )
+
+        self.assertIn("already added", str(ctx.exception.detail))
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_execute_raises_when_user_email_not_found(self, _mock_ws):
+        with self.assertRaises(User.DoesNotExist):
+            self.usecase.execute(
+                self.discussion, "nonexistent@test.com", self.creator_user
+            )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_execute_raises_when_user_has_no_project_permission(self, _mock_ws):
+        with self.assertRaises(ValidationError):
+            self.usecase.execute(
+                self.discussion, self.outside_user.email, self.creator_user
+            )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_execute_raises_when_from_user_has_no_project_permission(self, _mock_ws):
+        from_user = User.objects.create(
+            email="noperm@test.com", first_name="NoPerm"
+        )
+
+        with self.assertRaises(ValidationError):
+            self.usecase.execute(
+                self.discussion, self.agent_user.email, from_user
+            )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_execute_does_not_duplicate_discussion_user(self, _mock_ws):
+        self.usecase.execute(
+            self.discussion, self.agent_user.email, self.creator_user
+        )
+
+        self.assertEqual(
+            DiscussionUser.objects.filter(
+                discussion=self.discussion, permission=self.agent_perm
+            ).count(),
+            1,
+        )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_execute_returns_role_in_response(self, _mock_ws):
+        result = self.usecase.execute(
+            self.discussion, self.agent_user.email, self.creator_user
+        )
+
+        self.assertIn("role", result)

--- a/chats/apps/discussions/tests/test_add_user_usecase.py
+++ b/chats/apps/discussions/tests/test_add_user_usecase.py
@@ -94,7 +94,7 @@ class AddUserToDiscussionUseCaseTests(TestCase):
             )
 
         self.assertEqual(
-            ctx.exception.detail["error"][0],
+            ctx.exception.detail["error"],
             f"User {self.agent_user.email} is already added to this discussion",
         )
 

--- a/chats/apps/discussions/tests/test_discussion_users_actions.py
+++ b/chats/apps/discussions/tests/test_discussion_users_actions.py
@@ -188,7 +188,10 @@ class CreateDiscussionUserViewActionTests(APITestCase):
         response = self._add_agent(self.admin_token, self.agent_user.email)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("already added", response.json()[0])
+        self.assertEqual(
+            response.json()["error"][0],
+            f"User {self.agent_user.email} is already added to this discussion",
+        )
         self.assertEqual(
             DiscussionUser.objects.filter(
                 discussion=self.discussion, permission=self.agent_perm

--- a/chats/apps/discussions/tests/test_discussion_users_actions.py
+++ b/chats/apps/discussions/tests/test_discussion_users_actions.py
@@ -1,129 +1,316 @@
+from unittest.mock import patch
+
+from django.test import override_settings
 from django.urls import reverse
-from parameterized import parameterized
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
+from chats.apps.accounts.models import User
+from chats.apps.discussions.models import Discussion, DiscussionUser
+from chats.apps.projects.models import Project, ProjectPermission
+from chats.apps.rooms.models import Room
 
+
+@patch("chats.utils.websockets.send_channels_group")
 class CreateDiscussionUserViewActionTests(APITestCase):
-    # ("Scenario description", room, queue, subject, initial_message, user_token, expected_response_status)
-    fixtures = [
-        "chats/fixtures/fixture_app.json",
-        "chats/fixtures/fixture_discussion.json",
-    ]
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project", timezone="UTC")
+        self.sector = self.project.sectors.create(
+            name="Test Sector",
+            rooms_limit=5,
+            work_start="08:00",
+            work_end="18:00",
+        )
+        self.queue = self.sector.queues.create(name="Test Queue")
 
-    parameters = [
-        # Success parameters
-        (
-            "Creator can add users to discussion",
-            "3c2d1694-8db9-4f09-976b-e263f9d79c99",
-            "agentqueue@chats.weni.ai",
-            "d7fddba0b1dfaad72aa9e21876cbc93caa9ce3fa",
-            status.HTTP_201_CREATED,
-        ),
-        (
-            "Queue user can add itself to the discussion",
-            "3c2d1694-8db9-4f09-976b-e263f9d79c99",
-            "foobar@chats.weni.ai",
-            "a0358e20c8755568189d3a7e688ac3ec771317e2",
-            status.HTTP_201_CREATED,
-        ),
-        (
-            "Admin can add itself to the discussion",
-            "3c2d1694-8db9-4f09-976b-e263f9d79c99",
-            "agentqueue@chats.weni.ai",
-            "4215e6d6666e54f7db9f98100533aa68909fd855",
-            status.HTTP_201_CREATED,
-        ),
-        (
-            "Queue user cannot add other users to the discussion",
-            "3c2d1694-8db9-4f09-976b-e263f9d79c99",
-            "agentqueue@chats.weni.ai",
-            "a0358e20c8755568189d3a7e688ac3ec771317e2",
-            status.HTTP_400_BAD_REQUEST,
-        ),
-        (
-            "Added users cannot add other users to the discussion",
-            "36584c70-aaf9-4f5c-b0c3-0547bb23879d",
-            "internal@weni.ai",
-            "a0358e20c8755568189d3a7e688ac3ec771317e2",
-            status.HTTP_400_BAD_REQUEST,
-        ),
-        (
-            "Cannot add a user that is already added to the discussion",
-            "36584c70-aaf9-4f5c-b0c3-0547bb23879d",
-            "foobar@chats.weni.ai",
-            "a0358e20c8755568189d3a7e688ac3ec771317e2",
-            status.HTTP_400_BAD_REQUEST,
-        ),
-    ]
+        self.admin_user = User.objects.create(
+            email="admin@test.com", first_name="Admin"
+        )
+        self.creator_user = User.objects.create(
+            email="creator@test.com", first_name="Creator"
+        )
+        self.agent_user = User.objects.create(
+            email="agent@test.com", first_name="Agent"
+        )
+        self.other_agent = User.objects.create(
+            email="other@test.com", first_name="Other"
+        )
+        self.outside_user = User.objects.create(
+            email="outside@test.com", first_name="Outside"
+        )
 
-    def _create_discussion_user(self, token, discussion, body):
-        url = reverse("discussion-detail", kwargs={"uuid": discussion}) + "add_agents/"
-        client = self.client
-        client.credentials(HTTP_AUTHORIZATION="Token " + token)
-        response = client.post(url, format="json", data=body)
-        return response
+        self.admin_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.admin_user,
+            role=ProjectPermission.ROLE_ADMIN,
+        )
+        self.creator_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.creator_user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        self.agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent_user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        self.other_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.other_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
 
-    @parameterized.expand(parameters)
-    def test_add_user_to_discussion(
-        self, _, discussion, user_email, token, expected_status
+        self.admin_token = Token.objects.create(user=self.admin_user)
+        self.creator_token = Token.objects.create(user=self.creator_user)
+        self.agent_token = Token.objects.create(user=self.agent_user)
+        self.other_token = Token.objects.create(user=self.other_agent)
+        self.outside_token = Token.objects.create(user=self.outside_user)
+
+        self.room = Room.objects.create(
+            queue=self.queue, project_uuid=str(self.project.pk)
+        )
+        self.discussion = Discussion.objects.create(
+            subject="Test Discussion",
+            created_by=self.creator_user,
+            room=self.room,
+            queue=self.queue,
+            is_queued=True,
+        )
+
+    def _add_agent(self, token, user_email):
+        url = (
+            reverse("discussion-detail", kwargs={"uuid": self.discussion.uuid})
+            + "add_agents/"
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        return self.client.post(url, data={"user_email": user_email}, format="json")
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_creator_can_add_user_to_discussion(self, _mock_ws):
+        response = self._add_agent(self.creator_token, self.agent_user.email)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(
+            DiscussionUser.objects.filter(
+                discussion=self.discussion, permission=self.agent_perm
+            ).exists()
+        )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_admin_can_add_user_to_discussion(self, _mock_ws):
+        response = self._add_agent(self.admin_token, self.agent_user.email)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(
+            DiscussionUser.objects.filter(
+                discussion=self.discussion, permission=self.agent_perm
+            ).exists()
+        )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_queue_user_can_add_itself_when_discussion_has_less_than_two_users(
+        self, _mock_ws
     ):
-        discussion_data = {
-            "user_email": user_email,
-        }
+        self.assertEqual(self.discussion.added_users.count(), 0)
 
-        response = self._create_discussion_user(token, discussion, discussion_data)
+        response = self._add_agent(self.agent_token, self.agent_user.email)
 
-        self.assertEqual(response.status_code, expected_status)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(
+            DiscussionUser.objects.filter(
+                discussion=self.discussion, permission=self.agent_perm
+            ).exists()
+        )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_queue_user_cannot_add_other_users_to_discussion(self, _mock_ws):
+        response = self._add_agent(self.agent_token, self.other_agent.email)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(
+            DiscussionUser.objects.filter(
+                discussion=self.discussion, permission=self.other_perm
+            ).exists()
+        )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_added_user_cannot_add_other_users_to_discussion(self, _mock_ws):
+        DiscussionUser.objects.create(
+            discussion=self.discussion,
+            permission=self.agent_perm,
+            role=DiscussionUser.Role.PARTICIPANT,
+        )
+        DiscussionUser.objects.create(
+            discussion=self.discussion,
+            permission=self.other_perm,
+            role=DiscussionUser.Role.PARTICIPANT,
+        )
+
+        new_user = User.objects.create(email="new@test.com", first_name="New")
+        new_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=new_user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+
+        response = self._add_agent(self.agent_token, new_user.email)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(
+            DiscussionUser.objects.filter(
+                discussion=self.discussion, permission=new_perm
+            ).exists()
+        )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_cannot_add_user_already_in_discussion(self, _mock_ws):
+        DiscussionUser.objects.create(
+            discussion=self.discussion,
+            permission=self.agent_perm,
+            role=DiscussionUser.Role.PARTICIPANT,
+        )
+
+        response = self._add_agent(self.creator_token, self.agent_user.email)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_add_duplicate_user_returns_already_added_message_and_keeps_single_record(
+        self, _mock_ws
+    ):
+        DiscussionUser.objects.create(
+            discussion=self.discussion,
+            permission=self.agent_perm,
+            role=DiscussionUser.Role.PARTICIPANT,
+        )
+
+        response = self._add_agent(self.admin_token, self.agent_user.email)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("already added", response.json()[0])
+        self.assertEqual(
+            DiscussionUser.objects.filter(
+                discussion=self.discussion, permission=self.agent_perm
+            ).count(),
+            1,
+        )
+
+    @override_settings(DISCUSSION_AGENTS_LIMIT=10)
+    def test_outside_project_user_cannot_add_agents(self, _mock_ws):
+        response = self._add_agent(self.outside_token, self.agent_user.email)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
+@patch("chats.utils.websockets.send_channels_group")
 class ListDiscussionUserViewActionTests(APITestCase):
-    fixtures = [
-        "chats/fixtures/fixture_app.json",
-        "chats/fixtures/fixture_discussion.json",
-    ]
-    parameters = [
-        (
-            "Creator can list all users on the discussions",
-            "d7fddba0b1dfaad72aa9e21876cbc93caa9ce3fa",
-            "3c2d1694-8db9-4f09-976b-e263f9d79c99",
-            status.HTTP_200_OK,
-            1,
-        ),
-        (
-            "Admin can list all users on the discussions",
-            "4215e6d6666e54f7db9f98100533aa68909fd855",
-            "3c2d1694-8db9-4f09-976b-e263f9d79c99",
-            status.HTTP_200_OK,
-            1,
-        ),
-        (
-            "Added user can list all users on the discussions",
-            "a0358e20c8755568189d3a7e688ac3ec771317e2",
-            "36584c70-aaf9-4f5c-b0c3-0547bb23879d",
-            status.HTTP_200_OK,
-            3,
-        ),
-        (
-            "Outside project user cannot list discussion users",
-            "1218da72b087b8be7f0e2520a515e968ab866fdd",
-            "3c2d1694-8db9-4f09-976b-e263f9d79c99",
-            status.HTTP_403_FORBIDDEN,
-            None,
-        ),
-    ]
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project", timezone="UTC")
+        self.sector = self.project.sectors.create(
+            name="Test Sector",
+            rooms_limit=5,
+            work_start="08:00",
+            work_end="18:00",
+        )
+        self.queue = self.sector.queues.create(name="Test Queue")
 
-    def _list_discussion_user(self, token, discussion, params={}):
-        url = reverse("discussion-detail", kwargs={"uuid": discussion}) + "list_agents/"
-        client = self.client
-        client.credentials(HTTP_AUTHORIZATION="Token " + token)
-        response = client.get(url, data=params)
-        return response
+        self.admin_user = User.objects.create(
+            email="admin@test.com", first_name="Admin"
+        )
+        self.creator_user = User.objects.create(
+            email="creator@test.com", first_name="Creator"
+        )
+        self.agent_user = User.objects.create(
+            email="agent@test.com", first_name="Agent"
+        )
+        self.other_agent = User.objects.create(
+            email="other@test.com", first_name="Other"
+        )
+        self.outside_user = User.objects.create(
+            email="outside@test.com", first_name="Outside"
+        )
 
-    @parameterized.expand(parameters)
-    def test_discussion_user_list(
-        self, _, token, discussion, expected_status, expected_count
-    ):
-        response = self._list_discussion_user(token=token, discussion=discussion)
-        self.assertEqual(response.status_code, expected_status)
-        self.assertEqual(response.json().get("count"), expected_count)
+        self.admin_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.admin_user,
+            role=ProjectPermission.ROLE_ADMIN,
+        )
+        self.creator_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.creator_user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        self.agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent_user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        self.other_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.other_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+
+        self.admin_token = Token.objects.create(user=self.admin_user)
+        self.creator_token = Token.objects.create(user=self.creator_user)
+        self.agent_token = Token.objects.create(user=self.agent_user)
+        self.outside_token = Token.objects.create(user=self.outside_user)
+
+        self.room = Room.objects.create(
+            queue=self.queue, project_uuid=str(self.project.pk)
+        )
+        self.discussion = Discussion.objects.create(
+            subject="Test Discussion",
+            created_by=self.creator_user,
+            room=self.room,
+            queue=self.queue,
+            is_queued=True,
+        )
+
+        DiscussionUser.objects.create(
+            discussion=self.discussion,
+            permission=self.creator_perm,
+            role=DiscussionUser.Role.CREATOR,
+        )
+        DiscussionUser.objects.create(
+            discussion=self.discussion,
+            permission=self.agent_perm,
+            role=DiscussionUser.Role.PARTICIPANT,
+        )
+        DiscussionUser.objects.create(
+            discussion=self.discussion,
+            permission=self.other_perm,
+            role=DiscussionUser.Role.PARTICIPANT,
+        )
+
+    def _list_agents(self, token):
+        url = (
+            reverse("discussion-detail", kwargs={"uuid": self.discussion.uuid})
+            + "list_agents/"
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        return self.client.get(url)
+
+    def test_creator_can_list_discussion_users(self, _mock_ws):
+        response = self._list_agents(self.creator_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 3)
+
+    def test_admin_can_list_discussion_users(self, _mock_ws):
+        response = self._list_agents(self.admin_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 3)
+
+    def test_added_user_can_list_discussion_users(self, _mock_ws):
+        response = self._list_agents(self.agent_token)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 3)
+
+    def test_outside_project_user_cannot_list_discussion_users(self, _mock_ws):
+        response = self._list_agents(self.outside_token)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/chats/apps/discussions/tests/test_discussion_users_actions.py
+++ b/chats/apps/discussions/tests/test_discussion_users_actions.py
@@ -189,7 +189,7 @@ class CreateDiscussionUserViewActionTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
-            response.json()["error"][0],
+            response.json()["error"],
             f"User {self.agent_user.email} is already added to this discussion",
         )
         self.assertEqual(

--- a/chats/apps/discussions/tests/test_filters_and_views.py
+++ b/chats/apps/discussions/tests/test_filters_and_views.py
@@ -68,8 +68,7 @@ class DiscussionFiltersAndViewsTests(TestCase):
         self.assertFalse(f.qs.exists())
 
     @override_settings(DISCUSSION_AGENTS_LIMIT=10)
-    def test_add_agents_resolves_user_and_creates(self, mock_cache):
-        mock_cache.return_value = self.agent.pk
+    def test_add_agents_resolves_user_and_creates(self):
         view = DummyView()
         view._obj = self.discussion
 

--- a/chats/apps/discussions/tests/test_filters_and_views.py
+++ b/chats/apps/discussions/tests/test_filters_and_views.py
@@ -67,9 +67,6 @@ class DiscussionFiltersAndViewsTests(TestCase):
         )
         self.assertFalse(f.qs.exists())
 
-    @patch(
-        "chats.apps.discussions.views._discussion_user_actions.get_user_id_by_email_cached"
-    )
     @override_settings(DISCUSSION_AGENTS_LIMIT=10)
     def test_add_agents_resolves_user_and_creates(self, mock_cache):
         mock_cache.return_value = self.agent.pk

--- a/chats/apps/discussions/usecases/__init__.py
+++ b/chats/apps/discussions/usecases/__init__.py
@@ -1,2 +1,3 @@
+from .add_user_to_discussion import AddUserToDiscussionUseCase  # noqa
 from .create_discussion import CreateDiscussionUseCase  # noqa
 from .create_message_with_media import CreateMessageWithMediaUseCase  # noqa

--- a/chats/apps/discussions/usecases/add_user_to_discussion.py
+++ b/chats/apps/discussions/usecases/add_user_to_discussion.py
@@ -16,7 +16,7 @@ class AddUserToDiscussionUseCase:
 
         if discussion.is_added_user(user):
             raise ValidationError(
-                f"User {user_email} is already added to this discussion"
+                {"error": f"User {user_email} is already added to this discussion"}
             )
 
         try:
@@ -24,7 +24,7 @@ class AddUserToDiscussionUseCase:
                 from_user=from_user, to_user=user
             )
         except UserProjectPermissionNotFound as e:
-            raise ValidationError(e)
+            raise ValidationError({"error": str(e)})
 
         feedback = {"user": added_agent.user.first_name}
         create_discussion_feedback_message(discussion, feedback, "da")

--- a/chats/apps/discussions/usecases/add_user_to_discussion.py
+++ b/chats/apps/discussions/usecases/add_user_to_discussion.py
@@ -1,0 +1,36 @@
+from django.contrib.auth import get_user_model
+from rest_framework.exceptions import ValidationError
+
+from chats.apps.discussions.app_services.feedbacks import (
+    create_discussion_feedback_message,
+)
+from chats.apps.discussions.exceptions import UserProjectPermissionNotFound
+from chats.apps.discussions.models import Discussion
+
+User = get_user_model()
+
+
+class AddUserToDiscussionUseCase:
+    def execute(self, discussion: Discussion, user_email: str, from_user) -> dict:
+        user = User.objects.get(email=user_email)
+
+        if discussion.is_added_user(user):
+            raise ValidationError(
+                f"User {user_email} is already added to this discussion"
+            )
+
+        try:
+            added_agent = discussion.create_discussion_user(
+                from_user=from_user, to_user=user
+            )
+        except UserProjectPermissionNotFound as e:
+            raise ValidationError(e)
+
+        feedback = {"user": added_agent.user.first_name}
+        create_discussion_feedback_message(discussion, feedback, "da")
+
+        return {
+            "first_name": added_agent.user.first_name,
+            "last_name": added_agent.user.last_name,
+            "role": added_agent.role,
+        }

--- a/chats/apps/discussions/usecases/add_user_to_discussion.py
+++ b/chats/apps/discussions/usecases/add_user_to_discussion.py
@@ -12,7 +12,7 @@ User = get_user_model()
 
 class AddUserToDiscussionUseCase:
     def execute(self, discussion: Discussion, user_email: str, from_user) -> dict:
-        user = User.objects.get(email=user_email)
+        user = User.objects.get(email=user_email.lower())
 
         if discussion.is_added_user(user):
             raise ValidationError(

--- a/chats/apps/discussions/views/_discussion_user_actions.py
+++ b/chats/apps/discussions/views/_discussion_user_actions.py
@@ -1,15 +1,16 @@
-from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from ..app_services.feedbacks import create_discussion_feedback_message
-from ..models import DiscussionUser
-from ..serializers import DiscussionUserListSerializer
-from chats.core.cache_utils import get_user_id_by_email_cached
+from chats.apps.discussions.serializers.discussions import (
+    AddAgentToDiscussionSerializer,
+)
 
-
-User = get_user_model()
+from chats.apps.discussions.models.discussion_user import DiscussionUser
+from chats.apps.discussions.serializers.discussion_users import (
+    DiscussionUserListSerializer,
+)
+from chats.apps.discussions.usecases import AddUserToDiscussionUseCase
 
 
 class DiscussionUserActionsMixin:
@@ -17,37 +18,17 @@ class DiscussionUserActionsMixin:
 
     @action(detail=True, methods=["POST"], url_name="add_agents", filterset_class=None)
     def add_agents(self, request, *args, **kwargs):
-        try:
-            user_email = request.data.get("user_email")
-            email_l = (user_email or "").lower()
-            uid = get_user_id_by_email_cached(email_l)
-            if uid is None:
-                return Response(
-                    {"detail": "User not found"},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
-            user = User.objects.get(pk=uid)
+        serializer = AddAgentToDiscussionSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
 
-            discussion = self.get_object()
-            added_agent = discussion.create_discussion_user(
-                from_user=request.user, to_user=user
-            )
-            feedback = {"user": added_agent.user.first_name}
-            create_discussion_feedback_message(discussion, feedback, "da")
+        discussion = self.get_object()
+        result = AddUserToDiscussionUseCase().execute(
+            discussion=discussion,
+            user_email=serializer.validated_data["user_email"],
+            from_user=request.user,
+        )
 
-            return Response(
-                {
-                    "first_name": added_agent.user.first_name,
-                    "last_name": added_agent.user.last_name,
-                    "role": added_agent.role,
-                },
-                status=status.HTTP_201_CREATED,
-            )
-        except Exception as error:
-            return Response(
-                {"detail": f"{type(error)}: {error}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        return Response(result, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["GET"], url_name="list_agents", filterset_class=None)
     def list_agents(self, request, *args, **kwargs):

--- a/chats/apps/discussions/views/permissions/discussions.py
+++ b/chats/apps/discussions/views/permissions/discussions.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import permissions
 
+from chats.apps.discussions.models.discussion import Discussion
 from chats.apps.rooms.models import Room
 
 
@@ -57,3 +58,15 @@ class CanManageDiscussion(permissions.BasePermission):
 
         except AttributeError:
             return obj.can_retrieve(request.user)
+
+
+class CanAddAgentToDiscussion(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if isinstance(request.user, AnonymousUser):
+            return False
+        if view.action == "add_agents":
+            return True
+        return super().has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj: Discussion) -> bool:
+        return obj.can_add_user(request.user)


### PR DESCRIPTION
### What
- Extracted the "add user to discussion" logic from the view layer into a dedicated `AddUserToDiscussionUseCase`, following the existing use case pattern in the codebase.
- Added an `AddAgentToDiscussionSerializer` to validate the `user_email` input before reaching the use case.
- Introduced a `CanAddAgentToDiscussion` permission class to enforce authorization at the view level instead of relying on a generic `try/except` block.
- Added a `UserProjectPermissionNotFound` exception, raised by the `Discussion.create_discussion_user` model method when either user lacks a project permission.
- The `add_agents` view action now returns proper HTTP status codes: `400` for duplicate users or missing permissions, `403` for unauthorized access, instead of a blanket `400` for all errors.
- Replaced the `get_user_id_by_email_cached` cache lookup with a direct `User.objects.get(email=...)` query inside the use case.
- Rewrote all tests in `test_discussion_users_actions.py` from fixture-based parameterized tests to explicit `setUp`-based tests, and added a new `test_add_user_usecase.py` suite covering the use case in isolation.

### Why
- The previous `add_agents` endpoint caught all exceptions with a broad `except Exception`, masking real errors (e.g., adding a user already in the discussion returned a generic `400` with an internal exception string instead of a clear validation message).
- Extracting a use case makes the business logic testable independently from HTTP concerns and keeps the view thin.
- Explicit permission checks at the view level follow DRF best practices and provide correct `403` responses instead of mixing authorization failures with validation errors.
- Removing fixtures in favor of programmatic test setup makes tests self-contained, easier to read, and less fragile.

### Sequence diagram
```mermaid
sequenceDiagram
    actor Client
    participant View as add_agents View
    participant Serializer as AddAgentToDiscussionSerializer
    participant Permission as CanAddAgentToDiscussion
    participant UseCase as AddUserToDiscussionUseCase
    participant Model as Discussion Model
    participant DB as Database

    Client->>View: POST /discussions/{uuid}/add_agents/ {user_email}
    View->>Serializer: Validate request data
    alt Invalid email format
        Serializer-->>View: ValidationError
        View-->>Client: 400 Bad Request
    end
    Serializer-->>View: Validated data

    View->>Permission: has_object_permission(request, discussion)
    alt User not authorized (not creator/admin)
        Permission-->>View: False
        View-->>Client: 403 Forbidden
    end
    Permission-->>View: True

    View->>UseCase: execute(discussion, user_email, from_user)
    UseCase->>DB: User.objects.get(email)
    alt User not found
        DB-->>UseCase: DoesNotExist
        UseCase-->>View: Exception
        View-->>Client: 400 Bad Request
    end
    DB-->>UseCase: User

    UseCase->>Model: is_added_user(user)
    alt User already in discussion
        Model-->>UseCase: True
        UseCase-->>View: ValidationError ("already added")
        View-->>Client: 400 Bad Request
    end
    Model-->>UseCase: False

    UseCase->>Model: create_discussion_user(from_user, to_user)
    Model->>DB: Check project permissions for both users
    alt Missing project permission
        DB-->>Model: None
        Model-->>UseCase: UserProjectPermissionNotFound
        UseCase-->>View: ValidationError
        View-->>Client: 400 Bad Request
    end
    Model->>DB: Create DiscussionUser
    DB-->>Model: DiscussionUser
    Model-->>UseCase: added_agent

    UseCase->>DB: Create feedback message
    UseCase-->>View: {first_name, last_name, role}
    View-->>Client: 201 Created
```