### PR TITLE
fix: implement pagination for agents data in InternalDashboardViewset

### DIFF
--- a/chats/apps/api/v1/internal/dashboard/viewsets.py
+++ b/chats/apps/api/v1/internal/dashboard/viewsets.py
@@ -2,6 +2,7 @@ from django.db.models import Count, Exists, OuterRef, Q, Subquery
 
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 
 from chats.apps.api.v1.dashboard.dto import (
@@ -113,8 +114,14 @@ class InternalDashboardViewset(viewsets.GenericViewSet):
         if has_filter:
             agents_data = agents_data.filter(combined_q)
 
-        agents = DashboardAgentsSerializer(agents_data, many=True)
+        paginator = LimitOffsetPagination()
+        paginated_data = paginator.paginate_queryset(agents_data, request)
 
+        if paginated_data is not None:
+            agents = DashboardAgentsSerializer(paginated_data, many=True)
+            return paginator.get_paginated_response(agents.data)
+
+        agents = DashboardAgentsSerializer(agents_data, many=True)
         return Response({"results": agents.data}, status.HTTP_200_OK)
 
     @action(

--- a/chats/apps/api/v2/internal/dashboard/viewsets.py
+++ b/chats/apps/api/v2/internal/dashboard/viewsets.py
@@ -40,8 +40,12 @@ class InternalDashboardViewsetV2(viewsets.GenericViewSet):
         usecase = InternalDashboardAgentsUsecase()
         agents_data = usecase.execute(project, serializer.validated_data)
 
-        agents = DashboardAgentsSerializerV2(agents_data, many=True)
+        page = self.paginate_queryset(agents_data)
+        if page is not None:
+            agents = DashboardAgentsSerializerV2(page, many=True)
+            return self.get_paginated_response(agents.data)
 
+        agents = DashboardAgentsSerializerV2(agents_data, many=True)
         return Response({"results": agents.data}, status.HTTP_200_OK)
 
     @action(


### PR DESCRIPTION
### What
- Added `LimitOffsetPagination` to the `agents` action in `InternalDashboardViewset` (v1), allowing clients to paginate results via `limit` and `offset` query parameters.
- Added pagination support to the `agents` action in `InternalDashboardViewsetV2` (v2), using the viewset's built-in `paginate_queryset` / `get_paginated_response` methods.
- Both endpoints fall back to the original unpaginated `{"results": [...]}` response when no pagination parameters are provided, preserving backward compatibility.
- Removed stale `CHANGELOG.md` entries.

### Why
The agents metrics endpoint returns all agents in a single response. For projects with a large number of agents this causes slow responses, high memory usage, and potential timeouts. Adding pagination lets consumers fetch agents in smaller, predictable pages and reduces backend load.