### PR TITLE
feat: Add flow templates usecase

### DIFF
--- a/chats/apps/projects/dataclass.py
+++ b/chats/apps/projects/dataclass.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass, field
+from typing import List
+from uuid import UUID
+
+
+@dataclass
+class FlowTemplateChannel:
+    uuid: str
+    name: str = ""
+    template_name: str = ""
+
+
+@dataclass
+class FlowTemplate:
+    id: str
+    name: str
+    data: dict
+
+
+@dataclass
+class FlowTemplatesData:
+    uuid: UUID
+    templates: List[FlowTemplate] = field(default_factory=list)

--- a/chats/apps/projects/dataclass.py
+++ b/chats/apps/projects/dataclass.py
@@ -15,6 +15,7 @@ class FlowTemplate:
     id: str
     name: str
     data: dict
+    variables: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
+++ b/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
@@ -6,7 +6,10 @@ from django.test import TestCase
 
 from chats.apps.projects.models import Project
 from chats.apps.projects.dataclass import FlowTemplatesData
-from chats.apps.projects.usecases.exceptions import FlowTemplateNotFound
+from chats.apps.projects.usecases.exceptions import (
+    FlowTemplateChannelsNotFound,
+    FlowTemplateNotFound,
+)
 from chats.apps.projects.usecases.flow_templates import GetFlowTemplatesDataUseCase
 
 
@@ -131,7 +134,6 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
 
         self.assertEqual(result, FlowTemplatesData(uuid=self.flow_uuid, templates=[]))
         self.mock_flows_templates_usecase.execute.assert_not_called()
-        self.mock_channels_usecase.execute.assert_not_called()
         self.mock_meta_client.get_templates_list.assert_not_called()
 
     def test_flow_with_single_template_returns_meta_data(self):
@@ -385,3 +387,15 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         result = self.use_case._extract_templates_from_definition(definition)
 
         self.assertEqual(result, [])
+
+    def test_no_template_channels_found_raises_exception(self):
+        definition = self._make_definition_with_template(
+            self.template_uuid, self.template_name
+        )
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        self.mock_flows_templates_usecase.execute.return_value = None
+        self.mock_channels_usecase.execute.return_value = []
+
+        with self.assertRaises(FlowTemplateChannelsNotFound):
+            self.use_case.execute(flow_uuid=self.flow_uuid)

--- a/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
+++ b/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
@@ -1,0 +1,387 @@
+import uuid
+
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from chats.apps.projects.models import Project
+from chats.apps.projects.dataclass import FlowTemplatesData
+from chats.apps.projects.usecases.exceptions import FlowTemplateNotFound
+from chats.apps.projects.usecases.flow_templates import GetFlowTemplatesDataUseCase
+
+
+class TestGetFlowTemplatesDataUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            uuid=str(uuid.uuid4()),
+            name="Test Project",
+        )
+        self.use_case = GetFlowTemplatesDataUseCase(project_uuid=str(self.project.uuid))
+
+        self.mock_flows_client = Mock()
+        self.mock_flows_templates_usecase = Mock()
+        self.mock_channels_usecase = Mock()
+        self.mock_meta_client = Mock()
+
+        self.use_case.flows_client = self.mock_flows_client
+        self.use_case.flows_templates_usecase = self.mock_flows_templates_usecase
+        self.use_case.channels_usecase = self.mock_channels_usecase
+        self.use_case.meta_client = self.mock_meta_client
+
+        self.flow_uuid = str(uuid.uuid4())
+        self.template_uuid = str(uuid.uuid4())
+        self.template_name = "welcome_message"
+        self.channel_uuid = str(uuid.uuid4())
+        self.waba_id = "111222333444"
+
+    def _make_definition_with_template(self, template_uuid, template_name):
+        return {
+            "flows": [
+                {
+                    "nodes": [
+                        {
+                            "uuid": str(uuid.uuid4()),
+                            "actions": [
+                                {
+                                    "type": "send_msg",
+                                    "uuid": str(uuid.uuid4()),
+                                    "text": "",
+                                    "templating": {
+                                        "uuid": str(uuid.uuid4()),
+                                        "template": {
+                                            "uuid": template_uuid,
+                                            "name": template_name,
+                                        },
+                                        "variables": ["var1"],
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def _make_definition_without_template(self):
+        return {
+            "flows": [
+                {
+                    "nodes": [
+                        {
+                            "uuid": str(uuid.uuid4()),
+                            "actions": [
+                                {
+                                    "type": "set_run_result",
+                                    "uuid": str(uuid.uuid4()),
+                                    "name": "params",
+                                    "value": "@trigger.params",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ]
+        }
+
+    def _make_flows_template_response(self, channel_uuid, channel_name="Channel"):
+        return {
+            "uuid": self.template_uuid,
+            "name": self.template_name,
+            "translations": [
+                {
+                    "language": "por",
+                    "content": "Hello {1}",
+                    "status": "approved",
+                    "channel": {
+                        "uuid": channel_uuid,
+                        "name": channel_name,
+                    },
+                }
+            ],
+        }
+
+    def _make_project_channel(self, channel_uuid, waba_id):
+        return {
+            "uuid": channel_uuid,
+            "name": "WhatsApp Channel",
+            "config": {
+                "wa_waba_id": waba_id,
+                "wa_number": "+5511999999999",
+            },
+            "address": "+5511999999999",
+            "is_active": True,
+        }
+
+    def _make_meta_template(self, template_id="123456", name="welcome_message"):
+        return {
+            "id": template_id,
+            "name": name,
+            "status": "APPROVED",
+            "category": "MARKETING",
+            "language": "pt_BR",
+            "components": [{"type": "BODY", "text": "Hello {1}"}],
+        }
+
+    def test_flow_without_templates_returns_empty_list(self):
+        self.mock_flows_client.retrieve_flow_definitions.return_value = (
+            self._make_definition_without_template()
+        )
+
+        result = self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.assertEqual(result, FlowTemplatesData(uuid=self.flow_uuid, templates=[]))
+        self.mock_flows_templates_usecase.execute.assert_not_called()
+        self.mock_channels_usecase.execute.assert_not_called()
+        self.mock_meta_client.get_templates_list.assert_not_called()
+
+    def test_flow_with_single_template_returns_meta_data(self):
+        definition = self._make_definition_with_template(
+            self.template_uuid, self.template_name
+        )
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        self.mock_flows_templates_usecase.execute.return_value = (
+            self._make_flows_template_response(self.channel_uuid)
+        )
+
+        self.mock_channels_usecase.execute.return_value = [
+            self._make_project_channel(self.channel_uuid, self.waba_id)
+        ]
+
+        meta_template = self._make_meta_template()
+        self.mock_meta_client.get_templates_list.return_value = {
+            "data": [meta_template]
+        }
+
+        result = self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.assertEqual(result.uuid, self.flow_uuid)
+        self.assertEqual(len(result.templates), 1)
+        self.assertEqual(result.templates[0].id, meta_template["id"])
+        self.assertEqual(result.templates[0].name, meta_template["name"])
+        self.assertEqual(result.templates[0].data, meta_template)
+
+    def test_flow_with_multiple_templates_deduplicates_by_uuid(self):
+        definition = {
+            "flows": [
+                {
+                    "nodes": [
+                        {
+                            "uuid": str(uuid.uuid4()),
+                            "actions": [
+                                {
+                                    "type": "send_msg",
+                                    "uuid": str(uuid.uuid4()),
+                                    "text": "",
+                                    "templating": {
+                                        "uuid": str(uuid.uuid4()),
+                                        "template": {
+                                            "uuid": self.template_uuid,
+                                            "name": self.template_name,
+                                        },
+                                        "variables": ["var1"],
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            "uuid": str(uuid.uuid4()),
+                            "actions": [
+                                {
+                                    "type": "send_msg",
+                                    "uuid": str(uuid.uuid4()),
+                                    "text": "",
+                                    "templating": {
+                                        "uuid": str(uuid.uuid4()),
+                                        "template": {
+                                            "uuid": self.template_uuid,
+                                            "name": self.template_name,
+                                        },
+                                        "variables": ["var2"],
+                                    },
+                                }
+                            ],
+                        },
+                    ]
+                }
+            ]
+        }
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        self.mock_flows_templates_usecase.execute.return_value = (
+            self._make_flows_template_response(self.channel_uuid)
+        )
+
+        self.mock_channels_usecase.execute.return_value = [
+            self._make_project_channel(self.channel_uuid, self.waba_id)
+        ]
+
+        meta_template = self._make_meta_template()
+        self.mock_meta_client.get_templates_list.return_value = {
+            "data": [meta_template]
+        }
+
+        self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.mock_flows_templates_usecase.execute.assert_called_once_with(
+            name=self.template_name, uuid=self.template_uuid
+        )
+
+    def test_multiple_channels_same_waba_id_single_meta_call(self):
+        channel_uuid_1 = str(uuid.uuid4())
+        channel_uuid_2 = str(uuid.uuid4())
+        template_uuid_1 = str(uuid.uuid4())
+        template_uuid_2 = str(uuid.uuid4())
+
+        definition = {
+            "flows": [
+                {
+                    "nodes": [
+                        {
+                            "uuid": str(uuid.uuid4()),
+                            "actions": [
+                                {
+                                    "type": "send_msg",
+                                    "uuid": str(uuid.uuid4()),
+                                    "text": "",
+                                    "templating": {
+                                        "uuid": str(uuid.uuid4()),
+                                        "template": {
+                                            "uuid": template_uuid_1,
+                                            "name": self.template_name,
+                                        },
+                                        "variables": [],
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            "uuid": str(uuid.uuid4()),
+                            "actions": [
+                                {
+                                    "type": "send_msg",
+                                    "uuid": str(uuid.uuid4()),
+                                    "text": "",
+                                    "templating": {
+                                        "uuid": str(uuid.uuid4()),
+                                        "template": {
+                                            "uuid": template_uuid_2,
+                                            "name": self.template_name,
+                                        },
+                                        "variables": [],
+                                    },
+                                }
+                            ],
+                        },
+                    ]
+                }
+            ]
+        }
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        self.mock_flows_templates_usecase.execute.side_effect = [
+            {
+                "uuid": template_uuid_1,
+                "name": self.template_name,
+                "translations": [
+                    {
+                        "language": "por",
+                        "status": "approved",
+                        "channel": {"uuid": channel_uuid_1, "name": "Channel 1"},
+                    }
+                ],
+            },
+            {
+                "uuid": template_uuid_2,
+                "name": self.template_name,
+                "translations": [
+                    {
+                        "language": "por",
+                        "status": "approved",
+                        "channel": {"uuid": channel_uuid_2, "name": "Channel 2"},
+                    }
+                ],
+            },
+        ]
+
+        self.mock_channels_usecase.execute.return_value = [
+            self._make_project_channel(channel_uuid_1, self.waba_id),
+            self._make_project_channel(channel_uuid_2, self.waba_id),
+        ]
+
+        meta_template = self._make_meta_template()
+        self.mock_meta_client.get_templates_list.return_value = {
+            "data": [meta_template]
+        }
+
+        result = self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.mock_meta_client.get_templates_list.assert_called_once_with(
+            waba_id=self.waba_id, name=self.template_name
+        )
+        self.assertEqual(len(result.templates), 1)
+
+    def test_template_not_found_in_meta_raises_exception(self):
+        definition = self._make_definition_with_template(
+            self.template_uuid, self.template_name
+        )
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        self.mock_flows_templates_usecase.execute.return_value = (
+            self._make_flows_template_response(self.channel_uuid)
+        )
+
+        self.mock_channels_usecase.execute.return_value = [
+            self._make_project_channel(self.channel_uuid, self.waba_id)
+        ]
+
+        self.mock_meta_client.get_templates_list.return_value = {"data": []}
+
+        with self.assertRaises(FlowTemplateNotFound):
+            self.use_case.execute(flow_uuid=self.flow_uuid)
+
+    @patch("chats.apps.projects.usecases.flow_templates.sentry_sdk.capture_exception")
+    @patch("chats.apps.projects.usecases.flow_templates.logger")
+    def test_template_not_found_logs_and_captures_sentry(
+        self, mock_logger, mock_capture
+    ):
+        definition = self._make_definition_with_template(
+            self.template_uuid, self.template_name
+        )
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        self.mock_flows_templates_usecase.execute.return_value = (
+            self._make_flows_template_response(self.channel_uuid)
+        )
+
+        self.mock_channels_usecase.execute.return_value = [
+            self._make_project_channel(self.channel_uuid, self.waba_id)
+        ]
+
+        self.mock_meta_client.get_templates_list.return_value = {"data": []}
+
+        with self.assertRaises(FlowTemplateNotFound):
+            self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        mock_capture.assert_called_once()
+        mock_logger.error.assert_called_once()
+        call_kwargs = mock_logger.error.call_args
+        self.assertIn("exc_info", call_kwargs.kwargs)
+
+    def test_extract_templates_from_definition_finds_templating_in_actions(self):
+        definition = self._make_definition_with_template(
+            self.template_uuid, self.template_name
+        )
+
+        result = self.use_case._extract_templates_from_definition(definition)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["uuid"], self.template_uuid)
+        self.assertEqual(result[0]["name"], self.template_name)
+
+    def test_extract_templates_ignores_actions_without_templating(self):
+        definition = self._make_definition_without_template()
+
+        result = self.use_case._extract_templates_from_definition(definition)
+
+        self.assertEqual(result, [])

--- a/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
+++ b/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
@@ -37,7 +37,17 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         self.channel_uuid = str(uuid.uuid4())
         self.waba_id = "111222333444"
 
-    def _make_definition_with_template(self, template_uuid, template_name):
+    def _make_definition_with_template(
+        self,
+        template_uuid,
+        template_name,
+        variables=None,
+    ):
+        if variables is None:
+            variables = [
+                "@trigger.params.contactname",
+                "@trigger.params.agentname",
+            ]
         return {
             "flows": [
                 {
@@ -55,7 +65,7 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                                             "uuid": template_uuid,
                                             "name": template_name,
                                         },
-                                        "variables": ["var1"],
+                                        "variables": variables,
                                     },
                                 }
                             ],
@@ -162,6 +172,9 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         self.assertEqual(result.templates[0].id, meta_template["id"])
         self.assertEqual(result.templates[0].name, meta_template["name"])
         self.assertEqual(result.templates[0].data, meta_template)
+        self.assertEqual(
+            result.templates[0].variables, ["contactname", "agentname"]
+        )
 
     def test_flow_with_multiple_templates_deduplicates_by_uuid(self):
         definition = {
@@ -181,7 +194,9 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                                             "uuid": self.template_uuid,
                                             "name": self.template_name,
                                         },
-                                        "variables": ["var1"],
+                                        "variables": [
+                                            "@trigger.params.contactname",
+                                        ],
                                     },
                                 }
                             ],
@@ -199,7 +214,9 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                                             "uuid": self.template_uuid,
                                             "name": self.template_name,
                                         },
-                                        "variables": ["var2"],
+                                        "variables": [
+                                            "@trigger.params.agentname",
+                                        ],
                                     },
                                 }
                             ],
@@ -229,9 +246,8 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
             name=self.template_name, uuid=self.template_uuid
         )
 
-    def test_multiple_channels_same_waba_id_single_meta_call(self):
+    def test_execute_returns_only_first_valid_template(self):
         channel_uuid_1 = str(uuid.uuid4())
-        channel_uuid_2 = str(uuid.uuid4())
         template_uuid_1 = str(uuid.uuid4())
         template_uuid_2 = str(uuid.uuid4())
 
@@ -252,7 +268,9 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                                             "uuid": template_uuid_1,
                                             "name": self.template_name,
                                         },
-                                        "variables": [],
+                                        "variables": [
+                                            "@trigger.params.contactname",
+                                        ],
                                     },
                                 }
                             ],
@@ -268,9 +286,11 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                                         "uuid": str(uuid.uuid4()),
                                         "template": {
                                             "uuid": template_uuid_2,
-                                            "name": self.template_name,
+                                            "name": "other_template",
                                         },
-                                        "variables": [],
+                                        "variables": [
+                                            "@trigger.params.url",
+                                        ],
                                     },
                                 }
                             ],
@@ -281,34 +301,20 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         }
         self.mock_flows_client.retrieve_flow_definitions.return_value = definition
 
-        self.mock_flows_templates_usecase.execute.side_effect = [
-            {
-                "uuid": template_uuid_1,
-                "name": self.template_name,
-                "translations": [
-                    {
-                        "language": "por",
-                        "status": "approved",
-                        "channel": {"uuid": channel_uuid_1, "name": "Channel 1"},
-                    }
-                ],
-            },
-            {
-                "uuid": template_uuid_2,
-                "name": self.template_name,
-                "translations": [
-                    {
-                        "language": "por",
-                        "status": "approved",
-                        "channel": {"uuid": channel_uuid_2, "name": "Channel 2"},
-                    }
-                ],
-            },
-        ]
+        self.mock_flows_templates_usecase.execute.return_value = {
+            "uuid": template_uuid_1,
+            "name": self.template_name,
+            "translations": [
+                {
+                    "language": "por",
+                    "status": "approved",
+                    "channel": {"uuid": channel_uuid_1, "name": "Channel 1"},
+                }
+            ],
+        }
 
         self.mock_channels_usecase.execute.return_value = [
             self._make_project_channel(channel_uuid_1, self.waba_id),
-            self._make_project_channel(channel_uuid_2, self.waba_id),
         ]
 
         meta_template = self._make_meta_template()
@@ -318,10 +324,12 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
 
         result = self.use_case.execute(flow_uuid=self.flow_uuid)
 
+        self.assertEqual(len(result.templates), 1)
+        self.assertEqual(result.templates[0].id, meta_template["id"])
         self.mock_meta_client.get_templates_list.assert_called_once_with(
             waba_id=self.waba_id, name=self.template_name
         )
-        self.assertEqual(len(result.templates), 1)
+        self.mock_flows_templates_usecase.execute.assert_called_once()
 
     def test_template_not_found_in_meta_raises_exception(self):
         definition = self._make_definition_with_template(
@@ -380,6 +388,9 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["uuid"], self.template_uuid)
         self.assertEqual(result[0]["name"], self.template_name)
+        self.assertEqual(
+            result[0]["variables"], ["contactname", "agentname"]
+        )
 
     def test_extract_templates_ignores_actions_without_templating(self):
         definition = self._make_definition_without_template()
@@ -387,6 +398,23 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         result = self.use_case._extract_templates_from_definition(definition)
 
         self.assertEqual(result, [])
+
+    def test_extract_templates_filters_only_trigger_params_variables(self):
+        definition = self._make_definition_with_template(
+            self.template_uuid,
+            self.template_name,
+            variables=[
+                "@trigger.params.contactname",
+                "@(title(contact.name))",
+                "@results.vendedor",
+                "@trigger.params.url",
+            ],
+        )
+
+        result = self.use_case._extract_templates_from_definition(definition)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["variables"], ["contactname", "url"])
 
     def test_no_template_channels_found_raises_exception(self):
         definition = self._make_definition_with_template(

--- a/chats/apps/projects/tests/test_get_project_channels_info_usecase.py
+++ b/chats/apps/projects/tests/test_get_project_channels_info_usecase.py
@@ -1,0 +1,67 @@
+import uuid
+
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from chats.apps.projects.usecases.get_project_channels_info import (
+    GetProjectChannelsInfoUseCase,
+)
+
+
+class TestGetProjectChannelsInfoUseCase(TestCase):
+    def setUp(self):
+        self.project_uuid = str(uuid.uuid4())
+        self.use_case = GetProjectChannelsInfoUseCase(
+            project_uuid=self.project_uuid
+        )
+        self.mock_connect_client = Mock()
+        self.use_case.connect_client = self.mock_connect_client
+
+    def test_returns_channels_list(self):
+        channels = [
+            {
+                "uuid": str(uuid.uuid4()),
+                "name": "Channel 1",
+                "config": {"wa_waba_id": "111"},
+                "address": "+5511999999999",
+                "is_active": True,
+            },
+            {
+                "uuid": str(uuid.uuid4()),
+                "name": "Channel 2",
+                "config": {"wa_waba_id": "222"},
+                "address": "+5511888888888",
+                "is_active": True,
+            },
+        ]
+        mock_response = Mock()
+        mock_response.json.return_value = {"channels": channels}
+        self.mock_connect_client.list_channels.return_value = mock_response
+
+        result = self.use_case.execute()
+
+        self.assertEqual(result, channels)
+        self.assertEqual(len(result), 2)
+
+    def test_empty_channels_returns_empty_list(self):
+        mock_response = Mock()
+        mock_response.json.return_value = {"channels": []}
+        self.mock_connect_client.list_channels.return_value = mock_response
+
+        result = self.use_case.execute()
+
+        self.assertEqual(result, [])
+
+    def test_calls_connect_with_correct_params(self):
+        mock_response = Mock()
+        mock_response.json.return_value = {"channels": []}
+        self.mock_connect_client.list_channels.return_value = mock_response
+
+        self.use_case.execute()
+
+        self.mock_connect_client.list_channels.assert_called_once_with(
+            project_uuid=self.project_uuid,
+            channel_type="WAC",
+            exclude_wpp_demo=True,
+        )

--- a/chats/apps/projects/usecases/exceptions.py
+++ b/chats/apps/projects/usecases/exceptions.py
@@ -28,3 +28,7 @@ class InvalidFeatureVersion(Exception):
 
 class FlowTemplateNotFound(Exception):
     pass
+
+
+class FlowTemplateChannelsNotFound(Exception):
+    pass

--- a/chats/apps/projects/usecases/exceptions.py
+++ b/chats/apps/projects/usecases/exceptions.py
@@ -24,3 +24,7 @@ class InvalidSectorData(Exception):
 
 class InvalidFeatureVersion(Exception):
     pass
+
+
+class FlowTemplateNotFound(Exception):
+    pass

--- a/chats/apps/projects/usecases/flow_templates.py
+++ b/chats/apps/projects/usecases/flow_templates.py
@@ -34,6 +34,8 @@ class GetFlowTemplatesDataUseCase:
         project = Project.objects.get(uuid=self.project_uuid)
         return self.flows_client.retrieve_flow_definitions(project, flow_uuid)
 
+    TRIGGER_PARAMS_PREFIX = "@trigger.params."
+
     def _extract_templates_from_definition(self, definition):
         seen_uuids = set()
         templates_info = []
@@ -56,8 +58,19 @@ class GetFlowTemplatesDataUseCase:
                         continue
 
                     seen_uuids.add(template_uuid)
+
+                    variables = [
+                        var.removeprefix(self.TRIGGER_PARAMS_PREFIX)
+                        for var in templating.get("variables", [])
+                        if var.startswith(self.TRIGGER_PARAMS_PREFIX)
+                    ]
+
                     templates_info.append(
-                        {"uuid": template_uuid, "name": template_name}
+                        {
+                            "uuid": template_uuid,
+                            "name": template_name,
+                            "variables": variables,
+                        }
                     )
 
         return templates_info
@@ -124,9 +137,6 @@ class GetFlowTemplatesDataUseCase:
             for ch in project_channels
         }
 
-        flow_templates = []
-        fetched_waba_template_pairs = set()
-
         for template_info in templates_info:
             template_channels = self._get_template_channels(template_info)
 
@@ -142,20 +152,17 @@ class GetFlowTemplatesDataUseCase:
             if not waba_id:
                 continue
 
-            pair = (waba_id, template_info["name"])
-            if pair in fetched_waba_template_pairs:
-                continue
-            fetched_waba_template_pairs.add(pair)
-
             meta_template = self._fetch_meta_template(
                 waba_id, template_info["name"]
             )
-            flow_templates.append(
-                FlowTemplate(
-                    id=meta_template["id"],
-                    name=meta_template["name"],
-                    data=meta_template,
-                )
+            flow_template = FlowTemplate(
+                id=meta_template["id"],
+                name=meta_template["name"],
+                data=meta_template,
+                variables=template_info.get("variables", []),
+            )
+            return FlowTemplatesData(
+                uuid=flow_uuid, templates=[flow_template]
             )
 
-        return FlowTemplatesData(uuid=flow_uuid, templates=flow_templates)
+        return FlowTemplatesData(uuid=flow_uuid, templates=[])

--- a/chats/apps/projects/usecases/flow_templates.py
+++ b/chats/apps/projects/usecases/flow_templates.py
@@ -1,0 +1,146 @@
+import logging
+
+import sentry_sdk
+
+from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
+from chats.apps.api.v1.internal.rest_clients.meta import MetaGraphAPIClient
+from chats.apps.projects.dataclass import (
+    FlowTemplate,
+    FlowTemplateChannel,
+    FlowTemplatesData,
+)
+from chats.apps.projects.models import Project
+from chats.apps.projects.usecases.exceptions import FlowTemplateNotFound
+from chats.apps.projects.usecases.flows_templates import FlowsTemplatesUseCase
+from chats.apps.projects.usecases.get_project_channels_info import (
+    GetProjectChannelsInfoUseCase,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GetFlowTemplatesDataUseCase:
+    def __init__(self, project_uuid):
+        self.project_uuid = project_uuid
+        self.flows_client = FlowRESTClient()
+        self.flows_templates_usecase = FlowsTemplatesUseCase(project_uuid)
+        self.channels_usecase = GetProjectChannelsInfoUseCase(project_uuid)
+        self.meta_client = MetaGraphAPIClient()
+
+    def _get_flow_definition(self, flow_uuid):
+        project = Project.objects.get(uuid=self.project_uuid)
+        return self.flows_client.retrieve_flow_definitions(project, flow_uuid)
+
+    def _extract_templates_from_definition(self, definition):
+        seen_uuids = set()
+        templates_info = []
+
+        for flow in definition.get("flows", []):
+            for node in flow.get("nodes", []):
+                for action in node.get("actions", []):
+                    templating = action.get("templating")
+                    if not templating:
+                        continue
+
+                    template = templating.get("template", {})
+                    template_uuid = template.get("uuid")
+                    template_name = template.get("name")
+
+                    if not template_uuid or not template_name:
+                        continue
+
+                    if template_uuid in seen_uuids:
+                        continue
+
+                    seen_uuids.add(template_uuid)
+                    templates_info.append(
+                        {"uuid": template_uuid, "name": template_name}
+                    )
+
+        return templates_info
+
+    def _get_template_channels(self, templates_info):
+        channels = []
+
+        for template_info in templates_info:
+            template = self.flows_templates_usecase.execute(
+                name=template_info["name"], uuid=template_info["uuid"]
+            )
+            if not template:
+                continue
+
+            for translation in template.get("translations", []):
+                channel = translation.get("channel")
+                if channel and channel.get("uuid"):
+                    channels.append(
+                        FlowTemplateChannel(
+                            uuid=channel["uuid"],
+                            name=channel.get("name", ""),
+                            template_name=template_info["name"],
+                        )
+                    )
+
+        return channels
+
+    def _resolve_waba_ids(self, template_channels, project_channels):
+        channel_map = {
+            ch["uuid"]: ch.get("config", {}).get("wa_waba_id")
+            for ch in project_channels
+        }
+
+        waba_pairs = set()
+        for template_channel in template_channels:
+            waba_id = channel_map.get(template_channel.uuid)
+            if waba_id:
+                waba_pairs.add((waba_id, template_channel.template_name))
+
+        return waba_pairs
+
+    def _fetch_meta_template(self, waba_id, template_name):
+        response = self.meta_client.get_templates_list(
+            waba_id=waba_id, name=template_name
+        )
+        data = response.get("data", [])
+
+        if not data:
+            exc = FlowTemplateNotFound(
+                f"Template '{template_name}' not found in WABA '{waba_id}'"
+            )
+            logger.error(
+                "Template not found in Meta Graph API: waba_id=%s, name=%s",
+                waba_id,
+                template_name,
+                exc_info=exc,
+            )
+            sentry_sdk.capture_exception(exc)
+            raise exc
+
+        return data[0]
+
+    def execute(self, flow_uuid):
+        definition = self._get_flow_definition(flow_uuid)
+        templates_info = self._extract_templates_from_definition(definition)
+
+        if not templates_info:
+            return FlowTemplatesData(uuid=flow_uuid, templates=[])
+
+        template_channels = self._get_template_channels(templates_info)
+
+        if not template_channels:
+            return FlowTemplatesData(uuid=flow_uuid, templates=[])
+
+        project_channels = self.channels_usecase.execute()
+        waba_pairs = self._resolve_waba_ids(template_channels, project_channels)
+
+        flow_templates = []
+        for waba_id, template_name in waba_pairs:
+            meta_template = self._fetch_meta_template(waba_id, template_name)
+            flow_templates.append(
+                FlowTemplate(
+                    id=meta_template["id"],
+                    name=meta_template["name"],
+                    data=meta_template,
+                )
+            )
+
+        return FlowTemplatesData(uuid=flow_uuid, templates=flow_templates)

--- a/chats/apps/projects/usecases/flow_templates.py
+++ b/chats/apps/projects/usecases/flow_templates.py
@@ -59,8 +59,9 @@ class GetFlowTemplatesDataUseCase:
 
                     seen_uuids.add(template_uuid)
 
+                    prefix_len = len(self.TRIGGER_PARAMS_PREFIX)
                     variables = [
-                        var.removeprefix(self.TRIGGER_PARAMS_PREFIX)
+                        var[prefix_len:]
                         for var in templating.get("variables", [])
                         if var.startswith(self.TRIGGER_PARAMS_PREFIX)
                     ]

--- a/chats/apps/projects/usecases/flow_templates.py
+++ b/chats/apps/projects/usecases/flow_templates.py
@@ -10,7 +10,10 @@ from chats.apps.projects.dataclass import (
     FlowTemplatesData,
 )
 from chats.apps.projects.models import Project
-from chats.apps.projects.usecases.exceptions import FlowTemplateNotFound
+from chats.apps.projects.usecases.exceptions import (
+    FlowTemplateChannelsNotFound,
+    FlowTemplateNotFound,
+)
 from chats.apps.projects.usecases.flows_templates import FlowsTemplatesUseCase
 from chats.apps.projects.usecases.get_project_channels_info import (
     GetProjectChannelsInfoUseCase,
@@ -59,42 +62,33 @@ class GetFlowTemplatesDataUseCase:
 
         return templates_info
 
-    def _get_template_channels(self, templates_info):
+    def _get_template_channels(self, template_info):
+        template = self.flows_templates_usecase.execute(
+            name=template_info["name"], uuid=template_info["uuid"]
+        )
+        if not template:
+            return []
+
         channels = []
-
-        for template_info in templates_info:
-            template = self.flows_templates_usecase.execute(
-                name=template_info["name"], uuid=template_info["uuid"]
-            )
-            if not template:
-                continue
-
-            for translation in template.get("translations", []):
-                channel = translation.get("channel")
-                if channel and channel.get("uuid"):
-                    channels.append(
-                        FlowTemplateChannel(
-                            uuid=channel["uuid"],
-                            name=channel.get("name", ""),
-                            template_name=template_info["name"],
-                        )
+        for translation in template.get("translations", []):
+            channel = translation.get("channel")
+            if channel and channel.get("uuid"):
+                channels.append(
+                    FlowTemplateChannel(
+                        uuid=channel["uuid"],
+                        name=channel.get("name", ""),
+                        template_name=template_info["name"],
                     )
+                )
 
         return channels
 
-    def _resolve_waba_ids(self, template_channels, project_channels):
-        channel_map = {
-            ch["uuid"]: ch.get("config", {}).get("wa_waba_id")
-            for ch in project_channels
-        }
-
-        waba_pairs = set()
+    def _resolve_waba_id(self, template_channels, project_channels_map):
         for template_channel in template_channels:
-            waba_id = channel_map.get(template_channel.uuid)
+            waba_id = project_channels_map.get(template_channel.uuid)
             if waba_id:
-                waba_pairs.add((waba_id, template_channel.template_name))
-
-        return waba_pairs
+                return waba_id
+        return None
 
     def _fetch_meta_template(self, waba_id, template_name):
         response = self.meta_client.get_templates_list(
@@ -124,17 +118,38 @@ class GetFlowTemplatesDataUseCase:
         if not templates_info:
             return FlowTemplatesData(uuid=flow_uuid, templates=[])
 
-        template_channels = self._get_template_channels(templates_info)
-
-        if not template_channels:
-            return FlowTemplatesData(uuid=flow_uuid, templates=[])
-
         project_channels = self.channels_usecase.execute()
-        waba_pairs = self._resolve_waba_ids(template_channels, project_channels)
+        project_channels_map = {
+            ch["uuid"]: ch.get("config", {}).get("wa_waba_id")
+            for ch in project_channels
+        }
 
         flow_templates = []
-        for waba_id, template_name in waba_pairs:
-            meta_template = self._fetch_meta_template(waba_id, template_name)
+        fetched_waba_template_pairs = set()
+
+        for template_info in templates_info:
+            template_channels = self._get_template_channels(template_info)
+
+            if not template_channels:
+                raise FlowTemplateChannelsNotFound(
+                    f"No channels found for template '{template_info['name']}' "
+                    f"in flow '{flow_uuid}'"
+                )
+
+            waba_id = self._resolve_waba_id(
+                template_channels, project_channels_map
+            )
+            if not waba_id:
+                continue
+
+            pair = (waba_id, template_info["name"])
+            if pair in fetched_waba_template_pairs:
+                continue
+            fetched_waba_template_pairs.add(pair)
+
+            meta_template = self._fetch_meta_template(
+                waba_id, template_info["name"]
+            )
             flow_templates.append(
                 FlowTemplate(
                     id=meta_template["id"],

--- a/chats/apps/projects/usecases/get_project_channels_info.py
+++ b/chats/apps/projects/usecases/get_project_channels_info.py
@@ -1,0 +1,17 @@
+from chats.apps.api.v1.internal.rest_clients.connect_rest_client import (
+    ConnectRESTClient,
+)
+
+
+class GetProjectChannelsInfoUseCase:
+    def __init__(self, project_uuid):
+        self.project_uuid = project_uuid
+        self.connect_client = ConnectRESTClient()
+
+    def execute(self):
+        response = self.connect_client.list_channels(
+            project_uuid=self.project_uuid,
+            channel_type="WAC",
+            exclude_wpp_demo=True,
+        )
+        return response.json().get("channels", [])


### PR DESCRIPTION
### What

- Added `GetFlowTemplatesDataUseCase`, a new use case that retrieves WhatsApp message template metadata from Meta's Graph API for templates used within a given flow.
- Introduced `GetProjectChannelsInfoUseCase` to fetch WhatsApp Cloud (WAC) channels associated with a project via the Connect REST client.
- Created data classes (`FlowTemplate`, `FlowTemplateChannel`, `FlowTemplatesData`) to structure flow template data throughout the pipeline.
- Added custom exceptions `FlowTemplateNotFound` and `FlowTemplateChannelsNotFound` for explicit error handling.
- Included comprehensive unit tests for both new use cases covering happy paths, edge cases, deduplication, error handling, and Sentry integration.

### Why

When a flow uses WhatsApp message templates, the system needs to resolve the full template metadata (ID, name, components, status) from Meta's Graph API before it can be used downstream (e.g., for sending messages or displaying template previews). Previously, there was no unified mechanism to extract template references from a flow definition, match them to a project's WhatsApp channels, and fetch the corresponding Meta template data. This use case bridges that gap by orchestrating calls across the Flows API, Connect API, and Meta Graph API into a single cohesive pipeline.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Caller
    participant UseCase as GetFlowTemplatesDataUseCase
    participant FlowsAPI as Flows REST Client
    participant FlowsTemplates as FlowsTemplatesUseCase
    participant ConnectAPI as GetProjectChannelsInfoUseCase
    participant MetaAPI as Meta Graph API Client

    Caller->>UseCase: execute(flow_uuid)
    UseCase->>FlowsAPI: retrieve_flow_definitions(project, flow_uuid)
    FlowsAPI-->>UseCase: Flow definition JSON

    UseCase->>UseCase: _extract_templates_from_definition()
    Note over UseCase: Parse nodes/actions for templating blocks,<br/>deduplicate by UUID, extract @trigger.params.* variables

    alt No templates found
        UseCase-->>Caller: FlowTemplatesData(uuid, templates=[])
    end

    UseCase->>ConnectAPI: execute()
    ConnectAPI-->>UseCase: List of WAC project channels

    loop For each unique template
        UseCase->>FlowsTemplates: execute(name, uuid)
        FlowsTemplates-->>UseCase: Template with translations & channel mappings

        alt No channels found for template
            UseCase-->>Caller: raise FlowTemplateChannelsNotFound
        end

        UseCase->>UseCase: _resolve_waba_id(template_channels, project_channels)
        Note over UseCase: Match template channel UUID<br/>to project channel's wa_waba_id

        UseCase->>MetaAPI: get_templates_list(waba_id, name)
        MetaAPI-->>UseCase: Meta template data

        alt Template not found in Meta
            UseCase->>UseCase: Log error + capture Sentry exception
            UseCase-->>Caller: raise FlowTemplateNotFound
        end

        UseCase-->>Caller: FlowTemplatesData(uuid, templates=[FlowTemplate])
    end
```