### PR TITLE
fix: pick room from view mode transfer history info

### DIFF
--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -479,16 +479,18 @@ class RoomViewset(
             action = "transfer" if self.request.user.email != user else "pick"
             feedback = create_transfer_json(
                 action=action,
-                from_=old_instance.user or old_instance.queue,
+                from_=old_user or old_instance.queue,
                 to=instance.user,
                 requested_by=self.request.user,
             )
+
+            instance.add_transfer_to_history(feedback)
 
         if queue:
             # Create constraint to make queue not none
             feedback = create_transfer_json(
                 action="transfer",
-                from_=old_instance.user or old_instance.queue,
+                from_=old_user or old_instance.queue,
                 to=instance.queue,
                 requested_by=self.request.user,
             )
@@ -503,8 +505,9 @@ class RoomViewset(
             room_metric.transfer_count += 1
             room_metric.save()
 
+            instance.add_transfer_to_history(feedback)
+
         instance.save()
-        instance.add_transfer_to_history(feedback)
 
         # Create a message with the transfer data and Send to the room group
         # TODO separate create message in a function

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -484,6 +484,12 @@ class RoomViewset(
                 requested_by=self.request.user,
             )
 
+            create_room_feedback_message(
+                instance,
+                feedback,
+                method=RoomFeedbackMethods.ROOM_TRANSFER,
+                requested_by=self.request.user,
+            )
             instance.add_transfer_to_history(feedback)
 
         if queue:
@@ -505,18 +511,16 @@ class RoomViewset(
             room_metric.transfer_count += 1
             room_metric.save()
 
+            create_room_feedback_message(
+                instance,
+                feedback,
+                method=RoomFeedbackMethods.ROOM_TRANSFER,
+                requested_by=self.request.user,
+            )
+
             instance.add_transfer_to_history(feedback)
 
         instance.save()
-
-        # Create a message with the transfer data and Send to the room group
-        # TODO separate create message in a function
-        create_room_feedback_message(
-            instance,
-            feedback,
-            method=RoomFeedbackMethods.ROOM_TRANSFER,
-            requested_by=self.request.user,
-        )
 
         if old_user is None and user:  # queued > agent
             instance.notify_queue("update")


### PR DESCRIPTION
### What
- Fixed the `from_` parameter in `create_transfer_json` calls to use `old_user` directly instead of `old_instance.user`. After the room instance is updated, `old_instance.user` may already reflect the new state, causing incorrect transfer history records.
- Extracted the feedback message creation and transfer history logic into each transfer branch (`if user` / `if queue`) instead of running them once at the end with a shared `feedback` variable.
- Moved `instance.save()` to after both branches complete, ensuring feedback messages and transfer history entries are recorded before the final save.

### Why
When a room was picked or transferred from "view mode" (e.g., an agent picking a room from a queue), the transfer history was recording incorrect `from` information. This happened because `old_instance.user` was being used as the source of the transfer, but after the update, `old_instance.user` could already point to the new user. By using the previously captured `old_user` variable and scoping the feedback/history logic to each branch independently, the transfer history now correctly reflects who the room was transferred from and to in all scenarios (agent-to-agent, queue-to-agent, agent-to-queue).

### Sequence diagram
```mermaid
sequenceDiagram
    participant Client
    participant RoomViewset
    participant Room as Room Instance
    participant Metrics as RoomMetrics
    participant Feedback as create_transfer_json
    participant Message as create_room_feedback_message

    Client->>RoomViewset: PATCH /rooms/{id}/ (user or queue transfer)
    RoomViewset->>RoomViewset: Capture old_user and old_instance state

    alt Transfer to User
        RoomViewset->>Metrics: Update waiting_time or transfer_count
        RoomViewset->>Feedback: create_transfer_json(from_=old_user or old_queue, to=new_user)
        Feedback-->>RoomViewset: feedback JSON
        RoomViewset->>Message: create_room_feedback_message(feedback)
        RoomViewset->>Room: add_transfer_to_history(feedback)
    end

    alt Transfer to Queue
        RoomViewset->>Feedback: create_transfer_json(from_=old_user or old_queue, to=new_queue)
        Feedback-->>RoomViewset: feedback JSON
        RoomViewset->>Metrics: Update transfer_count
        RoomViewset->>Message: create_room_feedback_message(feedback)
        RoomViewset->>Room: add_transfer_to_history(feedback)
    end

    RoomViewset->>Room: instance.save()
    RoomViewset->>Room: Notify relevant users/queues
    RoomViewset-->>Client: 200 OK
```