### PR TITLE
chore: Remove cooldown feature flag

### DIFF
--- a/chats/apps/queues/tasks.py
+++ b/chats/apps/queues/tasks.py
@@ -3,7 +3,6 @@ from uuid import UUID
 
 from django.conf import settings
 from django.core.cache import cache
-from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from chats.apps.queues.models import Queue
 from chats.apps.queues.services import QueueRouterService
@@ -40,46 +39,36 @@ def route_queue_rooms(queue_uuid: UUID):
         logger.info("[route_queue_rooms] Queue not found for UUID: %s", queue_uuid)
         return
 
-    try:
-        cooldown_feature_flag_active = is_feature_active_for_attributes(
-            settings.ROUTE_QUEUE_COOLDOWN_FEATURE_FLAG_KEY,
-            {"projectUUID": str(queue.sector.project.uuid)},
-        )
-    except Exception as e:
-        logger.error("[route_queue_rooms] Error checking cooldown feature flag: %s", e)
-        cooldown_feature_flag_active = False
-
     lock_key = get_route_lock_key_for_queue(queue.uuid)
     pending_key = get_route_pending_key_for_queue(queue_uuid)
 
-    if cooldown_feature_flag_active:
-        acquired = cache.add(
-            lock_key, True, timeout=settings.ROUTE_QUEUE_COOLDOWN_MAX_TIME
+    acquired = cache.add(
+        lock_key, True, timeout=settings.ROUTE_QUEUE_COOLDOWN_MAX_TIME
+    )
+    if not acquired:
+        logger.info(
+            "[route_queue_rooms] Route queue rooms cooldown is active for queue %s. "
+            "Skipping routing for now.",
+            queue.uuid,
         )
-        if not acquired:
+        already_pending = not cache.add(
+            pending_key, True, timeout=settings.ROUTE_QUEUE_COOLDOWN_RETRY_DELAY
+        )
+        if not already_pending:
+            route_queue_rooms.apply_async(
+                args=[queue_uuid],
+                countdown=settings.ROUTE_QUEUE_COOLDOWN_RETRY_DELAY,
+            )
             logger.info(
-                "[route_queue_rooms] Route queue rooms cooldown is active for queue %s. "
-                "Skipping routing for now.",
+                "[route_queue_rooms] Scheduled deferred route_queue_rooms for queue %s",
                 queue.uuid,
             )
-            already_pending = not cache.add(
-                pending_key, True, timeout=settings.ROUTE_QUEUE_COOLDOWN_RETRY_DELAY
-            )
-            if not already_pending:
-                route_queue_rooms.apply_async(
-                    args=[queue_uuid],
-                    countdown=settings.ROUTE_QUEUE_COOLDOWN_RETRY_DELAY,
-                )
-                logger.info(
-                    "[route_queue_rooms] Scheduled deferred route_queue_rooms for queue %s",
-                    queue.uuid,
-                )
-            return False
+        return False
+
     try:
         QueueRouterService(queue).route_rooms()
     finally:
-        if cooldown_feature_flag_active:
-            cache.delete(lock_key)
+        cache.delete(lock_key)
     return True
 
 

--- a/chats/apps/queues/tests/test_tasks.py
+++ b/chats/apps/queues/tests/test_tasks.py
@@ -141,11 +141,10 @@ class RouteQueueRoomsCooldownTestCase(TestCase):
             countdown=2,
         )
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
     @patch("chats.apps.queues.tasks.route_queue_rooms.apply_async")
     def test_second_rejected_call_does_not_schedule_duplicate_retry(
-        self, mock_apply_async, mock_service_cls, mock_ff
+        self, mock_apply_async, mock_service_cls
     ):
         cache.set(self._lock_key(self.queue), True, timeout=30)
 
@@ -157,11 +156,10 @@ class RouteQueueRoomsCooldownTestCase(TestCase):
         mock_service_cls.assert_not_called()
         mock_apply_async.assert_called_once()
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
     @patch("chats.apps.queues.tasks.route_queue_rooms.apply_async")
     def test_multiple_rejected_calls_schedule_only_one_retry(
-        self, mock_apply_async, mock_service_cls, mock_ff
+        self, mock_apply_async, mock_service_cls
     ):
         cache.set(self._lock_key(self.queue), True, timeout=30)
 
@@ -170,11 +168,10 @@ class RouteQueueRoomsCooldownTestCase(TestCase):
 
         mock_apply_async.assert_called_once()
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
     @patch("chats.apps.queues.tasks.route_queue_rooms.apply_async")
     def test_lock_is_cleared_after_successful_routing(
-        self, mock_apply_async, mock_service_cls, mock_ff
+        self, mock_apply_async, mock_service_cls
     ):
         mock_service = MagicMock()
         mock_service_cls.return_value = mock_service
@@ -183,12 +180,11 @@ class RouteQueueRoomsCooldownTestCase(TestCase):
 
         self.assertIsNone(cache.get(self._lock_key(self.queue)))
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
     @patch("chats.apps.queues.tasks.route_queue_rooms.apply_async")
     @patch("chats.apps.queues.tasks.logger")
     def test_logs_when_cooldown_rejects_and_schedules_retry(
-        self, mock_logger, mock_apply_async, mock_service_cls, mock_ff
+        self, mock_logger, mock_apply_async, mock_service_cls
     ):
         cache.set(self._lock_key(self.queue), True, timeout=30)
 
@@ -205,11 +201,10 @@ class RouteQueueRoomsCooldownTestCase(TestCase):
         )
 
     @override_settings(ROUTE_QUEUE_COOLDOWN_RETRY_DELAY=5)
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
     @patch("chats.apps.queues.tasks.route_queue_rooms.apply_async")
     def test_retry_uses_configured_delay(
-        self, mock_apply_async, mock_service_cls, mock_ff
+        self, mock_apply_async, mock_service_cls
     ):
         cache.set(self._lock_key(self.queue), True, timeout=30)
 
@@ -220,11 +215,10 @@ class RouteQueueRoomsCooldownTestCase(TestCase):
             countdown=5,
         )
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
     @patch("chats.apps.queues.tasks.route_queue_rooms.apply_async")
     def test_different_sectors_have_independent_locks(
-        self, mock_apply_async, mock_service_cls, mock_ff
+        self, mock_apply_async, mock_service_cls
     ):
         other_sector = Sector.objects.create(
             name="Other Sector",
@@ -250,11 +244,10 @@ class RouteQueueRoomsCooldownTestCase(TestCase):
         self.assertTrue(result_unlocked)
         mock_service.route_rooms.assert_called_once()
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
     @patch("chats.apps.queues.tasks.route_queue_rooms.apply_async")
     def test_new_retry_can_be_scheduled_after_successful_routing_clears_lock(
-        self, mock_apply_async, mock_service_cls, mock_ff
+        self, mock_apply_async, mock_service_cls
     ):
         mock_service = MagicMock()
         mock_service_cls.return_value = mock_service

--- a/chats/apps/queues/tests/test_tasks.py
+++ b/chats/apps/queues/tests/test_tasks.py
@@ -16,9 +16,6 @@ from chats.apps.queues.tasks import route_queue_rooms, route_sector_rooms
 from chats.apps.sectors.models import Sector
 
 
-FEATURE_FLAG_PATH = "chats.apps.queues.tasks.is_feature_active_for_attributes"
-
-
 class RouteQueueRoomsTaskTestCase(TestCase):
     def setUp(self):
         self.project = Project.objects.create(
@@ -69,11 +66,8 @@ class RouteQueueRoomsTaskTestCase(TestCase):
             "[route_queue_rooms] Queue not found for UUID: %s", fake_uuid
         )
 
-    @patch(FEATURE_FLAG_PATH, return_value=False)
     @patch("chats.apps.queues.tasks.QueueRouterService")
-    def test_routes_without_cooldown_when_feature_flag_is_off(
-        self, mock_service_cls, mock_ff
-    ):
+    def test_acquires_lock_and_routes(self, mock_service_cls):
         mock_service = MagicMock()
         mock_service_cls.return_value = mock_service
 
@@ -82,22 +76,8 @@ class RouteQueueRoomsTaskTestCase(TestCase):
         self.assertTrue(result)
         mock_service.route_rooms.assert_called_once()
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
-    def test_acquires_lock_and_routes_when_cooldown_is_active(
-        self, mock_service_cls, mock_ff
-    ):
-        mock_service = MagicMock()
-        mock_service_cls.return_value = mock_service
-
-        result = route_queue_rooms(self.queue.uuid)
-
-        self.assertTrue(result)
-        mock_service.route_rooms.assert_called_once()
-
-    @patch(FEATURE_FLAG_PATH, return_value=True)
-    @patch("chats.apps.queues.tasks.QueueRouterService")
-    def test_clears_lock_after_routing(self, mock_service_cls, mock_ff):
+    def test_clears_lock_after_routing(self, mock_service_cls):
         mock_service = MagicMock()
         mock_service_cls.return_value = mock_service
 
@@ -106,9 +86,8 @@ class RouteQueueRoomsTaskTestCase(TestCase):
         lock_key = f"route_queue_rooms_lock:{self.sector.uuid}"
         self.assertIsNone(cache.get(lock_key))
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
-    def test_clears_lock_even_when_routing_raises(self, mock_service_cls, mock_ff):
+    def test_clears_lock_even_when_routing_raises(self, mock_service_cls):
         mock_service = MagicMock()
         mock_service.route_rooms.side_effect = Exception("boom")
         mock_service_cls.return_value = mock_service
@@ -146,11 +125,10 @@ class RouteQueueRoomsCooldownTestCase(TestCase):
     def _lock_key(self, queue):
         return f"route_queue_rooms_lock:{queue.uuid}"
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.tasks.QueueRouterService")
     @patch("chats.apps.queues.tasks.route_queue_rooms.apply_async")
     def test_rejected_call_schedules_deferred_retry(
-        self, mock_apply_async, mock_service_cls, mock_ff
+        self, mock_apply_async, mock_service_cls
     ):
         cache.set(self._lock_key(self.queue), True, timeout=30)
 

--- a/chats/apps/queues/tests/test_utils.py
+++ b/chats/apps/queues/tests/test_utils.py
@@ -1,5 +1,5 @@
 from datetime import time
-from unittest.mock import call, patch
+from unittest.mock import patch
 from django.test import TestCase
 
 from chats.apps.projects.models.models import Project, RoomRoutingType
@@ -9,8 +9,6 @@ from chats.apps.queues.utils import (
     start_queue_priority_routing_for_all_queues_in_project,
 )
 from chats.apps.sectors.models import Sector
-
-FEATURE_FLAG_PATH = "chats.apps.queues.utils.is_feature_active_for_attributes"
 
 
 class StartQueuePriorityRoutingTestCase(TestCase):
@@ -107,29 +105,25 @@ class StartQueuePriorityRoutingForAllQueuesInProjectTestCase(TestCase):
                 )
                 self.queues.append(queue)
 
-    @patch(FEATURE_FLAG_PATH, return_value=False)
-    @patch("chats.apps.queues.utils.logger")
-    @patch("chats.apps.queues.utils.route_queue_rooms")
+    @patch("chats.apps.queues.utils.route_sector_rooms")
     @patch("chats.apps.queues.utils.settings.USE_CELERY", False)
     def test_start_queue_priority_routing_for_all_queues_in_project(
         self,
-        mock_route_queue_rooms,
-        mock_logger,
-        mock_ff,
+        mock_route_sector_rooms,
     ):
-        mock_route_queue_rooms.return_value = None
+        mock_route_sector_rooms.return_value = None
 
         start_queue_priority_routing_for_all_queues_in_project(self.project)
 
-        mock_logger.info.assert_any_call(
-            "[start_queue_priority_routing_for_all_queues_in_project] "
-            "Started routing rooms for all queues in project %s",
-            self.project.uuid,
+        sector_uuids_called = [
+            c.args[0] for c in mock_route_sector_rooms.call_args_list
+        ]
+        expected_sector_uuids = list(
+            Queue.objects.filter(sector__project=self.project)
+            .values_list("sector__uuid", flat=True)
+            .distinct()
         )
-
-        mock_route_queue_rooms.assert_has_calls(
-            [call(queue.uuid) for queue in self.queues]
-        )
+        self.assertEqual(sorted(sector_uuids_called), sorted(expected_sector_uuids))
 
     @patch("chats.apps.queues.utils.logger")
     @patch("chats.apps.queues.utils.route_queue_rooms")
@@ -152,31 +146,11 @@ class StartQueuePriorityRoutingForAllQueuesInProjectTestCase(TestCase):
             self.project.uuid,
         )
 
-    @patch(FEATURE_FLAG_PATH, return_value=False)
-    @patch("chats.apps.queues.utils.logger")
-    @patch("chats.apps.queues.utils.route_queue_rooms")
-    @patch("chats.apps.queues.utils.settings.USE_CELERY", False)
-    def test_uses_per_queue_path_when_feature_flag_is_off(
-        self,
-        mock_route_queue_rooms,
-        mock_logger,
-        mock_ff,
-    ):
-        mock_route_queue_rooms.return_value = None
-
-        start_queue_priority_routing_for_all_queues_in_project(self.project)
-
-        mock_route_queue_rooms.assert_has_calls(
-            [call(queue.uuid) for queue in self.queues]
-        )
-
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.utils.route_sector_rooms")
     @patch("chats.apps.queues.utils.settings.USE_CELERY", False)
-    def test_uses_sector_path_when_feature_flag_is_on_sync(
+    def test_routes_by_sector_sync(
         self,
         mock_route_sector_rooms,
-        mock_ff,
     ):
         mock_route_sector_rooms.return_value = None
 
@@ -192,13 +166,11 @@ class StartQueuePriorityRoutingForAllQueuesInProjectTestCase(TestCase):
         )
         self.assertEqual(sorted(sector_uuids_called), sorted(expected_sector_uuids))
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.utils.route_sector_rooms")
     @patch("chats.apps.queues.utils.settings.USE_CELERY", True)
-    def test_uses_sector_path_when_feature_flag_is_on_async(
+    def test_routes_by_sector_async(
         self,
         mock_route_sector_rooms,
-        mock_ff,
     ):
         mock_route_sector_rooms.delay.return_value = None
 
@@ -214,15 +186,13 @@ class StartQueuePriorityRoutingForAllQueuesInProjectTestCase(TestCase):
         )
         self.assertEqual(sorted(sector_uuids_called), sorted(expected_sector_uuids))
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.utils.route_sector_rooms")
     @patch("chats.apps.queues.utils.route_queue_rooms")
     @patch("chats.apps.queues.utils.settings.USE_CELERY", False)
-    def test_sector_path_does_not_call_per_queue_routing(
+    def test_does_not_call_per_queue_routing(
         self,
         mock_route_queue_rooms,
         mock_route_sector_rooms,
-        mock_ff,
     ):
         mock_route_sector_rooms.return_value = None
 
@@ -230,15 +200,13 @@ class StartQueuePriorityRoutingForAllQueuesInProjectTestCase(TestCase):
 
         mock_route_queue_rooms.assert_not_called()
 
-    @patch(FEATURE_FLAG_PATH, return_value=True)
     @patch("chats.apps.queues.utils.logger")
     @patch("chats.apps.queues.utils.route_sector_rooms")
     @patch("chats.apps.queues.utils.settings.USE_CELERY", False)
-    def test_sector_path_logs_sector_count(
+    def test_logs_sector_count(
         self,
         mock_route_sector_rooms,
         mock_logger,
-        mock_ff,
     ):
         mock_route_sector_rooms.return_value = None
 

--- a/chats/apps/queues/utils.py
+++ b/chats/apps/queues/utils.py
@@ -3,8 +3,6 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 
-from weni.feature_flags.shortcuts import is_feature_active_for_attributes
-
 from chats.apps.projects.models.models import Project
 from chats.apps.queues.models import Queue
 from chats.apps.queues.tasks import route_queue_rooms, route_sector_rooms
@@ -48,9 +46,8 @@ def start_queue_priority_routing_for_all_queues_in_project(project: Project):
     """
     Start routing rooms for all queues in a project, if the project is configured to use priority routing.
 
-    When the cooldown feature flag is active, routes are grouped by sector
-    so that all queues in a sector are routed under a single lock acquisition,
-    preventing accidental queue prioritization.
+    Routes are grouped by sector so that all queues in a sector are routed
+    under a single lock acquisition, preventing accidental queue prioritization.
     """
     if not project.use_queue_priority_routing:
         logger.info(
@@ -60,60 +57,24 @@ def start_queue_priority_routing_for_all_queues_in_project(project: Project):
         )
         return
 
-    try:
-        cooldown_feature_flag_active = is_feature_active_for_attributes(
-            settings.ROUTE_QUEUE_COOLDOWN_FEATURE_FLAG_KEY,
-            {"projectUUID": str(project.uuid)},
-        )
-    except Exception as e:
-        logger.error(
-            "[start_queue_priority_routing_for_all_queues_in_project] Error checking cooldown feature flag: %s",
-            e,
-        )
-        cooldown_feature_flag_active = False
-
-    if cooldown_feature_flag_active:
-        logger.info(
-            "[start_queue_priority_routing_for_all_queues_in_project] "
-            "Cooldown feature flag is active for project %s",
-            project.uuid,
-        )
-        sector_uuids = (
-            Queue.objects.filter(sector__project=project)
-            .values_list("sector__uuid", flat=True)
-            .distinct()
-        )
-
-        logger.info(
-            "[start_queue_priority_routing_for_all_queues_in_project] "
-            "Started routing rooms by sector for project %s (%d sectors)",
-            project.uuid,
-            len(sector_uuids),
-        )
-
-        for sector_uuid in sector_uuids:
-            if settings.USE_CELERY:
-                route_sector_rooms.delay(sector_uuid)
-            else:
-                route_sector_rooms(sector_uuid)
-        return
+    sector_uuids = (
+        Queue.objects.filter(sector__project=project)
+        .values_list("sector__uuid", flat=True)
+        .distinct()
+    )
 
     logger.info(
         "[start_queue_priority_routing_for_all_queues_in_project] "
-        "Cooldown feature flag is not active for project %s",
+        "Started routing rooms by sector for project %s (%d sectors)",
         project.uuid,
+        len(sector_uuids),
     )
 
-    queues = Queue.objects.filter(sector__project=project)
-
-    logger.info(
-        "[start_queue_priority_routing_for_all_queues_in_project] "
-        "Started routing rooms for all queues in project %s",
-        project.uuid,
-    )
-
-    for queue in queues:
-        start_queue_priority_routing(queue)
+    for sector_uuid in sector_uuids:
+        if settings.USE_CELERY:
+            route_sector_rooms.delay(sector_uuid)
+        else:
+            route_sector_rooms(sector_uuid)
 
 
 def create_room_assigned_from_queue_feedback(room: "Room", user: "User"):

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -798,12 +798,6 @@ IMPROVE_USER_MESSAGE_FEATURE_PROMPT_CACHE_TTL = env.int(
     "IMPROVE_USER_MESSAGE_FEATURE_PROMPT_CACHE_TTL", default=30
 )
 
-# Route Queue Cooldown Feature Flag
-ROUTE_QUEUE_COOLDOWN_FEATURE_FLAG_KEY = env.str(
-    "ROUTE_QUEUE_COOLDOWN_FEATURE_FLAG_KEY",
-    default="weniChatsRouteQueueCooldown",
-)
-
 NEW_GET_ROOM_USER_FEATURE_FLAG_KEY = env.str(
     "CHATS_NEW_GET_ROOM_USER_FEATURE_FLAG_KEY",
     default="weniChatsNewGetRoomUser",


### PR DESCRIPTION
### What

- Removed the `weni.feature_flags` dependency (`is_feature_active_for_attributes`) from `tasks.py` and `utils.py` in the queues app.
- The route queue cooldown logic (lock acquisition, deferred retry scheduling, lock cleanup) is now always active — no longer gated behind the `ROUTE_QUEUE_COOLDOWN_FEATURE_FLAG_KEY` feature flag.
- Routing in `start_queue_priority_routing_for_all_queues_in_project` now always groups routes by sector instead of conditionally falling back to per-queue routing.
- Removed the `ROUTE_QUEUE_COOLDOWN_FEATURE_FLAG_KEY` setting from `settings.py`.
- Updated all related tests to remove feature flag mocking and deleted tests that only covered the feature-flag-off path (e.g., `test_routes_without_cooldown_when_feature_flag_is_off`, `test_uses_per_queue_path_when_feature_flag_is_off`).

### Why

The route queue cooldown and sector-based routing were behind a feature flag for a gradual rollout. Now that the feature has been validated in production, the flag is no longer needed. Removing it simplifies the routing logic, eliminates an external dependency on the feature flag service in the hot path, and reduces branching complexity in both the code and the test suite.