### PR TITLE
feat: get room user usecase

### DIFF
--- a/chats/apps/api/v1/external/rooms/serializers.py
+++ b/chats/apps/api/v1/external/rooms/serializers.py
@@ -24,6 +24,7 @@ from chats.apps.queues.models import Queue
 from chats.apps.queues.usecases.can_agent_receive_room import (
     CanAgentReceiveRoomUseCase,
 )
+from chats.apps.rooms.usecases.resolve_room_user import ResolveRoomUserUseCase
 from chats.apps.queues.utils import start_queue_priority_routing
 from chats.apps.rooms.models import Room
 from chats.apps.rooms.views import close_room
@@ -90,6 +91,8 @@ def get_last_flow_start(
     return last_flow_start
 
 
+# TODO: Remove get_room_user once ResolveRoomUserUseCase is fully rolled out
+#  and the weniChatsNewGetRoomUser feature flag is removed.
 def get_room_user(
     contact: Contact,
     queue: Queue,
@@ -555,9 +558,20 @@ class RoomFlowSerializer(serializers.ModelSerializer):
 
         last_flow_start = get_last_flow_start(contact, groups, project, flow_uuid)
 
-        validated_data["user"] = get_room_user(
-            contact, queue, user, created, project, last_flow_start
-        )
+        # TODO: Remove this feature flag check and the get_room_user fallback
+        #  once ResolveRoomUserUseCase is fully rolled out.
+        if is_feature_active(
+            settings.NEW_GET_ROOM_USER_FEATURE_FLAG_KEY,
+            None,
+            str(project.uuid),
+        ):
+            validated_data["user"] = ResolveRoomUserUseCase(queue, project).execute(
+                contact, user, created, last_flow_start
+            )
+        else:
+            validated_data["user"] = get_room_user(
+                contact, queue, user, created, project, last_flow_start
+            )
 
         has_room_after_flow_start = False
 

--- a/chats/apps/api/v1/tests/test_dashboard.py
+++ b/chats/apps/api/v1/tests/test_dashboard.py
@@ -36,8 +36,9 @@ class DashboardTests(APITestCase):
         cls.patcher.stop()
         super().tearDownClass()
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=False)
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
-    def test_create_room_metrics(self, mock_is_attending):
+    def test_create_room_metrics(self, mock_is_attending, _mock_flag):
         """
         Verify if the room metric its created when a room is created.
         """

--- a/chats/apps/rooms/tests/test_external_rooms_working_hours.py
+++ b/chats/apps/rooms/tests/test_external_rooms_working_hours.py
@@ -71,11 +71,12 @@ class ExternalRoomsWorkingHoursTests(APITestCase):
         resp = self._create(payload)
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=False)
     @patch(
         "chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room",
         return_value=None,
     )
-    def test_allows_inside_working_hours_weekday(self, _mock_billing):
+    def test_allows_inside_working_hours_weekday(self, _mock_billing, _mock_flag):
         # Quinta-feira 2025-08-21 10:00 -03:00 (dentro do horário)
         payload = self._base_payload()
         payload["contact"]["external_id"] = "00000000-0000-0000-0000-000000000002"

--- a/chats/apps/rooms/tests/test_resolve_room_user.py
+++ b/chats/apps/rooms/tests/test_resolve_room_user.py
@@ -1,0 +1,505 @@
+from datetime import time
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from chats.apps.accounts.models import User
+from chats.apps.contacts.models import Contact
+from chats.apps.projects.models.models import (
+    FlowStart,
+    LinkContact,
+    Project,
+    ProjectPermission,
+    RoomRoutingType,
+)
+from chats.apps.queues.models import Queue, QueueAuthorization
+from chats.apps.rooms.models import Room
+from chats.apps.rooms.usecases.resolve_room_user import ResolveRoomUserUseCase
+from chats.apps.sectors.models import Sector
+
+GROWTHBOOK_PATCH = (
+    "chats.apps.queues.models.is_feature_active_for_attributes"
+)
+
+
+class ResolveRoomUserFlowStartTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start=time(hour=0, minute=0),
+            work_end=time(hour=23, minute=59),
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.contact = Contact.objects.create(
+            external_id="contact-1", name="Test Contact"
+        )
+
+        self.agent = User.objects.create(email="agent@example.com")
+        self.permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+        )
+
+        self.flow_start = FlowStart.objects.create(
+            project=self.project,
+            permission=self.permission,
+            flow="test-flow",
+        )
+
+        self.usecase = ResolveRoomUserUseCase(self.queue, self.project)
+
+    def test_returns_flow_start_user_when_contact_is_created_and_permission_online(
+        self,
+    ):
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+            last_flow_start=self.flow_start,
+        )
+
+        self.assertEqual(result, self.agent)
+
+    def test_returns_flow_start_user_when_no_rooms_after_flow_start_and_permission_online(
+        self,
+    ):
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=False,
+            last_flow_start=self.flow_start,
+        )
+
+        self.assertEqual(result, self.agent)
+
+    def test_skips_flow_start_when_permission_offline(self):
+        self.permission.status = "OFFLINE"
+        self.permission.save(update_fields=["status"])
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+            last_flow_start=self.flow_start,
+        )
+
+        self.assertIsNone(result)
+
+    def test_skips_flow_start_when_rooms_exist_after_flow_start(self):
+        Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            is_active=True,
+        )
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=False,
+            last_flow_start=self.flow_start,
+        )
+
+        self.assertIsNone(result)
+
+    def test_skips_flow_start_when_none(self):
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+            last_flow_start=None,
+        )
+
+        self.assertIsNone(result)
+
+
+class ResolveRoomUserLinkedUserTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start=time(hour=0, minute=0),
+            work_end=time(hour=23, minute=59),
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.contact = Contact.objects.create(
+            external_id="contact-linked", name="Linked Contact"
+        )
+
+        self.linked_agent = User.objects.create(email="linked@example.com")
+        self.permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.linked_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+        )
+        LinkContact.objects.create(
+            user=self.linked_agent,
+            contact=self.contact,
+            project=self.project,
+        )
+
+        self.usecase = ResolveRoomUserUseCase(self.queue, self.project)
+
+    def test_returns_linked_user_when_not_created_and_linked_user_online(self):
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=False,
+        )
+
+        self.assertEqual(result, self.linked_agent)
+
+    def test_skips_linked_user_when_is_created(self):
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+        )
+
+        self.assertIsNone(result)
+
+    def test_skips_linked_user_when_linked_user_offline(self):
+        self.permission.status = "OFFLINE"
+        self.permission.save(update_fields=["status"])
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=False,
+        )
+
+        self.assertIsNone(result)
+
+
+class ResolveRoomUserExplicitUserTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start=time(hour=0, minute=0),
+            work_end=time(hour=23, minute=59),
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.contact = Contact.objects.create(
+            external_id="contact-explicit", name="Explicit Contact"
+        )
+
+        self.agent = User.objects.create(email="explicit@example.com")
+
+        self.usecase = ResolveRoomUserUseCase(self.queue, self.project)
+
+    def test_returns_explicit_user_when_online_in_project(self):
+        ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+        )
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=self.agent,
+            is_created=True,
+        )
+
+        self.assertEqual(result, self.agent)
+
+    def test_skips_explicit_user_when_not_online(self):
+        ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="OFFLINE",
+        )
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=self.agent,
+            is_created=True,
+        )
+
+        self.assertIsNone(result)
+
+    def test_skips_explicit_user_when_none(self):
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+        )
+
+        self.assertIsNone(result)
+
+
+@patch(GROWTHBOOK_PATCH, return_value=False)
+class ResolveRoomUserQueuePriorityTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project",
+            room_routing_type=RoomRoutingType.QUEUE_PRIORITY,
+        )
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start=time(hour=0, minute=0),
+            work_end=time(hour=23, minute=59),
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.contact = Contact.objects.create(
+            external_id="contact-qp", name="QP Contact"
+        )
+
+        self.agent = User.objects.create(email="qp-agent@example.com")
+        permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=permission,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        self.usecase = ResolveRoomUserUseCase(self.queue, self.project)
+
+    @patch(
+        "chats.apps.rooms.usecases.resolve_room_user.is_feature_active",
+        return_value=False,
+    )
+    @patch("chats.apps.rooms.usecases.resolve_room_user.start_queue_priority_routing")
+    def test_queue_priority_empty_queue_returns_available_agent(
+        self, mock_routing, mock_flag, _mock_gb
+    ):
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+        )
+
+        self.assertEqual(result, self.agent)
+        mock_routing.assert_not_called()
+
+    @patch(
+        "chats.apps.rooms.usecases.resolve_room_user.is_feature_active",
+        return_value=False,
+    )
+    @patch("chats.apps.rooms.usecases.resolve_room_user.start_queue_priority_routing")
+    def test_queue_priority_empty_queue_no_agent_returns_none(
+        self, mock_routing, mock_flag, _mock_gb
+    ):
+        self.agent.delete()
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+        )
+
+        self.assertIsNone(result)
+        mock_routing.assert_not_called()
+
+    @patch(
+        "chats.apps.rooms.usecases.resolve_room_user.is_feature_active",
+        return_value=True,
+    )
+    @patch("chats.apps.rooms.usecases.resolve_room_user.start_queue_priority_routing")
+    def test_queue_priority_empty_queue_agent_fails_capacity_recheck(
+        self, mock_routing, mock_flag, _mock_gb
+    ):
+        for i in range(5):
+            Room.objects.create(
+                queue=self.queue,
+                contact=Contact.objects.create(external_id=f"overloaded-{i}"),
+                user=self.agent,
+                is_active=True,
+            )
+
+        with patch.object(Queue, "get_available_agent", return_value=self.agent):
+            result = self.usecase.execute(
+                contact=self.contact,
+                user=None,
+                is_created=True,
+            )
+
+        self.assertIsNone(result)
+        mock_routing.assert_called_once_with(self.queue)
+
+    @patch(
+        "chats.apps.rooms.usecases.resolve_room_user.is_feature_active",
+        return_value=False,
+    )
+    @patch("chats.apps.rooms.usecases.resolve_room_user.start_queue_priority_routing")
+    def test_queue_priority_empty_queue_capacity_recheck_flag_off(
+        self, mock_routing, mock_flag, _mock_gb
+    ):
+        for i in range(5):
+            Room.objects.create(
+                queue=self.queue,
+                contact=Contact.objects.create(external_id=f"overloaded-{i}"),
+                user=self.agent,
+                is_active=True,
+            )
+
+        with patch.object(Queue, "get_available_agent", return_value=self.agent):
+            result = self.usecase.execute(
+                contact=self.contact,
+                user=None,
+                is_created=True,
+            )
+
+        self.assertEqual(result, self.agent)
+        mock_routing.assert_not_called()
+
+    @patch("chats.apps.rooms.usecases.resolve_room_user.start_queue_priority_routing")
+    def test_queue_priority_non_empty_queue_returns_none(
+        self, mock_routing, _mock_gb
+    ):
+        Room.objects.create(
+            queue=self.queue,
+            contact=Contact.objects.create(external_id="waiting-contact"),
+            user=None,
+            is_active=True,
+        )
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+        )
+
+        self.assertIsNone(result)
+        mock_routing.assert_called_once_with(self.queue)
+
+
+@patch(GROWTHBOOK_PATCH, return_value=False)
+class ResolveRoomUserGeneralRoutingTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project",
+            room_routing_type=RoomRoutingType.GENERAL,
+        )
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start=time(hour=0, minute=0),
+            work_end=time(hour=23, minute=59),
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.contact = Contact.objects.create(
+            external_id="contact-general", name="General Contact"
+        )
+
+        self.agent = User.objects.create(email="general-agent@example.com")
+        permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=permission,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        self.usecase = ResolveRoomUserUseCase(self.queue, self.project)
+
+    def test_general_routing_with_waiting_rooms_returns_none(self, _mock_gb):
+        Room.objects.create(
+            queue=self.queue,
+            contact=Contact.objects.create(external_id="waiting-general"),
+            user=None,
+            is_active=True,
+        )
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+        )
+
+        self.assertIsNone(result)
+
+    @patch(
+        "chats.apps.rooms.usecases.resolve_room_user.is_feature_active",
+        return_value=False,
+    )
+    def test_general_routing_returns_available_agent(self, mock_flag, _mock_gb):
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+        )
+
+        self.assertEqual(result, self.agent)
+
+    @patch(
+        "chats.apps.rooms.usecases.resolve_room_user.is_feature_active",
+        return_value=False,
+    )
+    def test_general_routing_no_agent_returns_none(self, mock_flag, _mock_gb):
+        self.agent.delete()
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=True,
+        )
+
+        self.assertIsNone(result)
+
+    @patch(
+        "chats.apps.rooms.usecases.resolve_room_user.is_feature_active",
+        return_value=True,
+    )
+    def test_general_routing_agent_fails_capacity_recheck(self, mock_flag, _mock_gb):
+        for i in range(5):
+            Room.objects.create(
+                queue=self.queue,
+                contact=Contact.objects.create(external_id=f"general-overloaded-{i}"),
+                user=self.agent,
+                is_active=True,
+            )
+
+        with patch.object(Queue, "get_available_agent", return_value=self.agent):
+            result = self.usecase.execute(
+                contact=self.contact,
+                user=None,
+                is_created=True,
+            )
+
+        self.assertIsNone(result)
+
+    @patch(
+        "chats.apps.rooms.usecases.resolve_room_user.is_feature_active",
+        return_value=False,
+    )
+    def test_general_routing_capacity_recheck_flag_off(self, mock_flag, _mock_gb):
+        for i in range(5):
+            Room.objects.create(
+                queue=self.queue,
+                contact=Contact.objects.create(external_id=f"general-overloaded-{i}"),
+                user=self.agent,
+                is_active=True,
+            )
+
+        with patch.object(Queue, "get_available_agent", return_value=self.agent):
+            result = self.usecase.execute(
+                contact=self.contact,
+                user=None,
+                is_created=True,
+            )
+
+        self.assertEqual(result, self.agent)

--- a/chats/apps/rooms/tests/test_viewsets_external.py
+++ b/chats/apps/rooms/tests/test_viewsets_external.py
@@ -230,9 +230,10 @@ class RoomsExternalTests(APITestCase):
         )
         self.assertEqual(response.data["contact"]["custom_fields"]["job"], "streamer")
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=False)
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
-    def test_is_anon_true_wont_save_urn(self, mock_get_room, mock_is_attending):
+    def test_is_anon_true_wont_save_urn(self, mock_get_room, mock_is_attending, _mock_flag):
         mock_get_room.return_value = None
         data = {
             "queue_uuid": str(self.queue_1.uuid),
@@ -456,7 +457,10 @@ class RoomsQueuePriorityExternalTests(APITestCase):
             self.queue.uuid,
         )
 
-    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=True)
+    @patch(
+        "chats.apps.api.v1.external.rooms.serializers.is_feature_active",
+        side_effect=lambda key, *a, **kw: key != settings.NEW_GET_ROOM_USER_FEATURE_FLAG_KEY,
+    )
     @patch("chats.apps.api.v1.external.rooms.serializers.start_queue_priority_routing")
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_room_with_queue_priority_when_agent_fails_capacity_recheck(
@@ -913,12 +917,13 @@ class RoomsExternalProtocolTests(APITestCase):
         room = Room.objects.get(uuid=response.data["uuid"])
         self.assertEqual(room.protocol, "PROTO_CUSTOM")
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=False)
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     @patch(
         "chats.apps.accounts.authentication.drf.backends.WeniOIDCAuthenticationBackend.get_userinfo"
     )
     def test_protocol_absent_in_body_uses_custom(
-        self, mock_get_userinfo, mock_get_room
+        self, mock_get_userinfo, mock_get_room, _mock_flag
     ):
         mock_get_userinfo.return_value = {"sub": "test_user"}
         mock_get_room.return_value = None

--- a/chats/apps/rooms/usecases/resolve_room_user.py
+++ b/chats/apps/rooms/usecases/resolve_room_user.py
@@ -78,7 +78,8 @@ class ResolveRoomUserUseCase:
             return None
 
         logger.info(
-            "Calling start_queue_priority_routing for queue %s from ResolveRoomUserUseCase because the queue is not empty",
+            "Calling start_queue_priority_routing for queue %s from"
+            " ResolveRoomUserUseCase because the queue is not empty",
             self.queue.uuid,
         )
         start_queue_priority_routing(self.queue)

--- a/chats/apps/rooms/usecases/resolve_room_user.py
+++ b/chats/apps/rooms/usecases/resolve_room_user.py
@@ -1,0 +1,104 @@
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from django.conf import settings
+from weni.feature_flags.shortcuts import is_feature_active
+
+from chats.apps.queues.usecases.can_agent_receive_room import (
+    CanAgentReceiveRoomUseCase,
+)
+from chats.apps.queues.utils import start_queue_priority_routing
+
+if TYPE_CHECKING:
+    from chats.apps.accounts.models import User
+    from chats.apps.contacts.models import Contact
+    from chats.apps.projects.models.models import FlowStart, Project
+    from chats.apps.queues.models import Queue
+
+logger = logging.getLogger(__name__)
+
+
+class ResolveRoomUserUseCase:
+    def __init__(self, queue: "Queue", project: "Project"):
+        self.queue = queue
+        self.project = project
+
+    def execute(
+        self,
+        contact: "Contact",
+        user: Optional["User"],
+        is_created: bool,
+        last_flow_start: Optional["FlowStart"] = None,
+    ) -> Optional["User"]:
+        if last_flow_start:
+            if is_created is True or not contact.rooms.filter(
+                queue__sector__project=self.project,
+                created_on__gt=last_flow_start.created_on,
+            ):
+                if last_flow_start.permission.status == "ONLINE":
+                    return last_flow_start.permission.user
+
+        if not is_created:
+            linked_user = contact.get_linked_user(self.project)
+            if linked_user is not None and linked_user.is_online:
+                return linked_user.user
+
+        if user and self.project.permissions.filter(
+            user=user, status="ONLINE"
+        ).exists():
+            return user
+
+        if self.project.use_queue_priority_routing:
+            return self._resolve_queue_priority()
+
+        return self._resolve_general()
+
+    def _resolve_queue_priority(self) -> Optional["User"]:
+        current_queue_size = self.queue.rooms.filter(
+            is_active=True, user__isnull=True
+        ).count()
+
+        if current_queue_size == 0:
+            agent = self.queue.get_available_agent()
+            if agent is None:
+                return None
+
+            if not is_feature_active(
+                settings.AGENT_CAPACITY_RECHECK_FEATURE_FLAG_KEY,
+                None,
+                str(self.project.uuid),
+            ):
+                return agent
+
+            capacity = CanAgentReceiveRoomUseCase(self.queue).execute(agent)
+            if capacity.can_receive:
+                return agent
+
+            start_queue_priority_routing(self.queue)
+            return None
+
+        logger.info(
+            "Calling start_queue_priority_routing for queue %s from ResolveRoomUserUseCase because the queue is not empty",
+            self.queue.uuid,
+        )
+        start_queue_priority_routing(self.queue)
+
+        return None
+
+    def _resolve_general(self) -> Optional["User"]:
+        if self.queue.rooms.filter(is_active=True, user__isnull=True).exists():
+            return None
+
+        agent = self.queue.get_available_agent()
+        if agent is None:
+            return None
+
+        if not is_feature_active(
+            settings.AGENT_CAPACITY_RECHECK_FEATURE_FLAG_KEY,
+            None,
+            str(self.project.uuid),
+        ):
+            return agent
+
+        capacity = CanAgentReceiveRoomUseCase(self.queue).execute(agent)
+        return agent if capacity.can_receive else None

--- a/chats/apps/rooms/usecases/resolve_room_user.py
+++ b/chats/apps/rooms/usecases/resolve_room_user.py
@@ -59,6 +59,9 @@ class ResolveRoomUserUseCase:
         ).count()
 
         if current_queue_size == 0:
+            # If the queue is empty, the available user with the least number
+            # of rooms will be selected, if any, subject to a last-moment
+            # capacity recheck to close the race with concurrent assignments.
             agent = self.queue.get_available_agent()
             if agent is None:
                 return None
@@ -74,6 +77,9 @@ class ResolveRoomUserUseCase:
             if capacity.can_receive:
                 return agent
 
+            # Agent was picked but failed the recheck: leave the room in the
+            # queue and trigger routing so it is retried on the next
+            # opportunity.
             start_queue_priority_routing(self.queue)
             return None
 
@@ -84,12 +90,18 @@ class ResolveRoomUserUseCase:
         )
         start_queue_priority_routing(self.queue)
 
+        # If the queue is not empty, the room must stay in the queue, so that
+        # when an agent becomes available, the first room in the queue will be
+        # assigned to them. This logic is not done here.
         return None
 
     def _resolve_general(self) -> Optional["User"]:
         if self.queue.rooms.filter(is_active=True, user__isnull=True).exists():
             return None
 
+        # General room routing type. The last-moment capacity recheck is
+        # applied as well; if the picked agent fails it, the room stays
+        # unassigned.
         agent = self.queue.get_available_agent()
         if agent is None:
             return None

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -788,6 +788,11 @@ ROUTE_QUEUE_COOLDOWN_FEATURE_FLAG_KEY = env.str(
     "ROUTE_QUEUE_COOLDOWN_FEATURE_FLAG_KEY",
     default="weniChatsRouteQueueCooldown",
 )
+
+NEW_GET_ROOM_USER_FEATURE_FLAG_KEY = env.str(
+    "CHATS_NEW_GET_ROOM_USER_FEATURE_FLAG_KEY",
+    default="weniChatsNewGetRoomUser",
+)
 ROUTE_QUEUE_COOLDOWN_MAX_TIME = env.int(
     "ROUTE_QUEUE_COOLDOWN_MAX_TIME",
     default=30,


### PR DESCRIPTION
### What

- Introduced `ResolveRoomUserUseCase` in `chats/apps/rooms/usecases/resolve_room_user.py`, a dedicated use case class that encapsulates the logic for determining which agent should be assigned to a new chat room. It handles, in order: flow start assignment, linked-user lookup, explicit user validation, queue priority routing, and general routing — each with online/capacity checks.
- Added a new feature flag `weniChatsNewGetRoomUser` (setting `NEW_GET_ROOM_USER_FEATURE_FLAG_KEY`) to toggle between the new `ResolveRoomUserUseCase` and the legacy `get_room_user` function in `RoomFlowSerializer`.
- Marked the legacy `get_room_user` function with a TODO for removal once the feature flag is fully rolled out.
- Added comprehensive unit tests (`test_resolve_room_user.py`, 505 lines) covering all resolution strategies: flow start, linked user, explicit user, queue priority routing, and general routing — including edge cases for offline agents, capacity rechecks, and queue non-empty scenarios.
- Updated existing tests (`test_dashboard.py`, `test_external_rooms_working_hours.py`, `test_viewsets_external.py`) to patch the new `is_feature_active` call introduced by the feature flag gate.

### Why

The room-user resolution logic was previously embedded as a standalone function (`get_room_user`) inside the serializers module, making it difficult to test in isolation and tightly coupled to the serializer layer. Extracting it into a proper use case class (`ResolveRoomUserUseCase`) improves separation of concerns, testability, and readability. The feature flag allows a safe, incremental rollout with the ability to instantly fall back to the previous behavior if issues arise in production.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Serializer as RoomFlowSerializer
    participant FF as Feature Flag
    participant UC as ResolveRoomUserUseCase
    participant Contact as Contact
    participant Project as Project
    participant Queue as Queue

    Serializer->>FF: is_feature_active("weniChatsNewGetRoomUser", project)?
    alt Flag enabled
        Serializer->>UC: execute(contact, user, is_created, last_flow_start)

        UC->>UC: Check last_flow_start
        alt flow_start exists & permission ONLINE & (new contact or no rooms after flow_start)
            UC-->>Serializer: return flow_start.permission.user
        end

        UC->>Contact: get_linked_user(project)
        alt not is_created & linked_user ONLINE
            UC-->>Serializer: return linked_user
        end

        UC->>Project: permissions.filter(user=user, status="ONLINE")
        alt explicit user is ONLINE
            UC-->>Serializer: return user
        end

        alt project uses queue priority routing
            UC->>Queue: rooms.filter(is_active, user__isnull).count()
            alt queue is empty
                UC->>Queue: get_available_agent()
                UC->>UC: CanAgentReceiveRoomUseCase capacity recheck
                alt agent has capacity
                    UC-->>Serializer: return agent
                else agent over capacity
                    UC->>Queue: start_queue_priority_routing()
                    UC-->>Serializer: return None
                end
            else queue has waiting rooms
                UC->>Queue: start_queue_priority_routing()
                UC-->>Serializer: return None
            end
        else general routing
            alt queue has unassigned rooms
                UC-->>Serializer: return None
            else queue is clear
                UC->>Queue: get_available_agent()
                UC->>UC: CanAgentReceiveRoomUseCase capacity recheck
                UC-->>Serializer: return agent or None
            end
        end

    else Flag disabled
        Serializer->>Serializer: get_room_user() (legacy)
        Serializer-->>Serializer: return user or None
    end
```