### PR TITLE
feat: Flows templates request

### DIFF
--- a/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
@@ -355,3 +355,24 @@ class FlowRESTClient(
         )
 
         return response
+
+    def get_templates(self, project, **kwargs):
+        params = {
+            key: value for key, value in kwargs.items() if value is not None
+        }
+        response = retry_request_and_refresh_flows_auth_token(
+            project=project,
+            request_method=requests.get,
+            headers=self.project_headers(project.flows_authorization),
+            params=params,
+            url=f"{self.base_url}/api/v2/templates.json",
+        )
+        try:
+            return response.json()
+        except ValueError as e:
+            LOGGER.error(
+                "Failed to parse JSON response from get_templates: %s. Response content: %s",
+                str(e),
+                response.content,
+            )
+            raise

--- a/chats/apps/projects/tests/test_flows_templates_usecases.py
+++ b/chats/apps/projects/tests/test_flows_templates_usecases.py
@@ -1,0 +1,148 @@
+import uuid
+
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from chats.apps.projects.models import Project
+from chats.apps.projects.usecases.flows_templates import FlowsTemplatesUseCase
+
+
+class TestFlowsTemplatesUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            uuid=str(uuid.uuid4()),
+            name="Test Project",
+        )
+        self.use_case = FlowsTemplatesUseCase(project_uuid=str(self.project.uuid))
+        self.mock_flows_client = Mock()
+        self.use_case.flows_client = self.mock_flows_client
+
+        self.template_uuid = str(uuid.uuid4())
+        self.template_name = "Example"
+        self.template_data = {
+            "uuid": self.template_uuid,
+            "name": self.template_name,
+            "category": "MARKETING",
+        }
+
+    def test_found_on_first_page(self):
+        self.mock_flows_client.get_templates.return_value = {
+            "next": None,
+            "previous": None,
+            "results": [self.template_data],
+        }
+
+        result = self.use_case.execute(name=self.template_name, uuid=self.template_uuid)
+
+        self.assertEqual(result, self.template_data)
+        self.mock_flows_client.get_templates.assert_called_once()
+
+    def test_found_on_second_page(self):
+        other_template = {
+            "uuid": str(uuid.uuid4()),
+            "name": "Other",
+        }
+        self.mock_flows_client.get_templates.side_effect = [
+            {
+                "next": "https://flows.example.com/api/v2/templates.json?name=Example&cursor=abc123",
+                "previous": None,
+                "results": [other_template],
+            },
+            {
+                "next": None,
+                "previous": "https://flows.example.com/api/v2/templates.json?cursor=start",
+                "results": [self.template_data],
+            },
+        ]
+
+        result = self.use_case.execute(name=self.template_name, uuid=self.template_uuid)
+
+        self.assertEqual(result, self.template_data)
+        self.assertEqual(self.mock_flows_client.get_templates.call_count, 2)
+
+        second_call_kwargs = self.mock_flows_client.get_templates.call_args_list[1]
+        self.assertEqual(second_call_kwargs.kwargs.get("cursor"), "abc123")
+        self.assertEqual(second_call_kwargs.kwargs.get("name"), "Example")
+
+    def test_not_found_single_page(self):
+        other_template = {
+            "uuid": str(uuid.uuid4()),
+            "name": "Other",
+        }
+        self.mock_flows_client.get_templates.return_value = {
+            "next": None,
+            "previous": None,
+            "results": [other_template],
+        }
+
+        result = self.use_case.execute(name=self.template_name, uuid=self.template_uuid)
+
+        self.assertIsNone(result)
+        self.mock_flows_client.get_templates.assert_called_once()
+
+    def test_not_found_multiple_pages_exhausted(self):
+        self.mock_flows_client.get_templates.side_effect = [
+            {
+                "next": "https://flows.example.com/api/v2/templates.json?cursor=page2",
+                "previous": None,
+                "results": [{"uuid": str(uuid.uuid4()), "name": "A"}],
+            },
+            {
+                "next": "https://flows.example.com/api/v2/templates.json?cursor=page3",
+                "previous": None,
+                "results": [{"uuid": str(uuid.uuid4()), "name": "B"}],
+            },
+            {
+                "next": None,
+                "previous": None,
+                "results": [{"uuid": str(uuid.uuid4()), "name": "C"}],
+            },
+        ]
+
+        result = self.use_case.execute(name=self.template_name, uuid=self.template_uuid)
+
+        self.assertIsNone(result)
+        self.assertEqual(self.mock_flows_client.get_templates.call_count, 3)
+
+    def test_name_matches_but_uuid_does_not(self):
+        wrong_uuid_template = {
+            "uuid": str(uuid.uuid4()),
+            "name": self.template_name,
+        }
+        self.mock_flows_client.get_templates.return_value = {
+            "next": None,
+            "previous": None,
+            "results": [wrong_uuid_template],
+        }
+
+        result = self.use_case.execute(name=self.template_name, uuid=self.template_uuid)
+
+        self.assertIsNone(result)
+
+    def test_uuid_matches_but_name_does_not(self):
+        wrong_name_template = {
+            "uuid": self.template_uuid,
+            "name": "Wrong Name",
+        }
+        self.mock_flows_client.get_templates.return_value = {
+            "next": None,
+            "previous": None,
+            "results": [wrong_name_template],
+        }
+
+        result = self.use_case.execute(name=self.template_name, uuid=self.template_uuid)
+
+        self.assertIsNone(result)
+
+    def test_empty_results_list(self):
+        self.mock_flows_client.get_templates.return_value = {
+            "next": None,
+            "previous": None,
+            "results": [],
+        }
+
+        result = self.use_case.execute(name=self.template_name, uuid=self.template_uuid)
+
+        self.assertIsNone(result)
+        self.mock_flows_client.get_templates.assert_called_once()

--- a/chats/apps/projects/usecases/flows_templates.py
+++ b/chats/apps/projects/usecases/flows_templates.py
@@ -1,0 +1,44 @@
+import logging
+from urllib.parse import urlparse, parse_qs
+
+from django.conf import settings
+from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
+from chats.apps.projects.models import Project
+
+logger = logging.getLogger(__name__)
+
+MAX_PAGES = settings.FLOWS_TEMPLATES_MAX_PAGES
+
+
+class FlowsTemplatesUseCase:
+    def __init__(self, project_uuid):
+        self.project_uuid = project_uuid
+        self.flows_client = FlowRESTClient()
+
+    def _parse_next_url(self, next_url):
+        parsed = urlparse(next_url)
+        params = {
+            key: value[0] if len(value) == 1 else value
+            for key, value in parse_qs(parsed.query).items()
+        }
+        return params
+
+    def execute(self, name, uuid):
+        project = Project.objects.get(uuid=self.project_uuid)
+        extra_kwargs = {
+            "name": name,
+            "uuid": uuid,
+        }
+
+        for _ in range(MAX_PAGES):
+            response = self.flows_client.get_templates(project, **extra_kwargs)
+
+            for template in response.get("results", []):
+                if template.get("name") == name and template.get("uuid") == uuid:
+                    return template
+
+            next_url = response.get("next")
+            if not next_url:
+                return None
+
+            extra_kwargs = self._parse_next_url(next_url)

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -819,3 +819,6 @@ META_GRAPH_API_BASE_HOST_URL = env.str(
     "META_GRAPH_API_BASE_HOST_URL", default="https://graph.facebook.com"
 )
 WHATSAPP_API_ACCESS_TOKEN = env.str("WHATSAPP_API_ACCESS_TOKEN", default="")
+
+# Flows Templates
+FLOWS_TEMPLATES_MAX_PAGES = env.int("FLOWS_TEMPLATES_MAX_PAGES", default=10)


### PR DESCRIPTION
### What
- Added a `get_templates` method to `FlowRESTClient` that fetches templates from the Flows API (`/api/v2/templates.json`), with support for arbitrary query parameters and JSON response parsing with error logging.
- Created `FlowsTemplatesUseCase` that retrieves a specific flow template by `name` and `uuid`, handling cursor-based pagination across multiple pages with a configurable max page limit (`FLOWS_TEMPLATES_MAX_PAGES`).
- Added the `FLOWS_TEMPLATES_MAX_PAGES` setting (default: 10) to control pagination depth.
- Added comprehensive unit tests covering: template found on first page, found on second page, not found (single and multiple pages), name/uuid mismatch scenarios, and empty results.

### Why
- A use case is needed to look up specific flow templates from the Flows service by name and UUID. Since the Flows API uses cursor-based pagination, the solution must iterate through pages until the matching template is found or all pages are exhausted, with a safety limit to prevent infinite loops.