### PR TITLE
chore: add tests for starting flow in ProjectViewset

### DIFF
--- a/chats/apps/api/v1/projects/tests/test_project_viewset_actions.py
+++ b/chats/apps/api/v1/projects/tests/test_project_viewset_actions.py
@@ -1,15 +1,20 @@
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from chats.apps.api.utils import create_user_and_token
 from chats.apps.contacts.models import Contact
-from chats.apps.projects.models.models import Project, ProjectPermission
+from chats.apps.projects.models.models import (
+    ContactGroupFlowReference,
+    FlowStart,
+    Project,
+    ProjectPermission,
+)
 from chats.apps.queues.models import Queue
 from chats.apps.rooms.models import Room
 from chats.apps.sectors.models import Sector
-from chats.apps.api.utils import create_user_and_token
 
 
 class RetrieveFlowWarningTestCase(APITestCase):
@@ -41,7 +46,10 @@ class RetrieveFlowWarningTestCase(APITestCase):
     def test_project_not_found_returns_404(self):
         response = self.client.get(
             self.url,
-            {"project": "00000000-0000-0000-0000-000000000000", "contact": str(self.contact.external_id)},
+            {
+                "project": "00000000-0000-0000-0000-000000000000",
+                "contact": str(self.contact.external_id),
+            },
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertIn("project", response.data)
@@ -116,7 +124,9 @@ class ListUsersTestCase(APITestCase):
             user=self.user,
             role=ProjectPermission.ROLE_ADMIN,
         )
-        self.url = reverse("project-list-users", kwargs={"uuid": str(self.project.uuid)})
+        self.url = reverse(
+            "project-list-users", kwargs={"uuid": str(self.project.uuid)}
+        )
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
 
     def test_list_users_returns_project_permissions(self):
@@ -150,7 +160,9 @@ class SetProjectAsPrincipalTestCase(APITestCase):
         self.user, self.token = create_user_and_token("principaluser")
         self.org_id = "org-test-001"
         self.project = Project.objects.create(name="Main Project", org=self.org_id)
-        self.other_project = Project.objects.create(name="Secondary Project", org=self.org_id)
+        self.other_project = Project.objects.create(
+            name="Secondary Project", org=self.org_id
+        )
         ProjectPermission.objects.create(
             project=self.project,
             user=self.user,
@@ -274,9 +286,7 @@ class IntegrateSectorsTestCase(APITestCase):
         mock_integrations.integrate_ticketer.return_value = None
         mock_integrations.integrate_topic.return_value = None
 
-        response = self.client.post(
-            f"{self.url}?project={self.project.uuid}"
-        )
+        response = self.client.post(f"{self.url}?project={self.project.uuid}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_integrate_sectors_project_not_found_returns_404(self):
@@ -289,10 +299,277 @@ class IntegrateSectorsTestCase(APITestCase):
     @patch("chats.apps.api.v1.projects.viewsets.IntegratedTicketers")
     def test_integrate_sectors_exception_returns_400(self, mock_integrations_cls):
         mock_integrations = mock_integrations_cls.return_value
-        mock_integrations.integrate_ticketer.side_effect = Exception("integration failed")
-
-        response = self.client.post(
-            f"{self.url}?project={self.project.uuid}"
+        mock_integrations.integrate_ticketer.side_effect = Exception(
+            "integration failed"
         )
+
+        response = self.client.post(f"{self.url}?project={self.project.uuid}")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("error integrating ticketers", response.data)
+
+
+MOCK_FLOW_START_RESPONSE = {
+    "uuid": "ext-flow-start-uuid",
+    "flow": {"name": "Test Flow", "uuid": "flow-uuid-001"},
+}
+
+
+@patch("chats.apps.api.v1.projects.viewsets.FlowRESTClient")
+class StartFlowTestCase(APITestCase):
+    """Tests for ProjectViewset.start_flow (POST /project/{uuid}/start_flow/)"""
+
+    def setUp(self):
+        self.user, self.token = create_user_and_token("flowuser")
+        self.project = Project.objects.create(
+            name="Flow Project", flows_authorization="fake-token"
+        )
+        self.permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.contact = Contact.objects.create(
+            name="Flow Contact",
+            external_id="ext-contact-flow-001",
+        )
+        self.url = reverse("project-flows", kwargs={"uuid": str(self.project.uuid)})
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        self.base_payload = {
+            "flow": "flow-uuid-001",
+            "contacts": [self.contact.external_id],
+            "contact_name": "Flow Contact",
+        }
+
+    def _mock_client(self, mock_client_cls, response=None):
+        mock_instance = mock_client_cls.return_value
+        mock_instance.start_flow.return_value = response or MOCK_FLOW_START_RESPONSE
+        return mock_instance
+
+    # -- Permission / validation --
+
+    def test_start_flow_without_permission_returns_401(self, mock_client_cls):
+        self._mock_client(mock_client_cls)
+        other_user, other_token = create_user_and_token("nopermflow")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {other_token.key}")
+
+        response = self.client.post(self.url, self.base_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_start_flow_missing_flow_field_returns_400(self, mock_client_cls):
+        self._mock_client(mock_client_cls)
+        payload = {
+            "contacts": [self.contact.external_id],
+            "contact_name": "Flow Contact",
+        }
+        response = self.client.post(self.url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # -- Happy path --
+
+    def test_start_flow_success_returns_200(self, mock_client_cls):
+        self._mock_client(mock_client_cls)
+        response = self.client.post(self.url, self.base_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["uuid"], "ext-flow-start-uuid")
+
+    def test_start_flow_creates_flow_start_record(self, mock_client_cls):
+        self._mock_client(mock_client_cls)
+        self.client.post(self.url, self.base_payload, format="json")
+
+        flow_start = FlowStart.objects.get(project=self.project)
+        self.assertEqual(flow_start.flow, "flow-uuid-001")
+        self.assertEqual(flow_start.permission, self.permission)
+        self.assertEqual(
+            flow_start.contact_data["external_id"], self.contact.external_id
+        )
+        self.assertEqual(flow_start.contact_data["name"], "Flow Contact")
+
+    def test_start_flow_saves_external_id_and_name_from_response(self, mock_client_cls):
+        self._mock_client(mock_client_cls)
+        self.client.post(self.url, self.base_payload, format="json")
+
+        flow_start = FlowStart.objects.get(project=self.project)
+        self.assertEqual(flow_start.external_id, "ext-flow-start-uuid")
+        self.assertEqual(flow_start.name, "Test Flow")
+
+    def test_start_flow_creates_contact_references(self, mock_client_cls):
+        self._mock_client(mock_client_cls)
+        self.client.post(self.url, self.base_payload, format="json")
+
+        refs = ContactGroupFlowReference.objects.filter(
+            flow_start__project=self.project
+        )
+        self.assertEqual(refs.count(), 1)
+        self.assertEqual(refs.first().receiver_type, "contact")
+        self.assertEqual(refs.first().external_id, self.contact.external_id)
+
+    def test_start_flow_creates_group_references(self, mock_client_cls):
+        self._mock_client(mock_client_cls)
+        payload = {
+            **self.base_payload,
+            "groups": ["group-uuid-001", "group-uuid-002"],
+        }
+        self.client.post(self.url, payload, format="json")
+
+        refs = ContactGroupFlowReference.objects.filter(
+            flow_start__project=self.project
+        )
+        contact_refs = refs.filter(receiver_type="contact")
+        group_refs = refs.filter(receiver_type="group")
+        self.assertEqual(contact_refs.count(), 1)
+        self.assertEqual(group_refs.count(), 2)
+        self.assertEqual(
+            set(group_refs.values_list("external_id", flat=True)),
+            {"group-uuid-001", "group-uuid-002"},
+        )
+
+    # -- Params forwarding --
+
+    def test_start_flow_with_params_forwards_to_client(self, mock_client_cls):
+        mock_instance = self._mock_client(mock_client_cls)
+        payload = {**self.base_payload, "params": {"key": "value"}}
+
+        self.client.post(self.url, payload, format="json")
+
+        call_args = mock_instance.start_flow.call_args
+        data_sent = call_args[0][1]
+        self.assertIn("params", data_sent)
+        self.assertEqual(data_sent["params"], {"key": "value"})
+
+    def test_start_flow_without_params_excludes_params_from_client(
+        self, mock_client_cls
+    ):
+        mock_instance = self._mock_client(mock_client_cls)
+
+        self.client.post(self.url, self.base_payload, format="json")
+
+        call_args = mock_instance.start_flow.call_args
+        data_sent = call_args[0][1]
+        self.assertNotIn("params", data_sent)
+
+    def test_start_flow_with_complex_params_forwards_intact(self, mock_client_cls):
+        mock_instance = self._mock_client(mock_client_cls)
+        complex_params = {
+            "greeting": "Hello {name}",
+            "nested": {"level1": {"level2": [1, 2, 3]}},
+            "tags": ["vip", "returning"],
+            "priority": 5,
+        }
+        payload = {**self.base_payload, "params": complex_params}
+
+        self.client.post(self.url, payload, format="json")
+
+        call_args = mock_instance.start_flow.call_args
+        data_sent = call_args[0][1]
+        self.assertEqual(data_sent["params"], complex_params)
+
+    def test_start_flow_params_not_persisted_in_flow_start_model(self, mock_client_cls):
+        """params are forwarded to the external API, not stored in FlowStart."""
+        self._mock_client(mock_client_cls)
+        payload = {**self.base_payload, "params": {"key": "value"}}
+
+        self.client.post(self.url, payload, format="json")
+
+        flow_start = FlowStart.objects.get(project=self.project)
+        self.assertNotIn("params", flow_start.contact_data)
+
+    # -- Room-related --
+
+    def test_start_flow_room_with_existing_active_flowstart_returns_400(
+        self, mock_client_cls
+    ):
+        self._mock_client(mock_client_cls)
+        room = Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            is_active=True,
+        )
+        FlowStart.objects.create(
+            project=self.project,
+            permission=self.permission,
+            room=room,
+            is_deleted=False,
+        )
+        payload = {**self.base_payload, "room": str(room.pk)}
+        response = self.client.post(self.url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch.object(Room, "notify_room")
+    @patch.object(Room, "request_callback")
+    @patch.object(Room, "is_24h_valid", new_callable=PropertyMock, return_value=False)
+    def test_start_flow_room_not_24h_valid_links_room_and_sets_waiting(
+        self, _mock_24h, mock_callback, mock_notify, mock_client_cls
+    ):
+        self._mock_client(mock_client_cls)
+        room = Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            is_active=True,
+        )
+        payload = {**self.base_payload, "room": str(room.pk)}
+
+        self.client.post(self.url, payload, format="json")
+
+        room.refresh_from_db()
+        self.assertTrue(room.is_waiting)
+        mock_callback.assert_called_once()
+
+        flow_start = FlowStart.objects.get(project=self.project)
+        self.assertEqual(flow_start.room, room)
+
+    @patch.object(Room, "notify_room")
+    @patch.object(Room, "is_24h_valid", new_callable=PropertyMock, return_value=True)
+    def test_start_flow_room_24h_valid_does_not_link_room(
+        self, _mock_24h, mock_notify, mock_client_cls
+    ):
+        self._mock_client(mock_client_cls)
+        room = Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            is_active=True,
+        )
+        payload = {**self.base_payload, "room": str(room.pk)}
+
+        self.client.post(self.url, payload, format="json")
+
+        flow_start = FlowStart.objects.get(project=self.project)
+        self.assertIsNone(flow_start.room)
+
+    @patch("chats.apps.api.v1.projects.viewsets.create_room_feedback_message")
+    @patch.object(Room, "notify_room")
+    @patch.object(Room, "request_callback")
+    @patch.object(Room, "is_24h_valid", new_callable=PropertyMock, return_value=False)
+    def test_start_flow_with_room_creates_feedback_message(
+        self, _mock_24h, mock_callback, mock_notify, mock_feedback, mock_client_cls
+    ):
+        self._mock_client(mock_client_cls)
+        room = Room.objects.create(
+            queue=self.queue,
+            contact=self.contact,
+            is_active=True,
+        )
+        payload = {**self.base_payload, "room": str(room.pk)}
+
+        self.client.post(self.url, payload, format="json")
+
+        mock_feedback.assert_called_once()
+        call_kwargs = mock_feedback.call_args
+        self.assertEqual(call_kwargs[0][0], room)
+        self.assertEqual(call_kwargs[1]["method"], "fs")
+
+    def test_start_flow_without_room_does_not_create_feedback(self, mock_client_cls):
+        self._mock_client(mock_client_cls)
+
+        with patch(
+            "chats.apps.api.v1.projects.viewsets.create_room_feedback_message"
+        ) as mock_feedback:
+            self.client.post(self.url, self.base_payload, format="json")
+            mock_feedback.assert_not_called()


### PR DESCRIPTION
- Implement tests for the start_flow endpoint, including permission checks, validation, and successful flow start scenarios.
- Mock external client interactions to validate flow start behavior and ensure correct data handling.
- Verify creation of FlowStart records and associated contact references.