### PR TITLE
feat: Change has chats summary flag logic

### DIFF
--- a/chats/apps/api/v1/projects/serializers.py
+++ b/chats/apps/api/v1/projects/serializers.py
@@ -26,10 +26,12 @@ class ProjectSerializer(serializers.ModelSerializer):
             "config",
             "org",
             "room_routing_type",
+            "is_chats_summary_enabled",
         ]
         read_only_fields = [
             "timezone",
             "room_routing_type",
+            "is_chats_summary_enabled",
         ]
 
     def get_config(self, project: Project):

--- a/chats/apps/projects/models/models.py
+++ b/chats/apps/projects/models/models.py
@@ -268,15 +268,12 @@ class Project(BaseConfigurableModel, BaseModel):
         Checks if the chat summary feature is enabled for this project.
 
         The feature is enabled if:
-        1. `settings.AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS` is True, or
-        2. The project-specific configuration "has_chats_summary" is True.
+        1. `Project.is_chats_summary_enabled` is True, or
 
         Returns:
             bool: True if chat summary is enabled, False otherwise.
         """
-        return settings.AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS or self.get_config(
-            "has_chats_summary", False
-        )
+        return self.is_chats_summary_enabled
 
     def is_admin(self, user):
         return self.permissions.filter(

--- a/chats/apps/projects/models/models.py
+++ b/chats/apps/projects/models/models.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import (
     MultipleObjectsReturned,

--- a/chats/apps/projects/tests/test_models.py
+++ b/chats/apps/projects/tests/test_models.py
@@ -1,6 +1,5 @@
 import uuid
 from django.db import IntegrityError
-from django.test import override_settings
 from rest_framework.test import APITestCase
 
 from chats.apps.csat.models import CSATFlowProjectConfig
@@ -105,97 +104,37 @@ class PropertyTests(APITestCase):
         user_permission = self.project_permission.is_manager(sector=self.sector)
         self.assertEqual(user_permission, True)
 
-    @override_settings(AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS=False)
-    def test_has_chats_summary_when_flag_is_not_in_config_and_not_enabled_for_all_projects(
-        self,
-    ):
+    def test_has_chats_summary_returns_true_by_default(self):
         """
-        Verify that `has_chats_summary` returns `False` when the global setting
-        `AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS` is `False` and the project
-        config does not explicitly set `has_chats_summary`.
+        Verify that `has_chats_summary` returns `True` when
+        `is_chats_summary_enabled` uses its default value (`True`).
         """
         project = Project.objects.create(
             name="Test Project",
+        )
+
+        self.assertEqual(project.has_chats_summary, True)
+
+    def test_has_chats_summary_returns_false_when_disabled(self):
+        """
+        Verify that `has_chats_summary` returns `False` when
+        `is_chats_summary_enabled` is explicitly set to `False`.
+        """
+        project = Project.objects.create(
+            name="Test Project",
+            is_chats_summary_enabled=False,
         )
 
         self.assertEqual(project.has_chats_summary, False)
 
-    @override_settings(AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS=False)
-    def test_has_chats_summary_when_flag_is_in_config_and_is_false_when_flag_is_not_enabled_for_all_projects(
-        self,
-    ):
+    def test_has_chats_summary_returns_true_when_enabled(self):
         """
-        Verify that `has_chats_summary` returns `False` when the global setting
-        `AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS` is `False` and the project
-        config explicitly sets `has_chats_summary` to `False`.
-        """
-
-        project = Project.objects.create(
-            name="Test Project",
-            config={"has_chats_summary": False},
-        )
-
-        self.assertEqual(project.has_chats_summary, False)
-
-    @override_settings(AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS=False)
-    def test_has_chats_summary_when_flag_is_in_config_and_is_true_when_flag_is_not_enabled_for_all_projects(
-        self,
-    ):
-        """
-        Verify that `has_chats_summary` returns `True` when the global setting
-        `AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS` is `False` and the project
-        config explicitly sets `has_chats_summary` to `True`.
+        Verify that `has_chats_summary` returns `True` when
+        `is_chats_summary_enabled` is explicitly set to `True`.
         """
         project = Project.objects.create(
             name="Test Project",
-            config={"has_chats_summary": True},
-        )
-
-        self.assertEqual(project.has_chats_summary, True)
-
-    @override_settings(AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS=True)
-    def test_has_chats_summary_when_flag_is_not_in_config_and_flag_is_enabled_for_all_projects(
-        self,
-    ):
-        """
-        Verify that `has_chats_summary` returns `True` when the global setting
-        `AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS` is `True` and the project
-        config does not explicitly set `has_chats_summary`.
-        """
-        project = Project.objects.create(
-            name="Test Project",
-        )
-
-        self.assertEqual(project.has_chats_summary, True)
-
-    @override_settings(AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS=True)
-    def test_has_chats_summary_when_flag_is_in_config_and_is_true_when_flag_is_enabled_for_all_projects(
-        self,
-    ):
-        """
-        Verify that `has_chats_summary` returns `True` when the global setting
-        `AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS` is `True` and the project
-        config explicitly sets `has_chats_summary` to `True`.
-        """
-        project = Project.objects.create(
-            name="Test Project",
-            config={"has_chats_summary": True},
-        )
-
-        self.assertEqual(project.has_chats_summary, True)
-
-    @override_settings(AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS=True)
-    def test_has_chats_summary_when_flag_is_in_config_and_is_false_when_flag_is_enabled_for_all_projects(
-        self,
-    ):
-        """
-        Verify that `has_chats_summary` returns `True` when the global setting
-        `AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS` is `True` and the project
-        config explicitly sets `has_chats_summary` to `False`.
-        """
-        project = Project.objects.create(
-            name="Test Project",
-            config={"has_chats_summary": False},
+            is_chats_summary_enabled=True,
         )
 
         self.assertEqual(project.has_chats_summary, True)


### PR DESCRIPTION
### What

- Added `is_chats_summary_enabled` boolean field to the `Project` model (defaults to `True`) with a corresponding migration.
- Updated `has_chats_summary` property to read from the new `is_chats_summary_enabled` field instead of relying on the `AI_CHAT_SUMMARY_ENABLED_FOR_ALL_PROJECTS` environment variable and the `has_chats_summary` project config key.
- Exposed `is_chats_summary_enabled` in `ProjectSerializer` as a read-only field.
- Simplified tests to cover the new field-based logic, removing all `@override_settings` usages.
- Removed the now-unused `django.conf.settings` import from the model module.

### Why

This moves the chat summary enablement source of truth from an environment variable / project config combination to a dedicated database field on the `Project` model. Having a first-class field makes the flag queryable, easier to manage per project, and visible through the API. A follow-up PR will update the remaining flag logic to fully deprecate the environment variable and config-based approach.