### PR TITLE
feat: Add list_channels method to ConnectRESTClient with tests

### DIFF
--- a/chats/apps/api/v1/internal/rest_clients/connect_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/connect_rest_client.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 import requests
 from django.conf import settings
 
@@ -37,4 +39,21 @@ class ConnectRESTClient(InternalAuthentication):
             params=params,
         )
 
+        return response
+
+    def list_channels(
+        self,
+        project_uuid: UUID,
+        channel_type: str,
+        exclude_wpp_demo: bool = None,
+    ):
+        params = {"project_uuid": str(project_uuid), "channel_type": channel_type}
+        if exclude_wpp_demo is not None:
+            params["exclude_wpp_demo"] = exclude_wpp_demo
+
+        response = requests.get(
+            url=f"{self.base_url}/v2/projects/channels",
+            headers=self.headers,
+            params=params,
+        )
         return response

--- a/chats/apps/api/v1/internal/rest_clients/connect_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/connect_rest_client.py
@@ -46,10 +46,14 @@ class ConnectRESTClient(InternalAuthentication):
         project_uuid: UUID,
         channel_type: str,
         exclude_wpp_demo: bool = None,
+        **kwargs,
     ):
         params = {"project_uuid": str(project_uuid), "channel_type": channel_type}
         if exclude_wpp_demo is not None:
             params["exclude_wpp_demo"] = exclude_wpp_demo
+        params.update(
+            {key: value for key, value in kwargs.items() if value is not None}
+        )
 
         response = requests.get(
             url=f"{self.base_url}/v2/projects/channels",

--- a/chats/apps/api/v1/internal/rest_clients/tests/test_connect_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/tests/test_connect_rest_client.py
@@ -91,3 +91,41 @@ class TestListChannels(TestCase):
 
         called_params = mock_get.call_args.kwargs["params"]
         self.assertNotIn("exclude_wpp_demo", called_params)
+
+    @patch("chats.apps.api.v1.internal.rest_clients.connect_rest_client.requests.get")
+    def test_list_channels_with_additional_query_params(self, mock_get, _mock_token):
+        mock_get.return_value = MagicMock(status_code=200)
+
+        response = self.client_rest.list_channels(
+            project_uuid=self.project_uuid,
+            channel_type="whatsapp",
+            is_active=True,
+            name="my-channel",
+        )
+
+        mock_get.assert_called_once_with(
+            url=f"{CONNECT_BASE_URL}/v2/projects/channels",
+            headers=self.client_rest.headers,
+            params={
+                "project_uuid": str(self.project_uuid),
+                "channel_type": "whatsapp",
+                "is_active": True,
+                "name": "my-channel",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @patch("chats.apps.api.v1.internal.rest_clients.connect_rest_client.requests.get")
+    def test_list_channels_omits_none_kwargs(self, mock_get, _mock_token):
+        mock_get.return_value = MagicMock(status_code=200)
+
+        self.client_rest.list_channels(
+            project_uuid=self.project_uuid,
+            channel_type="whatsapp",
+            is_active=None,
+            name="my-channel",
+        )
+
+        called_params = mock_get.call_args.kwargs["params"]
+        self.assertNotIn("is_active", called_params)
+        self.assertIn("name", called_params)

--- a/chats/apps/api/v1/internal/rest_clients/tests/test_connect_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/tests/test_connect_rest_client.py
@@ -1,0 +1,93 @@
+from uuid import uuid4
+from unittest.mock import patch, MagicMock
+
+from django.test import TestCase, override_settings
+
+from chats.apps.api.v1.internal.rest_clients.connect_rest_client import (
+    ConnectRESTClient,
+)
+
+
+CONNECT_BASE_URL = "https://connect.example.com"
+
+
+@override_settings(CONNECT_API_URL=CONNECT_BASE_URL)
+@patch.object(ConnectRESTClient, "get_module_token", return_value="Bearer fake-token")
+class TestListChannels(TestCase):
+    def setUp(self):
+        self.client_rest = ConnectRESTClient()
+        self.project_uuid = uuid4()
+
+    @patch("chats.apps.api.v1.internal.rest_clients.connect_rest_client.requests.get")
+    def test_list_channels(self, mock_get, _mock_token):
+        mock_get.return_value = MagicMock(status_code=200)
+
+        response = self.client_rest.list_channels(
+            project_uuid=self.project_uuid,
+            channel_type="whatsapp",
+        )
+
+        mock_get.assert_called_once_with(
+            url=f"{CONNECT_BASE_URL}/v2/projects/channels",
+            headers=self.client_rest.headers,
+            params={
+                "project_uuid": str(self.project_uuid),
+                "channel_type": "whatsapp",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @patch("chats.apps.api.v1.internal.rest_clients.connect_rest_client.requests.get")
+    def test_list_channels_with_exclude_wpp_demo(self, mock_get, _mock_token):
+        mock_get.return_value = MagicMock(status_code=200)
+
+        response = self.client_rest.list_channels(
+            project_uuid=self.project_uuid,
+            channel_type="whatsapp",
+            exclude_wpp_demo=True,
+        )
+
+        mock_get.assert_called_once_with(
+            url=f"{CONNECT_BASE_URL}/v2/projects/channels",
+            headers=self.client_rest.headers,
+            params={
+                "project_uuid": str(self.project_uuid),
+                "channel_type": "whatsapp",
+                "exclude_wpp_demo": True,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+
+    @patch("chats.apps.api.v1.internal.rest_clients.connect_rest_client.requests.get")
+    def test_list_channels_exclude_wpp_demo_false(self, mock_get, _mock_token):
+        mock_get.return_value = MagicMock(status_code=200)
+
+        self.client_rest.list_channels(
+            project_uuid=self.project_uuid,
+            channel_type="whatsapp",
+            exclude_wpp_demo=False,
+        )
+
+        mock_get.assert_called_once_with(
+            url=f"{CONNECT_BASE_URL}/v2/projects/channels",
+            headers=self.client_rest.headers,
+            params={
+                "project_uuid": str(self.project_uuid),
+                "channel_type": "whatsapp",
+                "exclude_wpp_demo": False,
+            },
+        )
+
+    @patch("chats.apps.api.v1.internal.rest_clients.connect_rest_client.requests.get")
+    def test_list_channels_omits_exclude_wpp_demo_when_none(
+        self, mock_get, _mock_token
+    ):
+        mock_get.return_value = MagicMock(status_code=200)
+
+        self.client_rest.list_channels(
+            project_uuid=self.project_uuid,
+            channel_type="whatsapp",
+        )
+
+        called_params = mock_get.call_args.kwargs["params"]
+        self.assertNotIn("exclude_wpp_demo", called_params)


### PR DESCRIPTION
### What

Add a new `list_channels` method to `ConnectRESTClient` that queries the Connect API (`GET /v2/projects/channels`) to list channels for a given project, filtered by channel type. The method also supports an optional `exclude_wpp_demo` parameter to exclude WhatsApp demo channels from the results. Unit tests covering all parameter combinations are included.

### Why

The chats-engine needs to retrieve channel information from the Connect service to support features that depend on knowing which channels are available for a project. Exposing this as a method on the existing `ConnectRESTClient` keeps the integration consistent with how other Connect endpoints are consumed internally.