### PR TITLE
fix: Agents list performance for deleted permissions

### DIFF
--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -53,16 +53,10 @@ class AgentRepository:
         agents_filters = Q(project_permissions__project=project) & Q(is_active=True)
 
         if include_removed:
-            agents_filters = (
-                Q(project_permissions__project=project)
-                | Exists(
-                    ProjectPermission.all_objects.filter(
-                        project=project,
-                        user_id=OuterRef("email"),
-                        is_deleted=True,
-                    )
-                )
-            ) & Q(is_active=True)
+            all_project_user_emails = ProjectPermission.all_objects.filter(
+                project=project,
+            ).values("user_id")
+            agents_filters = Q(email__in=all_project_user_emails) & Q(is_active=True)
 
         if filters.queues:
             rooms_filter["rooms__queue__in"] = filters.queues
@@ -443,15 +437,11 @@ class AgentRepository:
         self, filters: Filters, project: Project, include_removed: bool = False
     ):
         if include_removed:
+            all_project_user_emails = ProjectPermission.all_objects.filter(
+                project=project,
+            ).values("user_id")
             agents = self.model.filter(
-                Q(project_permissions__project=project)
-                | Exists(
-                    ProjectPermission.all_objects.filter(
-                        project=project,
-                        user_id=OuterRef("email"),
-                        is_deleted=True,
-                    )
-                )
+                email__in=all_project_user_emails,
             )
         else:
             agents = self.model.filter(project_permissions__project=project)


### PR DESCRIPTION
### What

Refactored the agent filtering logic in `AgentRepository` (`chats/apps/api/v1/internal/dashboard/repository.py`) across two methods — `get_agents_data` and `_get_agents_query` — replacing a correlated `Exists` subquery with a simpler `__in` lookup.

**Before:** When `include_removed=True`, the query used `Exists(ProjectPermission.all_objects.filter(project=project, user_id=OuterRef("email"), is_deleted=True))` combined with an `OR` against the standard project permission filter. This generated a correlated subquery evaluated per row.

**After:** A single upfront query fetches all `user_id` values from `ProjectPermission.all_objects` for the given project, and agents are filtered with `email__in=all_project_user_emails`. This produces a flat `IN` clause instead of a correlated subquery.

### Why

The `Exists` + `OuterRef` pattern produced a correlated subquery that the database had to evaluate for every row in the `User` table, leading to poor performance on the agents list endpoint — especially for projects with a large number of users. Replacing it with a pre-fetched `__in` lookup allows the database to use a hash or index-based semi-join, significantly reducing query execution time and improving the dashboard agents list response latency.