### PR TITLE
fix: Handle missing project permissions in MessagePermission class

### DIFF
--- a/chats/apps/api/v1/msgs/permissions.py
+++ b/chats/apps/api/v1/msgs/permissions.py
@@ -3,6 +3,7 @@ from rest_framework import permissions
 from rest_framework.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+from chats.apps.projects.models import ProjectPermission
 from chats.apps.rooms.models import Room
 
 
@@ -22,7 +23,10 @@ class MessagePermission(permissions.BasePermission):
             if room.user == user:
                 return True
             project = room.queue.sector.project
-            permission = user.project_permissions.get(project=project)
+            try:
+                permission = user.project_permissions.get(project=project)
+            except ProjectPermission.DoesNotExist:
+                return False
         else:
             project_uuid = request.query_params.get("project")
 

--- a/chats/apps/api/v2/msgs/tests/test_viewsets.py
+++ b/chats/apps/api/v2/msgs/tests/test_viewsets.py
@@ -216,8 +216,7 @@ class TestMessageViewSetV2AsAuthenticatedUser(BaseTestMessageViewSetV2):
         self.client.force_authenticate(user=other_user)
 
         response = self.list({"room": str(self.room.uuid)})
-        # TODO: This should be a 403, fix in the view
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_list_messages_with_media(self):
         """Tests listing messages with media array"""

--- a/chats/apps/sectors/tests/test_viewsets.py
+++ b/chats/apps/sectors/tests/test_viewsets.py
@@ -256,9 +256,10 @@ class RoomsExternalTests(APITestCase):
     def setUp(self) -> None:
         self.queue_1 = Queue.objects.get(uuid="f2519480-7e58-4fc4-9894-9ab1769e29cf")
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=False)
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
-    def test_create_external_room(self, mock_get_room, mock_is_attending):
+    def test_create_external_room(self, mock_get_room, mock_is_attending, _mock_flag):
         mock_get_room.return_value = None
         url = reverse("external_rooms-list")
         client = self.client
@@ -278,10 +279,11 @@ class RoomsExternalTests(APITestCase):
         response = client.post(url, data=data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=False)
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_external_room_with_external_uuid(
-        self, mock_get_room, mock_is_attending
+        self, mock_get_room, mock_is_attending, _mock_flag
     ):
         mock_get_room.return_value = None
         url = reverse("external_rooms-list")
@@ -308,10 +310,11 @@ class RoomsExternalTests(APITestCase):
             "aec9f84e-3dcd-11ed-b878-0242ac190012",
         )
 
+    @patch("chats.apps.api.v1.external.rooms.serializers.is_feature_active", return_value=False)
     @patch("chats.apps.sectors.models.Sector.is_attending", return_value=True)
     @patch("chats.apps.projects.usecases.send_room_info.RoomInfoUseCase.get_room")
     def test_create_external_room_editing_contact(
-        self, mock_get_room, mock_is_attending
+        self, mock_get_room, mock_is_attending, _mock_flag
     ):
         mock_get_room.return_value = None
         url = reverse("external_rooms-list")


### PR DESCRIPTION
### What
Handle missing project permissions in `MessagePermission` by catching `ProjectPermission.DoesNotExist` and returning `False` instead of letting the exception propagate as an unhandled 500 error.

### Why
When a user without a `ProjectPermission` for a given project attempts to access messages in a room, the `user.project_permissions.get(project=project)` call raises a `ProjectPermission.DoesNotExist` exception. This results in an unhandled server error (500) instead of a proper permission denial. Wrapping the call in a try/except ensures the user is gracefully denied access (403) without triggering a server error.