### PR TITLE
Feat: add transfer change ticket logic with flows

### DIFF
--- a/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
@@ -10,6 +10,10 @@ from rest_framework import status
 from chats.apps.api.v1.internal.rest_clients.internal_authorization import (
     InternalAuthentication,
 )
+from chats.apps.rooms.exceptions import (
+    FlowsChangeTicketerError,
+    FlowsTicketerNotFoundError,
+)
 from chats.core.requests import get_request_session_with_retries
 
 
@@ -321,6 +325,126 @@ class FlowRESTClient(
             ),
             headers=self.headers,
         )
+
+    def get_ticketer_by_sector(self, sector_uuid: str) -> str:
+        """
+        Discover the Flows ticketer UUID associated with a given sector_uuid.
+
+        Calls GET /api/v2/ticketers.json?sector_uuid=<uuid>. Expects the
+        standard Flows/RapidPro paginated payload (`{"results": [...]}`) and
+        returns the `uuid` field of the first result.
+
+        Raises:
+            FlowsTicketerNotFoundError: if the request fails or no ticketer
+                is returned for the given sector_uuid.
+        """
+        url = f"{self.base_url}/api/v2/ticketers.json"
+
+        headers = {**self.headers, "Accept": "application/json"}
+
+        try:
+            response = requests.get(
+                url,
+                params={"sector_uuid": str(sector_uuid)},
+                headers=headers,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise FlowsTicketerNotFoundError(
+                sector_uuid=str(sector_uuid),
+                message=(
+                    f"Failed to request ticketer for sector {sector_uuid}: {exc}"
+                ),
+            ) from exc
+
+        if response.status_code != status.HTTP_200_OK:
+            raise FlowsTicketerNotFoundError(
+                sector_uuid=str(sector_uuid),
+                message=(
+                    f"[{response.status_code}] Failed to fetch ticketer for "
+                    f"sector {sector_uuid}: {response.content!r}"
+                ),
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise FlowsTicketerNotFoundError(
+                sector_uuid=str(sector_uuid),
+                message=(
+                    f"Invalid JSON response when fetching ticketer for sector "
+                    f"{sector_uuid}: {exc}"
+                ),
+            ) from exc
+
+        results = payload.get("results") or []
+        if not results:
+            raise FlowsTicketerNotFoundError(sector_uuid=str(sector_uuid))
+
+        ticketer_uuid = results[0].get("uuid")
+        if not ticketer_uuid:
+            raise FlowsTicketerNotFoundError(
+                sector_uuid=str(sector_uuid),
+                message=(
+                    f"Ticketer entry for sector {sector_uuid} is missing the "
+                    f"'uuid' field: {results[0]!r}"
+                ),
+            )
+
+        return ticketer_uuid
+
+    def change_ticketer(self, ticket_uuids: list, ticketer_uuid: str):
+        """
+        Move tickets to another ticketer in Flows via ticket_actions.
+
+        Calls POST /api/v2/ticket_actions.json with body:
+            {"tickets": [...], "action": "change_ticketer", "ticketer": "..."}
+
+        Raises:
+            FlowsChangeTicketerError: if the response status is not 2xx.
+        """
+        url = f"{self.base_url}/api/v2/ticket_actions.json"
+
+        body = {
+            "tickets": [str(uuid) for uuid in ticket_uuids],
+            "action": "change_ticketer",
+            "ticketer": str(ticketer_uuid),
+        }
+
+        request_session = get_request_session_with_retries(
+            status_forcelist=[429, 500, 502, 503, 504], method_whitelist=["POST"]
+        )
+
+        try:
+            response = request_session.post(
+                url,
+                data=json.dumps(body, cls=DjangoJSONEncoder),
+                headers={**self.headers, "Accept": "application/json"},
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise FlowsChangeTicketerError(
+                ticket_uuids=body["tickets"],
+                ticketer_uuid=str(ticketer_uuid),
+                message=(
+                    f"Network error calling change_ticketer for tickets "
+                    f"{body['tickets']}: {exc}"
+                ),
+            ) from exc
+
+        if response.status_code not in [
+            status.HTTP_200_OK,
+            status.HTTP_201_CREATED,
+            status.HTTP_204_NO_CONTENT,
+        ]:
+            raise FlowsChangeTicketerError(
+                ticket_uuids=body["tickets"],
+                ticketer_uuid=str(ticketer_uuid),
+                status_code=response.status_code,
+                response_content=response.content.decode(errors="replace"),
+            )
+
+        return response
 
     def create_or_update_flow(self, project: "Project", definition: dict):
         payload = {

--- a/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
@@ -326,28 +326,30 @@ class FlowRESTClient(
             headers=self.headers,
         )
 
-    def get_ticketer_by_sector(self, sector_uuid: str) -> str:
+    def get_ticketer_by_sector(self, project, sector_uuid: str) -> str:
         """
         Discover the Flows ticketer UUID associated with a given sector_uuid.
 
-        Calls GET /api/v2/ticketers.json?sector_uuid=<uuid>. Expects the
-        standard Flows/RapidPro paginated payload (`{"results": [...]}`) and
-        returns the `uuid` field of the first result.
+        Calls GET /api/v2/ticketers.json?sector_uuid=<uuid> using the
+        project-scoped Flows token (`Authorization: Token <project_token>`),
+        with auto-refresh on 401/403. Expects the standard Flows/RapidPro
+        paginated payload (`{"results": [...]}`) and returns the `uuid` field
+        of the first result.
 
         Raises:
             FlowsTicketerNotFoundError: if the request fails or no ticketer
                 is returned for the given sector_uuid.
         """
         url = f"{self.base_url}/api/v2/ticketers.json"
-
-        headers = {**self.headers, "Accept": "application/json"}
+        headers = self.project_headers(project.flows_authorization)
 
         try:
-            response = requests.get(
-                url,
-                params={"sector_uuid": str(sector_uuid)},
+            response = retry_request_and_refresh_flows_auth_token(
+                project=project,
+                request_method=requests.get,
                 headers=headers,
-                timeout=30,
+                url=url,
+                params={"sector_uuid": str(sector_uuid)},
             )
         except requests.RequestException as exc:
             raise FlowsTicketerNotFoundError(
@@ -393,17 +395,20 @@ class FlowRESTClient(
 
         return ticketer_uuid
 
-    def change_ticketer(self, ticket_uuids: list, ticketer_uuid: str):
+    def change_ticketer(self, project, ticket_uuids: list, ticketer_uuid: str):
         """
         Move tickets to another ticketer in Flows via ticket_actions.
 
-        Calls POST /api/v2/ticket_actions.json with body:
+        Calls POST /api/v2/ticket_actions.json using the project-scoped Flows
+        token (`Authorization: Token <project_token>`), with auto-refresh on
+        401/403. Body:
             {"tickets": [...], "action": "change_ticketer", "ticketer": "..."}
 
         Raises:
             FlowsChangeTicketerError: if the response status is not 2xx.
         """
         url = f"{self.base_url}/api/v2/ticket_actions.json"
+        headers = self.project_headers(project.flows_authorization)
 
         body = {
             "tickets": [str(uuid) for uuid in ticket_uuids],
@@ -411,16 +416,13 @@ class FlowRESTClient(
             "ticketer": str(ticketer_uuid),
         }
 
-        request_session = get_request_session_with_retries(
-            status_forcelist=[429, 500, 502, 503, 504], method_whitelist=["POST"]
-        )
-
         try:
-            response = request_session.post(
-                url,
-                data=json.dumps(body, cls=DjangoJSONEncoder),
-                headers={**self.headers, "Accept": "application/json"},
-                timeout=30,
+            response = retry_request_and_refresh_flows_auth_token(
+                project=project,
+                request_method=requests.post,
+                headers=headers,
+                url=url,
+                json=body,
             )
         except requests.RequestException as exc:
             raise FlowsChangeTicketerError(

--- a/chats/apps/api/v1/internal/rest_clients/tests/test_flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/tests/test_flows_rest_client.py
@@ -12,6 +12,9 @@ from chats.apps.rooms.exceptions import (
 )
 
 
+CLIENT_PATH = "chats.apps.api.v1.internal.rest_clients.flows_rest_client"
+
+
 def _build_response(status_code: int, payload=None, raise_on_json: bool = False):
     response = MagicMock()
     response.status_code = status_code
@@ -23,20 +26,20 @@ def _build_response(status_code: int, payload=None, raise_on_json: bool = False)
     return response
 
 
+def _build_project(token: str = "project-token"):
+    project = MagicMock()
+    project.flows_authorization = token
+    return project
+
+
 @override_settings(FLOWS_API_URL="https://flows.test")
 class GetTicketerBySectorTests(TestCase):
     def setUp(self):
-        patcher = patch.object(
-            FlowRESTClient, "headers", new={"Authorization": "Bearer test"}
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
+        self.project = _build_project()
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
-    )
-    def test_returns_uuid_from_first_result(self, mock_get):
-        mock_get.return_value = _build_response(
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_returns_uuid_from_first_result(self, mock_retry):
+        mock_retry.return_value = _build_response(
             200,
             {
                 "results": [
@@ -48,143 +51,121 @@ class GetTicketerBySectorTests(TestCase):
 
         client = FlowRESTClient()
 
-        result = client.get_ticketer_by_sector("sector-uuid")
+        result = client.get_ticketer_by_sector(self.project, "sector-uuid")
 
         self.assertEqual(result, "ticketer-uuid-1")
+        call_kwargs = mock_retry.call_args.kwargs
+        self.assertEqual(call_kwargs["project"], self.project)
+        self.assertEqual(call_kwargs["request_method"], requests.get)
         self.assertEqual(
-            mock_get.call_args.args[0],
+            call_kwargs["url"],
             "https://flows.test/api/v2/ticketers.json",
         )
+        self.assertEqual(call_kwargs["params"], {"sector_uuid": "sector-uuid"})
         self.assertEqual(
-            mock_get.call_args.kwargs["params"],
-            {"sector_uuid": "sector-uuid"},
-        )
-        self.assertIn("Authorization", mock_get.call_args.kwargs["headers"])
-        self.assertEqual(
-            mock_get.call_args.kwargs["headers"]["Accept"],
-            "application/json",
+            call_kwargs["headers"]["Authorization"], "Token project-token"
         )
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
-    )
-    def test_raises_when_results_are_empty(self, mock_get):
-        mock_get.return_value = _build_response(200, {"results": []})
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_raises_when_results_are_empty(self, mock_retry):
+        mock_retry.return_value = _build_response(200, {"results": []})
 
         client = FlowRESTClient()
 
         with self.assertRaises(FlowsTicketerNotFoundError):
-            client.get_ticketer_by_sector("sector-uuid")
+            client.get_ticketer_by_sector(self.project, "sector-uuid")
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
-    )
-    def test_raises_on_non_200_status(self, mock_get):
-        mock_get.return_value = _build_response(500, {"detail": "boom"})
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_raises_on_non_200_status(self, mock_retry):
+        mock_retry.return_value = _build_response(500, {"detail": "boom"})
 
         client = FlowRESTClient()
 
         with self.assertRaises(FlowsTicketerNotFoundError):
-            client.get_ticketer_by_sector("sector-uuid")
+            client.get_ticketer_by_sector(self.project, "sector-uuid")
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
-    )
-    def test_raises_on_invalid_json(self, mock_get):
-        mock_get.return_value = _build_response(200, raise_on_json=True)
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_raises_on_invalid_json(self, mock_retry):
+        mock_retry.return_value = _build_response(200, raise_on_json=True)
 
         client = FlowRESTClient()
 
         with self.assertRaises(FlowsTicketerNotFoundError):
-            client.get_ticketer_by_sector("sector-uuid")
+            client.get_ticketer_by_sector(self.project, "sector-uuid")
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
-    )
-    def test_raises_on_request_exception(self, mock_get):
-        mock_get.side_effect = requests.ConnectionError("network down")
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_raises_on_request_exception(self, mock_retry):
+        mock_retry.side_effect = requests.ConnectionError("network down")
 
         client = FlowRESTClient()
 
         with self.assertRaises(FlowsTicketerNotFoundError):
-            client.get_ticketer_by_sector("sector-uuid")
+            client.get_ticketer_by_sector(self.project, "sector-uuid")
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
-    )
-    def test_raises_when_first_result_has_no_uuid(self, mock_get):
-        mock_get.return_value = _build_response(
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_raises_when_first_result_has_no_uuid(self, mock_retry):
+        mock_retry.return_value = _build_response(
             200, {"results": [{"name": "T1"}]}
         )
 
         client = FlowRESTClient()
 
         with self.assertRaises(FlowsTicketerNotFoundError):
-            client.get_ticketer_by_sector("sector-uuid")
+            client.get_ticketer_by_sector(self.project, "sector-uuid")
 
 
 @override_settings(FLOWS_API_URL="https://flows.test")
 class ChangeTicketerTests(TestCase):
     def setUp(self):
-        patcher = patch.object(
-            FlowRESTClient, "headers", new={"Authorization": "Bearer test"}
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
+        self.project = _build_project()
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client."
-        "get_request_session_with_retries"
-    )
-    def test_posts_change_ticketer_payload(self, mock_session_factory):
-        session = MagicMock()
-        session.post.return_value = _build_response(200, {})
-        mock_session_factory.return_value = session
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_posts_change_ticketer_payload(self, mock_retry):
+        mock_retry.return_value = _build_response(200, {})
 
         client = FlowRESTClient()
 
         client.change_ticketer(
+            project=self.project,
             ticket_uuids=["ticket-1", "ticket-2"],
             ticketer_uuid="ticketer-1",
         )
 
-        url = session.post.call_args.args[0]
-        self.assertEqual(url, "https://flows.test/api/v2/ticket_actions.json")
-        body_kwarg = session.post.call_args.kwargs["data"]
-        self.assertIn('"action": "change_ticketer"', body_kwarg)
-        self.assertIn('"ticketer": "ticketer-1"', body_kwarg)
-        self.assertIn('"ticket-1"', body_kwarg)
-        self.assertIn('"ticket-2"', body_kwarg)
-        headers = session.post.call_args.kwargs["headers"]
-        self.assertEqual(headers["Accept"], "application/json")
-        self.assertIn("Authorization", headers)
+        call_kwargs = mock_retry.call_args.kwargs
+        self.assertEqual(call_kwargs["project"], self.project)
+        self.assertEqual(call_kwargs["request_method"], requests.post)
+        self.assertEqual(
+            call_kwargs["url"],
+            "https://flows.test/api/v2/ticket_actions.json",
+        )
+        self.assertEqual(
+            call_kwargs["json"],
+            {
+                "tickets": ["ticket-1", "ticket-2"],
+                "action": "change_ticketer",
+                "ticketer": "ticketer-1",
+            },
+        )
+        self.assertEqual(
+            call_kwargs["headers"]["Authorization"], "Token project-token"
+        )
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client."
-        "get_request_session_with_retries"
-    )
-    def test_raises_on_non_2xx_response(self, mock_session_factory):
-        session = MagicMock()
-        session.post.return_value = _build_response(400, {"detail": "bad"})
-        mock_session_factory.return_value = session
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_raises_on_non_2xx_response(self, mock_retry):
+        mock_retry.return_value = _build_response(400, {"detail": "bad"})
 
         client = FlowRESTClient()
 
         with self.assertRaises(FlowsChangeTicketerError) as ctx:
-            client.change_ticketer(["t-1"], "ticketer-1")
+            client.change_ticketer(self.project, ["t-1"], "ticketer-1")
 
         self.assertEqual(ctx.exception.status_code, 400)
 
-    @patch(
-        "chats.apps.api.v1.internal.rest_clients.flows_rest_client."
-        "get_request_session_with_retries"
-    )
-    def test_raises_on_request_exception(self, mock_session_factory):
-        session = MagicMock()
-        session.post.side_effect = requests.ConnectionError("boom")
-        mock_session_factory.return_value = session
+    @patch(f"{CLIENT_PATH}.retry_request_and_refresh_flows_auth_token")
+    def test_raises_on_request_exception(self, mock_retry):
+        mock_retry.side_effect = requests.ConnectionError("boom")
 
         client = FlowRESTClient()
 
         with self.assertRaises(FlowsChangeTicketerError):
-            client.change_ticketer(["t-1"], "ticketer-1")
+            client.change_ticketer(self.project, ["t-1"], "ticketer-1")

--- a/chats/apps/api/v1/internal/rest_clients/tests/test_flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/tests/test_flows_rest_client.py
@@ -1,0 +1,192 @@
+from unittest.mock import MagicMock, patch
+
+import requests
+from django.test import TestCase, override_settings
+
+from chats.apps.api.v1.internal.rest_clients.flows_rest_client import (
+    FlowRESTClient,
+)
+from chats.apps.rooms.exceptions import (
+    FlowsChangeTicketerError,
+    FlowsTicketerNotFoundError,
+)
+
+
+def _build_response(status_code: int, payload=None, raise_on_json: bool = False):
+    response = MagicMock()
+    response.status_code = status_code
+    response.content = b"" if payload is None else str(payload).encode()
+    if raise_on_json:
+        response.json.side_effect = ValueError("invalid json")
+    else:
+        response.json.return_value = payload or {}
+    return response
+
+
+@override_settings(FLOWS_API_URL="https://flows.test")
+class GetTicketerBySectorTests(TestCase):
+    def setUp(self):
+        patcher = patch.object(
+            FlowRESTClient, "headers", new={"Authorization": "Bearer test"}
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
+    )
+    def test_returns_uuid_from_first_result(self, mock_get):
+        mock_get.return_value = _build_response(
+            200,
+            {
+                "results": [
+                    {"uuid": "ticketer-uuid-1", "name": "T1"},
+                    {"uuid": "ticketer-uuid-2", "name": "T2"},
+                ]
+            },
+        )
+
+        client = FlowRESTClient()
+
+        result = client.get_ticketer_by_sector("sector-uuid")
+
+        self.assertEqual(result, "ticketer-uuid-1")
+        called_url, _ = mock_get.call_args[0], mock_get.call_args[1]
+        # Validate that request was made to /api/v2/ticketers.json with sector_uuid param
+        self.assertEqual(
+            mock_get.call_args.args[0],
+            "https://flows.test/api/v2/ticketers.json",
+        )
+        self.assertEqual(
+            mock_get.call_args.kwargs["params"],
+            {"sector_uuid": "sector-uuid"},
+        )
+        self.assertIn("Authorization", mock_get.call_args.kwargs["headers"])
+        self.assertEqual(
+            mock_get.call_args.kwargs["headers"]["Accept"],
+            "application/json",
+        )
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
+    )
+    def test_raises_when_results_are_empty(self, mock_get):
+        mock_get.return_value = _build_response(200, {"results": []})
+
+        client = FlowRESTClient()
+
+        with self.assertRaises(FlowsTicketerNotFoundError):
+            client.get_ticketer_by_sector("sector-uuid")
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
+    )
+    def test_raises_on_non_200_status(self, mock_get):
+        mock_get.return_value = _build_response(500, {"detail": "boom"})
+
+        client = FlowRESTClient()
+
+        with self.assertRaises(FlowsTicketerNotFoundError):
+            client.get_ticketer_by_sector("sector-uuid")
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
+    )
+    def test_raises_on_invalid_json(self, mock_get):
+        mock_get.return_value = _build_response(200, raise_on_json=True)
+
+        client = FlowRESTClient()
+
+        with self.assertRaises(FlowsTicketerNotFoundError):
+            client.get_ticketer_by_sector("sector-uuid")
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
+    )
+    def test_raises_on_request_exception(self, mock_get):
+        mock_get.side_effect = requests.ConnectionError("network down")
+
+        client = FlowRESTClient()
+
+        with self.assertRaises(FlowsTicketerNotFoundError):
+            client.get_ticketer_by_sector("sector-uuid")
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client.requests.get"
+    )
+    def test_raises_when_first_result_has_no_uuid(self, mock_get):
+        mock_get.return_value = _build_response(
+            200, {"results": [{"name": "T1"}]}
+        )
+
+        client = FlowRESTClient()
+
+        with self.assertRaises(FlowsTicketerNotFoundError):
+            client.get_ticketer_by_sector("sector-uuid")
+
+
+@override_settings(FLOWS_API_URL="https://flows.test")
+class ChangeTicketerTests(TestCase):
+    def setUp(self):
+        patcher = patch.object(
+            FlowRESTClient, "headers", new={"Authorization": "Bearer test"}
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client."
+        "get_request_session_with_retries"
+    )
+    def test_posts_change_ticketer_payload(self, mock_session_factory):
+        session = MagicMock()
+        session.post.return_value = _build_response(200, {})
+        mock_session_factory.return_value = session
+
+        client = FlowRESTClient()
+
+        client.change_ticketer(
+            ticket_uuids=["ticket-1", "ticket-2"],
+            ticketer_uuid="ticketer-1",
+        )
+
+        url = session.post.call_args.args[0]
+        self.assertEqual(url, "https://flows.test/api/v2/ticket_actions.json")
+        body_kwarg = session.post.call_args.kwargs["data"]
+        self.assertIn('"action": "change_ticketer"', body_kwarg)
+        self.assertIn('"ticketer": "ticketer-1"', body_kwarg)
+        self.assertIn('"ticket-1"', body_kwarg)
+        self.assertIn('"ticket-2"', body_kwarg)
+        headers = session.post.call_args.kwargs["headers"]
+        self.assertEqual(headers["Accept"], "application/json")
+        self.assertIn("Authorization", headers)
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client."
+        "get_request_session_with_retries"
+    )
+    def test_raises_on_non_2xx_response(self, mock_session_factory):
+        session = MagicMock()
+        session.post.return_value = _build_response(400, {"detail": "bad"})
+        mock_session_factory.return_value = session
+
+        client = FlowRESTClient()
+
+        with self.assertRaises(FlowsChangeTicketerError) as ctx:
+            client.change_ticketer(["t-1"], "ticketer-1")
+
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    @patch(
+        "chats.apps.api.v1.internal.rest_clients.flows_rest_client."
+        "get_request_session_with_retries"
+    )
+    def test_raises_on_request_exception(self, mock_session_factory):
+        session = MagicMock()
+        session.post.side_effect = requests.ConnectionError("boom")
+        mock_session_factory.return_value = session
+
+        client = FlowRESTClient()
+
+        with self.assertRaises(FlowsChangeTicketerError):
+            client.change_ticketer(["t-1"], "ticketer-1")

--- a/chats/apps/api/v1/internal/rest_clients/tests/test_flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/tests/test_flows_rest_client.py
@@ -51,8 +51,6 @@ class GetTicketerBySectorTests(TestCase):
         result = client.get_ticketer_by_sector("sector-uuid")
 
         self.assertEqual(result, "ticketer-uuid-1")
-        called_url, _ = mock_get.call_args[0], mock_get.call_args[1]
-        # Validate that request was made to /api/v2/ticketers.json with sector_uuid param
         self.assertEqual(
             mock_get.call_args.args[0],
             "https://flows.test/api/v2/ticketers.json",

--- a/chats/apps/api/v1/rooms/services/bulk_transfer_service.py
+++ b/chats/apps/api/v1/rooms/services/bulk_transfer_service.py
@@ -3,6 +3,7 @@ import time
 from typing import Dict, Optional
 
 from django.conf import settings
+from django.db import transaction
 from django.db.models import QuerySet
 
 from chats.apps.accounts.models import User
@@ -12,6 +13,7 @@ from chats.apps.projects.models.models import ProjectPermission
 from chats.apps.queues.models import Queue
 from chats.apps.queues.utils import start_queue_priority_routing
 from chats.apps.rooms.choices import RoomFeedbackMethods
+from chats.apps.rooms.flows_ticketer_service import change_ticketer_for_room
 from chats.apps.rooms.models import Room
 from chats.apps.rooms.utils import create_transfer_json
 from chats.apps.rooms.views import create_room_feedback_message
@@ -262,6 +264,8 @@ class BulkTransferService:
         old_user = room.user
         old_queue = room.queue
 
+        change_ticketer_for_room(room, str(queue.sector.uuid))
+
         room.user = user
         room.queue = queue
         room.save()
@@ -359,6 +363,8 @@ class BulkTransferService:
     def _transfer_queue(self, room: Room, queue: Queue, user_request: User):
         transfer_user = room.user if room.user else user_request
 
+        change_ticketer_for_room(room, str(queue.sector.uuid))
+
         feedback = create_transfer_json(
             action="transfer",
             from_=transfer_user,
@@ -409,7 +415,8 @@ class BulkTransferService:
         for room in batch:
             try:
                 old_queue_id = room.queue_id
-                self._transfer_room(room, user, queue, user_request)
+                with transaction.atomic():
+                    self._transfer_room(room, user, queue, user_request)
                 result.add_success()
 
                 if old_queue_id:

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -85,9 +85,12 @@ from chats.apps.queues.models import Queue
 from chats.apps.queues.utils import start_queue_priority_routing
 from chats.apps.rooms.choices import RoomFeedbackMethods
 from chats.apps.rooms.exceptions import (
+    FlowsChangeTicketerError,
+    FlowsTicketerNotFoundError,
     MaxPinRoomLimitReachedError,
     RoomIsNotActiveError,
 )
+from chats.apps.rooms.flows_ticketer_service import change_ticketer_for_room
 from chats.apps.rooms.models import Room, RoomNote, RoomPin
 from chats.apps.rooms.services import RoomsReportService
 from chats.apps.rooms.tasks import generate_rooms_report
@@ -447,15 +450,45 @@ class RoomViewset(
         serializer.save()
         serializer.instance.notify_queue("create")
 
+    @transaction.atomic
     def perform_update(self, serializer):
         # TODO Separate this into smaller methods
         old_instance = serializer.instance
         old_user = old_instance.user
         old_user = old_instance.user
+        old_sector_uuid = (
+            str(old_instance.queue.sector.uuid)
+            if old_instance.queue and old_instance.queue.sector
+            else None
+        )
 
         user = self.request.data.get("user_email")
         queue = self.request.data.get("queue_uuid")
         serializer.save()
+
+        if queue:
+            instance = serializer.instance
+            new_sector_uuid = (
+                str(instance.queue.sector.uuid)
+                if instance.queue and instance.queue.sector
+                else None
+            )
+            if new_sector_uuid and new_sector_uuid != old_sector_uuid:
+                try:
+                    change_ticketer_for_room(instance, new_sector_uuid)
+                except (
+                    FlowsTicketerNotFoundError,
+                    FlowsChangeTicketerError,
+                ) as exc:
+                    raise ValidationError(
+                        {
+                            "detail": (
+                                "Could not update the ticketer in Flows. "
+                                "The room transfer was not applied."
+                            ),
+                            "error": str(exc),
+                        }
+                    ) from exc
 
         if not (user or queue):
             return None

--- a/chats/apps/rooms/exceptions.py
+++ b/chats/apps/rooms/exceptions.py
@@ -30,3 +30,41 @@ class RoomIsNotActiveError(ValidationError):
         Returns a dictionary representation of the error.
         """
         return {"code": self.code, "message": self.message}
+
+
+class FlowsTicketerNotFoundError(Exception):
+    """
+    Raised when no ticketer is found in Flows for a given sector.
+    """
+
+    def __init__(self, sector_uuid: str, message: str = ""):
+        self.sector_uuid = sector_uuid
+        self.message = (
+            message
+            or f"No ticketer found in Flows for sector {sector_uuid}"
+        )
+        super().__init__(self.message)
+
+
+class FlowsChangeTicketerError(Exception):
+    """
+    Raised when the Flows ticket_actions/change_ticketer call fails.
+    """
+
+    def __init__(
+        self,
+        ticket_uuids: list,
+        ticketer_uuid: str,
+        status_code: int = None,
+        response_content: str = "",
+        message: str = "",
+    ):
+        self.ticket_uuids = ticket_uuids
+        self.ticketer_uuid = ticketer_uuid
+        self.status_code = status_code
+        self.response_content = response_content
+        self.message = message or (
+            f"Failed to change ticketer to {ticketer_uuid} for tickets "
+            f"{ticket_uuids} (status={status_code}): {response_content}"
+        )
+        super().__init__(self.message)

--- a/chats/apps/rooms/flows_ticketer_service.py
+++ b/chats/apps/rooms/flows_ticketer_service.py
@@ -1,0 +1,99 @@
+"""
+Helper to keep the Flows ticketer in sync when a Room is transferred between
+Sectors. The Flows ticketer is bound to a Sector, so any room transfer that
+changes the destination Sector must also update the ticket's ticketer in
+Flows via POST /api/v2/ticket_actions.json (action=change_ticketer).
+
+Failures are reported to Sentry and re-raised so callers can rollback the
+local transfer (the local change is only valid if Flows accepts the move).
+"""
+
+import logging
+
+from django.conf import settings
+from sentry_sdk import capture_exception
+
+from chats.apps.api.v1.internal.rest_clients.flows_rest_client import (
+    FlowRESTClient,
+)
+from chats.apps.rooms.exceptions import (
+    FlowsChangeTicketerError,
+    FlowsTicketerNotFoundError,
+)
+from chats.apps.rooms.models import Room
+
+logger = logging.getLogger(__name__)
+
+
+def change_ticketer_for_room(
+    room: Room, destination_sector_uuid: str
+) -> None:
+    """
+    Ensure the Flows ticketer for `room` matches `destination_sector_uuid`.
+
+    No-ops when:
+      - `settings.USE_WENI_FLOWS` is False;
+      - the room has no `ticket_uuid` (no Flows ticket to migrate);
+      - the destination sector is the same as the current sector.
+
+    On any failure interacting with Flows, the exception is captured in
+    Sentry and re-raised so the caller can rollback the in-progress transfer.
+    """
+    if not getattr(settings, "USE_WENI_FLOWS", False):
+        return
+
+    if not room.ticket_uuid:
+        return
+
+    current_sector_uuid = (
+        str(room.queue.sector.uuid)
+        if room.queue and room.queue.sector
+        else None
+    )
+    destination_sector_uuid = str(destination_sector_uuid)
+
+    if current_sector_uuid == destination_sector_uuid:
+        return
+
+    flows_client = FlowRESTClient()
+
+    try:
+        ticketer_uuid = flows_client.get_ticketer_by_sector(
+            destination_sector_uuid
+        )
+    except FlowsTicketerNotFoundError as exc:
+        logger.error(
+            "[CHANGE_TICKETER] Could not find ticketer for sector %s "
+            "(room=%s, ticket=%s)",
+            destination_sector_uuid,
+            room.uuid,
+            room.ticket_uuid,
+            exc_info=True,
+        )
+        capture_exception(exc)
+        raise
+
+    try:
+        flows_client.change_ticketer(
+            ticket_uuids=[str(room.ticket_uuid)],
+            ticketer_uuid=ticketer_uuid,
+        )
+    except FlowsChangeTicketerError as exc:
+        logger.error(
+            "[CHANGE_TICKETER] Flows rejected change_ticketer for room %s "
+            "(ticket=%s, ticketer=%s)",
+            room.uuid,
+            room.ticket_uuid,
+            ticketer_uuid,
+            exc_info=True,
+        )
+        capture_exception(exc)
+        raise
+
+    logger.info(
+        "[CHANGE_TICKETER] Updated Flows ticketer for room %s "
+        "(ticket=%s, ticketer=%s)",
+        room.uuid,
+        room.ticket_uuid,
+        ticketer_uuid,
+    )

--- a/chats/apps/rooms/flows_ticketer_service.py
+++ b/chats/apps/rooms/flows_ticketer_service.py
@@ -55,11 +55,25 @@ def change_ticketer_for_room(
     if current_sector_uuid == destination_sector_uuid:
         return
 
+    project = (
+        room.queue.sector.project
+        if room.queue and room.queue.sector
+        else None
+    )
+    if project is None:
+        logger.error(
+            "[CHANGE_TICKETER] Cannot resolve project for room %s "
+            "(ticket=%s); skipping Flows ticketer update",
+            room.uuid,
+            room.ticket_uuid,
+        )
+        return
+
     flows_client = FlowRESTClient()
 
     try:
         ticketer_uuid = flows_client.get_ticketer_by_sector(
-            destination_sector_uuid
+            project, destination_sector_uuid
         )
     except FlowsTicketerNotFoundError as exc:
         logger.error(
@@ -75,6 +89,7 @@ def change_ticketer_for_room(
 
     try:
         flows_client.change_ticketer(
+            project=project,
             ticket_uuids=[str(room.ticket_uuid)],
             ticketer_uuid=ticketer_uuid,
         )

--- a/chats/apps/rooms/tests/test_flows_ticketer_service.py
+++ b/chats/apps/rooms/tests/test_flows_ticketer_service.py
@@ -1,0 +1,129 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+from chats.apps.contacts.models import Contact
+from chats.apps.projects.models.models import Project
+from chats.apps.queues.models import Queue
+from chats.apps.rooms.exceptions import (
+    FlowsChangeTicketerError,
+    FlowsTicketerNotFoundError,
+)
+from chats.apps.rooms.flows_ticketer_service import change_ticketer_for_room
+from chats.apps.rooms.models import Room
+from chats.apps.sectors.models import Sector
+
+
+User = get_user_model()
+
+
+HELPER_PATH = "chats.apps.rooms.flows_ticketer_service"
+
+
+class ChangeTicketerForRoomTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Project")
+        self.sector_a = Sector.objects.create(
+            name="Sector A",
+            project=self.project,
+            rooms_limit=5,
+            work_start="00:00",
+            work_end="23:59",
+        )
+        self.sector_b = Sector.objects.create(
+            name="Sector B",
+            project=self.project,
+            rooms_limit=5,
+            work_start="00:00",
+            work_end="23:59",
+        )
+        self.queue_a = Queue.objects.create(name="Q-A", sector=self.sector_a)
+        self.queue_b = Queue.objects.create(name="Q-B", sector=self.sector_b)
+        self.contact = Contact.objects.create(name="Contact")
+        self.room = Room.objects.create(
+            queue=self.queue_a,
+            contact=self.contact,
+            ticket_uuid=uuid.uuid4(),
+            is_active=True,
+        )
+
+    @override_settings(USE_WENI_FLOWS=False)
+    @patch(f"{HELPER_PATH}.FlowRESTClient")
+    def test_noop_when_use_weni_flows_disabled(self, mock_client_cls):
+        change_ticketer_for_room(self.room, str(self.sector_b.uuid))
+
+        mock_client_cls.assert_not_called()
+
+    @override_settings(USE_WENI_FLOWS=True)
+    @patch(f"{HELPER_PATH}.FlowRESTClient")
+    def test_noop_when_room_has_no_ticket_uuid(self, mock_client_cls):
+        self.room.ticket_uuid = None
+        self.room.save()
+
+        change_ticketer_for_room(self.room, str(self.sector_b.uuid))
+
+        mock_client_cls.assert_not_called()
+
+    @override_settings(USE_WENI_FLOWS=True)
+    @patch(f"{HELPER_PATH}.FlowRESTClient")
+    def test_noop_when_destination_sector_is_the_same(self, mock_client_cls):
+        change_ticketer_for_room(self.room, str(self.sector_a.uuid))
+
+        mock_client_cls.assert_not_called()
+
+    @override_settings(USE_WENI_FLOWS=True)
+    @patch(f"{HELPER_PATH}.FlowRESTClient")
+    def test_calls_get_ticketer_then_change_ticketer(self, mock_client_cls):
+        client = MagicMock()
+        client.get_ticketer_by_sector.return_value = "ticketer-uuid"
+        mock_client_cls.return_value = client
+
+        change_ticketer_for_room(self.room, str(self.sector_b.uuid))
+
+        client.get_ticketer_by_sector.assert_called_once_with(
+            str(self.sector_b.uuid)
+        )
+        client.change_ticketer.assert_called_once_with(
+            ticket_uuids=[str(self.room.ticket_uuid)],
+            ticketer_uuid="ticketer-uuid",
+        )
+
+    @override_settings(USE_WENI_FLOWS=True)
+    @patch(f"{HELPER_PATH}.capture_exception")
+    @patch(f"{HELPER_PATH}.FlowRESTClient")
+    def test_get_ticketer_failure_is_captured_and_reraised(
+        self, mock_client_cls, mock_capture
+    ):
+        client = MagicMock()
+        client.get_ticketer_by_sector.side_effect = (
+            FlowsTicketerNotFoundError(sector_uuid=str(self.sector_b.uuid))
+        )
+        mock_client_cls.return_value = client
+
+        with self.assertRaises(FlowsTicketerNotFoundError) as ctx:
+            change_ticketer_for_room(self.room, str(self.sector_b.uuid))
+
+        mock_capture.assert_called_once_with(ctx.exception)
+        client.change_ticketer.assert_not_called()
+
+    @override_settings(USE_WENI_FLOWS=True)
+    @patch(f"{HELPER_PATH}.capture_exception")
+    @patch(f"{HELPER_PATH}.FlowRESTClient")
+    def test_change_ticketer_failure_is_captured_and_reraised(
+        self, mock_client_cls, mock_capture
+    ):
+        client = MagicMock()
+        client.get_ticketer_by_sector.return_value = "ticketer-uuid"
+        client.change_ticketer.side_effect = FlowsChangeTicketerError(
+            ticket_uuids=[str(self.room.ticket_uuid)],
+            ticketer_uuid="ticketer-uuid",
+            status_code=500,
+        )
+        mock_client_cls.return_value = client
+
+        with self.assertRaises(FlowsChangeTicketerError) as ctx:
+            change_ticketer_for_room(self.room, str(self.sector_b.uuid))
+
+        mock_capture.assert_called_once_with(ctx.exception)

--- a/chats/apps/rooms/tests/test_flows_ticketer_service.py
+++ b/chats/apps/rooms/tests/test_flows_ticketer_service.py
@@ -83,9 +83,10 @@ class ChangeTicketerForRoomTests(TestCase):
         change_ticketer_for_room(self.room, str(self.sector_b.uuid))
 
         client.get_ticketer_by_sector.assert_called_once_with(
-            str(self.sector_b.uuid)
+            self.project, str(self.sector_b.uuid)
         )
         client.change_ticketer.assert_called_once_with(
+            project=self.project,
             ticket_uuids=[str(self.room.ticket_uuid)],
             ticketer_uuid="ticketer-uuid",
         )

--- a/chats/apps/rooms/tests/test_transfer_change_ticketer.py
+++ b/chats/apps/rooms/tests/test_transfer_change_ticketer.py
@@ -1,0 +1,230 @@
+"""
+Integration tests for the change_ticketer Flows side-effect triggered by
+room transfer endpoints (PATCH /v1/room/{uuid}/ and POST /v1/room/bulk_transfer/).
+"""
+
+import uuid
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from chats.apps.contacts.models import Contact
+from chats.apps.projects.models.models import Project, ProjectPermission
+from chats.apps.queues.models import Queue, QueueAuthorization
+from chats.apps.rooms.exceptions import (
+    FlowsChangeTicketerError,
+    FlowsTicketerNotFoundError,
+)
+from chats.apps.rooms.models import Room
+from chats.apps.sectors.models import Sector
+
+
+User = get_user_model()
+
+
+CHANGE_TICKETER_VIEWSETS_PATH = (
+    "chats.apps.api.v1.rooms.viewsets.change_ticketer_for_room"
+)
+CHANGE_TICKETER_BULK_PATH = (
+    "chats.apps.api.v1.rooms.services.bulk_transfer_service."
+    "change_ticketer_for_room"
+)
+
+
+class _BaseTransferSetup(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create_user(email="admin@test.com")
+        self.agent = User.objects.create_user(email="agent@test.com")
+        self.contact = Contact.objects.create(name="Contact")
+
+        self.project = Project.objects.create(name="P")
+
+        ProjectPermission.objects.create(
+            user=self.admin,
+            project=self.project,
+            role=ProjectPermission.ROLE_ADMIN,
+        )
+        agent_permission = ProjectPermission.objects.create(
+            user=self.agent,
+            project=self.project,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+
+        self.sector_a = Sector.objects.create(
+            name="A",
+            project=self.project,
+            rooms_limit=5,
+            work_start="00:00",
+            work_end="23:59",
+        )
+        self.sector_b = Sector.objects.create(
+            name="B",
+            project=self.project,
+            rooms_limit=5,
+            work_start="00:00",
+            work_end="23:59",
+        )
+        self.queue_a = Queue.objects.create(name="Q-A", sector=self.sector_a)
+        self.queue_b = Queue.objects.create(name="Q-B", sector=self.sector_b)
+        self.queue_a2 = Queue.objects.create(
+            name="Q-A2", sector=self.sector_a
+        )
+
+        QueueAuthorization.objects.create(
+            permission=agent_permission,
+            queue=self.queue_a,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+        QueueAuthorization.objects.create(
+            permission=agent_permission,
+            queue=self.queue_b,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        self.room = Room.objects.create(
+            queue=self.queue_a,
+            contact=self.contact,
+            user=self.agent,
+            ticket_uuid=uuid.uuid4(),
+            is_active=True,
+        )
+
+        self.client.force_authenticate(user=self.admin)
+
+
+@override_settings(USE_WENI_FLOWS=True)
+class PatchRoomChangeTicketerTests(_BaseTransferSetup):
+    def _patch_room(self, data):
+        url = reverse("room-detail", kwargs={"pk": str(self.room.pk)})
+        return self.client.patch(url, data=data, format="json")
+
+    @patch(CHANGE_TICKETER_VIEWSETS_PATH)
+    def test_change_ticketer_called_when_sector_changes(self, mock_change):
+        response = self._patch_room({"queue_uuid": str(self.queue_b.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_change.assert_called_once()
+        room_arg, sector_arg = mock_change.call_args.args
+        self.assertEqual(room_arg.pk, self.room.pk)
+        self.assertEqual(sector_arg, str(self.sector_b.uuid))
+
+        self.room.refresh_from_db()
+        self.assertEqual(self.room.queue, self.queue_b)
+
+    @patch(CHANGE_TICKETER_VIEWSETS_PATH)
+    def test_change_ticketer_not_called_when_same_sector(self, mock_change):
+        response = self._patch_room({"queue_uuid": str(self.queue_a2.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_change.assert_not_called()
+
+        self.room.refresh_from_db()
+        self.assertEqual(self.room.queue, self.queue_a2)
+
+    @patch(CHANGE_TICKETER_VIEWSETS_PATH)
+    def test_change_ticketer_not_called_for_user_only_transfer(
+        self, mock_change
+    ):
+        response = self._patch_room({"user_email": "agent@test.com"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_change.assert_not_called()
+
+    @patch(CHANGE_TICKETER_VIEWSETS_PATH)
+    def test_flows_failure_rolls_back_transfer(self, mock_change):
+        mock_change.side_effect = FlowsChangeTicketerError(
+            ticket_uuids=[str(self.room.ticket_uuid)],
+            ticketer_uuid="ticketer-uuid",
+            status_code=500,
+        )
+
+        response = self._patch_room({"queue_uuid": str(self.queue_b.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.room.refresh_from_db()
+        # Queue must NOT have changed because of rollback
+        self.assertEqual(self.room.queue, self.queue_a)
+
+    @patch(CHANGE_TICKETER_VIEWSETS_PATH)
+    def test_flows_ticketer_not_found_rolls_back(self, mock_change):
+        mock_change.side_effect = FlowsTicketerNotFoundError(
+            sector_uuid=str(self.sector_b.uuid)
+        )
+
+        response = self._patch_room({"queue_uuid": str(self.queue_b.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.room.refresh_from_db()
+        self.assertEqual(self.room.queue, self.queue_a)
+
+
+@override_settings(USE_WENI_FLOWS=True)
+class BulkTransferChangeTicketerTests(_BaseTransferSetup):
+    def _bulk_transfer(self, data):
+        url = reverse("room-bulk_transfer")
+        return self.client.post(url, data=data, format="json")
+
+    @patch(CHANGE_TICKETER_BULK_PATH)
+    def test_change_ticketer_called_when_sector_changes(self, mock_change):
+        response = self._bulk_transfer(
+            {
+                "rooms_list": [str(self.room.uuid)],
+                "queue_uuid": str(self.queue_b.uuid),
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_change.assert_called_once()
+        room_arg, sector_arg = mock_change.call_args.args
+        self.assertEqual(room_arg.pk, self.room.pk)
+        self.assertEqual(sector_arg, str(self.sector_b.uuid))
+
+        self.room.refresh_from_db()
+        self.assertEqual(self.room.queue, self.queue_b)
+
+    @patch("chats.apps.rooms.models.Room.update_ticket")
+    @patch(CHANGE_TICKETER_BULK_PATH)
+    def test_change_ticketer_not_called_for_user_only_transfer(
+        self, mock_change, _mock_update_ticket
+    ):
+        response = self._bulk_transfer(
+            {
+                "rooms_list": [str(self.room.uuid)],
+                "user_email": "agent@test.com",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_change.assert_not_called()
+
+    @patch(CHANGE_TICKETER_BULK_PATH)
+    def test_flows_failure_rolls_back_room_change(self, mock_change):
+        mock_change.side_effect = FlowsChangeTicketerError(
+            ticket_uuids=[str(self.room.ticket_uuid)],
+            ticketer_uuid="ticketer-uuid",
+            status_code=500,
+        )
+
+        response = self._bulk_transfer(
+            {
+                "rooms_list": [str(self.room.uuid)],
+                "queue_uuid": str(self.queue_b.uuid),
+            }
+        )
+
+        # All-failed bulk transfers respond with 400 (see viewset)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        body = response.json()
+        self.assertEqual(body["success_count"], 0)
+        self.assertEqual(body["failed_count"], 1)
+        self.assertIn(str(self.room.uuid), body["failed_rooms"])
+
+        self.room.refresh_from_db()
+        # Queue must NOT have changed because of rollback
+        self.assertEqual(self.room.queue, self.queue_a)


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Do we need to implement analytics?


### **What**
Adds a new Flows side-effect to every user-facing room transfer endpoint that changes the destination Sector. Whenever a transfer crosses sectors, we now call `POST /api/v2/ticket_actions.json` (action `change_ticketer`) on Flows so the underlying ticket is reattached to the destination sector's ticketer. The Flows ticketer UUID is discovered dynamically via `GET /api/v2/ticketers.json?sector_uuid=<uuid>`.

If the Flows call fails, the local DB transfer is rolled back inside `transaction.atomic`, the exception is captured in Sentry following the project standard (`from sentry_sdk import capture_exception` + `logger.error(..., exc_info=True)`), and the user receives a 4xx/5xx error.

**Affected endpoints:**

| # | Endpoint | Behavior |
|---|---|---|
| A | `PATCH /v1/room/{uuid}/` | Triggers `change_ticketer` only when `queue_uuid` moves the room to a different sector. Failure rolls back the entire transaction and returns `400`. |
| C | `POST /v1/room/bulk_transfer/` | Triggers `change_ticketer` per room when the destination queue is in a different sector. Failure marks the room in `result.failed_rooms` and rolls back its DB changes. |
| E | `DELETE /v1/queue/{uuid}/?transfer_to_queue=...` | Inherits the new behavior because it delegates to `BulkTransferService`. |
| F | `DELETE /v1/sector/{uuid}/?transfer_to_queue=...` | Same as above; by design the destination queue is always in another sector, so `change_ticketer` always runs. |

**Out of scope (intentionally not changed):**
- `pick_queue_room` and `bulk_take` — they only assign a user, never change queue/sector.
- External Flows endpoints (`RoomFlowViewSet`, `RoomUserExternalViewSet`).
- Internal automatic routing (`QueueRouterService.route_rooms`) and the `requeue_agent_rooms` signal.

**New files**
- `chats/apps/rooms/flows_ticketer_service.py` — orchestration helper `change_ticketer_for_room(room, destination_sector_uuid)` with no-ops for `USE_WENI_FLOWS=False`, missing `ticket_uuid`, or unchanged sector.
- `chats/apps/api/v1/internal/rest_clients/tests/test_flows_rest_client.py` — 9 unit tests for the new client methods.
- `chats/apps/rooms/tests/test_flows_ticketer_service.py` — 6 unit tests for the helper.
- `chats/apps/rooms/tests/test_transfer_change_ticketer.py` — 8 integration tests covering both endpoints (success path, no-op cases, rollback on Flows failure).

**Modified files**
- `chats/apps/rooms/exceptions.py` — adds `FlowsTicketerNotFoundError` and `FlowsChangeTicketerError`.
- `chats/apps/api/v1/internal/rest_clients/flows_rest_client.py` — adds `get_ticketer_by_sector(sector_uuid)` and `change_ticketer(ticket_uuids, ticketer_uuid)`.
- `chats/apps/api/v1/rooms/viewsets.py` — wraps `RoomViewset.perform_update` with `@transaction.atomic` and invokes the helper when the sector changes.
- `chats/apps/api/v1/rooms/services/bulk_transfer_service.py` — calls the helper in `_transfer_user_and_queue` and `_transfer_queue` and wraps `_transfer_room` with `transaction.atomic` to guarantee rollback per room.

**Test results**
- 9/9 client tests passing.
- 6/6 helper tests passing.
- 8/8 integration tests passing.
- 62/62 pre-existing `BulkTransferService` tests still passing (no regressions).

### **Why**
Each room transfer in chats-engine has a hard dependency on Flows: the Flows ticketer is bound to a Sector, so when a room moves between sectors the underlying ticket must be reattached to the destination sector's ticketer. Without this synchronization the local DB and Flows drift out of sync — the room appears under a new sector in chats but the ticket still belongs to the original sector in Flows, breaking ticket lookups, attendance metrics, and downstream automations.

This PR makes Flows the source of truth for the transfer outcome: the local change is only persisted if Flows accepts the `change_ticketer` action; otherwise we fail loud (rollback + Sentry + user-facing error) instead of silently committing an inconsistent state.


### **Architecture diagram**

```mermaid
flowchart TD
    Client[Client request]

    Client -->|PATCH /v1/room/uuid/| PatchRoom[RoomViewset.perform_update]
    Client -->|POST /v1/room/bulk_transfer/| BulkTransfer[BulkTransferService.transfer]
    Client -->|DELETE /v1/queue/uuid/| DelQueue[QueueViewset.destroy]
    Client -->|DELETE /v1/sector/uuid/| DelSector[SectorViewset.destroy]

    DelQueue --> BulkTransfer
    DelSector --> BulkTransfer

    PatchRoom --> Atomic1[transaction.atomic]
    BulkTransfer --> Atomic2[transaction.atomic per room]

    Atomic1 --> SectorCheck1{Sector destino<br/>!= Sector atual?}
    Atomic2 --> SectorCheck2{Sector destino<br/>!= Sector atual?}

    SectorCheck1 -- No --> Persist1[Persist local change]
    SectorCheck2 -- No --> Persist2[Persist local change]

    SectorCheck1 -- Yes --> Helper[change_ticketer_for_room]
    SectorCheck2 -- Yes --> Helper

    Helper --> GetTicketer["FlowRESTClient.get_ticketer_by_sector<br/>GET /api/v2/ticketers.json?sector_uuid="]
    GetTicketer -- ok --> ChangeTicketer["FlowRESTClient.change_ticketer<br/>POST /api/v2/ticket_actions.json"]

    GetTicketer -- error --> Capture[capture_exception + logger.error]
    ChangeTicketer -- error --> Capture
    ChangeTicketer -- 2xx --> Persist1
    ChangeTicketer -- 2xx --> Persist2

    Capture --> Rollback[Rollback transaction]
    Rollback --> ErrorResp[Return 4xx/5xx<br/>or mark room as failed]
```
