### PR TITLE
chore: Increase project, quick messages and sectors test coverage

### DIFF
--- a/chats/apps/projects/tests/test_dead_letter_consumer.py
+++ b/chats/apps/projects/tests/test_dead_letter_consumer.py
@@ -1,0 +1,51 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from chats.apps.projects.consumers.dead_letter_consumer import DeadLetterConsumer
+
+
+class TestDeadLetterConsumer(TestCase):
+    def setUp(self):
+        self.mock_channel = Mock()
+        self.mock_message = Mock()
+        self.mock_message.channel = self.mock_channel
+        self.mock_message.delivery_tag = "dt"
+        self.mock_message.headers = {"x-first-death-queue": "my.queue"}
+        self.mock_message.body = b'{"some": "payload"}'
+
+    @patch(
+        "chats.apps.projects.consumers.dead_letter_consumer.basic_publish"
+    )
+    @patch(
+        "chats.apps.projects.consumers.dead_letter_consumer.DeadLetterHandler"
+    )
+    def test_happy_path_republishes_and_acks(
+        self, mock_handler_class, mock_basic_publish
+    ):
+        mock_handler_class.return_value.execute.return_value = None
+
+        DeadLetterConsumer.consume(self.mock_message)
+
+        mock_handler_class.assert_called_once()
+        mock_handler_class.return_value.execute.assert_called_once()
+        mock_basic_publish.assert_called_once()
+        self.mock_channel.basic_ack.assert_called_once_with("dt")
+        self.mock_channel.basic_reject.assert_not_called()
+
+    @patch(
+        "chats.apps.projects.consumers.dead_letter_consumer.basic_publish"
+    )
+    @patch(
+        "chats.apps.projects.consumers.dead_letter_consumer.DeadLetterHandler"
+    )
+    def test_handler_exception_results_in_reject(
+        self, mock_handler_class, mock_basic_publish
+    ):
+        mock_handler_class.return_value.execute.side_effect = Exception("boom")
+
+        DeadLetterConsumer.consume(self.mock_message)
+
+        self.mock_channel.basic_reject.assert_called_once_with("dt", requeue=False)
+        self.mock_channel.basic_ack.assert_not_called()
+        mock_basic_publish.assert_not_called()

--- a/chats/apps/projects/tests/test_dead_letter_handler.py
+++ b/chats/apps/projects/tests/test_dead_letter_handler.py
@@ -1,0 +1,99 @@
+from unittest.mock import Mock
+
+from django.test import TestCase, override_settings
+
+from chats.apps.projects.usecases.dead_letter_handler import DeadLetterHandler
+from chats.apps.projects.usecases.exceptions import (
+    InvalidDLQHeaders,
+    ReceivedErrorMessage,
+)
+
+
+class TestDeadLetterHandler(TestCase):
+    def _make_message(self, headers=None):
+        message = Mock()
+        message.headers = headers if headers is not None else {}
+        return message
+
+    def test_execute_raises_received_error_message_when_error_type_present(self):
+        message = self._make_message()
+        content = {
+            "error_type": "ValueError",
+            "error_message": "bad payload",
+            "original_message": {"foo": "bar"},
+        }
+        handler = DeadLetterHandler(message=message, dead_letter_content=content)
+
+        with self.assertRaises(ReceivedErrorMessage) as ctx:
+            handler.execute()
+
+        message_text = str(ctx.exception)
+        self.assertIn("ValueError", message_text)
+        self.assertIn("bad payload", message_text)
+        self.assertIn("foo", message_text)
+
+    def test_execute_raises_invalid_dlq_headers_when_no_x_death(self):
+        message = self._make_message(headers={})
+        handler = DeadLetterHandler(message=message, dead_letter_content={})
+
+        with self.assertRaises(InvalidDLQHeaders) as ctx:
+            handler.execute()
+
+        self.assertIn("x-death", str(ctx.exception))
+
+    def test_execute_raises_when_reason_in_reject_reason(self):
+        message = self._make_message(
+            headers={"x-death": [{"reason": "rejected", "count": 1}]}
+        )
+        handler = DeadLetterHandler(message=message, dead_letter_content={})
+
+        with self.assertRaises(InvalidDLQHeaders) as ctx:
+            handler.execute()
+
+        self.assertIn("rejected", str(ctx.exception))
+
+    def test_execute_raises_when_reason_is_delivery_limit(self):
+        message = self._make_message(
+            headers={"x-death": [{"reason": "delivery_limit", "count": 1}]}
+        )
+        handler = DeadLetterHandler(message=message, dead_letter_content={})
+
+        with self.assertRaises(InvalidDLQHeaders) as ctx:
+            handler.execute()
+
+        self.assertIn("delivery_limit", str(ctx.exception))
+
+    @override_settings(EDA_REQUEUE_LIMIT=2)
+    def test_execute_raises_when_count_exceeds_requeue_limit(self):
+        message = self._make_message(
+            headers={"x-death": [{"reason": "expired", "count": 2}]}
+        )
+        handler = DeadLetterHandler(message=message, dead_letter_content={})
+
+        with self.assertRaises(InvalidDLQHeaders) as ctx:
+            handler.execute()
+
+        self.assertIn("2", str(ctx.exception))
+
+    @override_settings(EDA_REQUEUE_LIMIT=5)
+    def test_execute_passes_when_under_requeue_limit(self):
+        message = self._make_message(
+            headers={"x-death": [{"reason": "expired", "count": 1}]}
+        )
+        handler = DeadLetterHandler(message=message, dead_letter_content={})
+
+        self.assertIsNone(handler.execute())
+
+    def test_execute_uses_first_x_death_entry(self):
+        message = self._make_message(
+            headers={
+                "x-death": [
+                    {"reason": "rejected", "count": 1},
+                    {"reason": "expired", "count": 0},
+                ]
+            }
+        )
+        handler = DeadLetterHandler(message=message, dead_letter_content={})
+
+        with self.assertRaises(InvalidDLQHeaders):
+            handler.execute()

--- a/chats/apps/projects/tests/test_sector_creation_usecase.py
+++ b/chats/apps/projects/tests/test_sector_creation_usecase.py
@@ -1,0 +1,157 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from chats.apps.api.v1.dto.queue_dto import QueueDTO
+from chats.apps.api.v1.dto.sector_dto import SectorDTO
+from chats.apps.feature_version.models import IntegratedFeature
+from chats.apps.projects.models import Project
+from chats.apps.projects.usecases.sector_creation import SectorCreationUseCase
+from chats.apps.queues.models import Queue
+from chats.apps.sectors.models import Sector, SectorTag
+
+
+class TestCreateSectorDTO(TestCase):
+    def test_returns_dtos_from_message_body(self):
+        body = {
+            "sectors": [
+                {
+                    "name": "Sector A",
+                    "working_hours": {"init": "09:00", "close": "18:00"},
+                    "service_limit": 4,
+                    "tags": ["tag1", "tag2"],
+                    "queues": [{"name": "Queue A1"}, {"name": "Queue A2"}],
+                },
+                {
+                    "name": "Sector B",
+                    "working_hours": {"init": "10:00", "close": "16:00"},
+                    "service_limit": 2,
+                    "tags": [],
+                    "queues": [{"name": "Queue B1"}],
+                },
+            ]
+        }
+
+        dtos = SectorCreationUseCase.create_sector_dto(body)
+
+        self.assertEqual(len(dtos), 2)
+        self.assertIsInstance(dtos[0], SectorDTO)
+        self.assertEqual(dtos[0].name, "Sector A")
+        self.assertEqual(dtos[0].service_limit, 4)
+        self.assertEqual(dtos[0].tags, ["tag1", "tag2"])
+        self.assertEqual([q.name for q in dtos[0].queues], ["Queue A1", "Queue A2"])
+        self.assertEqual(dtos[1].name, "Sector B")
+        self.assertEqual(len(dtos[1].queues), 1)
+        self.assertIsInstance(dtos[1].queues[0], QueueDTO)
+
+
+class TestIntegrateFeature(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="SC Test Project")
+        self.user_email = "agent@test.com"
+
+    def _make_dto(self, name, queue_names):
+        return SectorDTO(
+            working_hours={"init": "09:00", "close": "18:00"},
+            service_limit=5,
+            tags=["tag-a"],
+            name=name,
+            queues=[QueueDTO(name=qn) for qn in queue_names],
+        )
+
+    def _body(self):
+        return {
+            "project_uuid": str(self.project.uuid),
+            "user_email": self.user_email,
+        }
+
+    @patch(
+        "chats.apps.projects.usecases.sector_creation.FlowsEDAClient.request_ticketer"
+    )
+    def test_integrate_feature_creates_sector_tags_queues_and_calls_eda(
+        self, mock_request_ticketer
+    ):
+        dtos = [self._make_dto("New Sector", ["Q1", "Q2"])]
+        use_case = SectorCreationUseCase()
+
+        use_case.integrate_feature(self._body(), dtos)
+
+        sector = Sector.objects.get(name="New Sector", project=self.project)
+        self.assertEqual(sector.rooms_limit, 5)
+        self.assertTrue(Queue.objects.filter(sector=sector, name="Q1").exists())
+        self.assertTrue(Queue.objects.filter(sector=sector, name="Q2").exists())
+        self.assertTrue(SectorTag.objects.filter(sector=sector, name="tag-a").exists())
+
+        # DTO uuids should be populated for later steps
+        self.assertEqual(dtos[0].uuid, str(sector.uuid))
+        for queue_dto in dtos[0].queues:
+            self.assertTrue(
+                Queue.objects.filter(uuid=queue_dto.uuid, sector=sector).exists()
+            )
+
+        mock_request_ticketer.assert_called_once()
+        call_kwargs = mock_request_ticketer.call_args.kwargs
+        content = call_kwargs["content"]
+        self.assertEqual(content["name"], "New Sector")
+        self.assertEqual(content["user_email"], self.user_email)
+        self.assertEqual(len(content["queues"]), 2)
+
+    @patch(
+        "chats.apps.projects.usecases.sector_creation.FlowsEDAClient.request_ticketer"
+    )
+    def test_integrate_feature_is_idempotent(self, mock_request_ticketer):
+        existing = Sector.objects.create(
+            name="Existing Sector",
+            project=self.project,
+            rooms_limit=10,
+            work_start="08:00",
+            work_end="20:00",
+        )
+        Queue.objects.create(name="Q1", sector=existing)
+        SectorTag.objects.create(name="tag-a", sector=existing)
+
+        dtos = [self._make_dto("Existing Sector", ["Q1", "Q2"])]
+        use_case = SectorCreationUseCase()
+        use_case.integrate_feature(self._body(), dtos)
+
+        # Original sector kept with its original rooms_limit (get_or_create defaults are ignored on get)
+        existing.refresh_from_db()
+        self.assertEqual(existing.rooms_limit, 10)
+
+        # Only one duplicate tag/queue created
+        self.assertEqual(
+            SectorTag.objects.filter(sector=existing, name="tag-a").count(), 1
+        )
+        self.assertEqual(Queue.objects.filter(sector=existing).count(), 2)
+        mock_request_ticketer.assert_called_once()
+
+
+class TestCreateIntegratedFeatureObject(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="IF Test Project")
+
+    def test_create_integrated_feature_object_persists_with_dto_dicts(self):
+        dto = SectorDTO(
+            working_hours={"init": "09:00", "close": "18:00"},
+            service_limit=5,
+            tags=["t"],
+            name="Sector",
+            queues=[QueueDTO(name="Q1")],
+        )
+        # Mimic state after integrate_feature ran: queues need a uuid attr
+        dto.queues[0].uuid = "queue-uuid"
+
+        use_case = SectorCreationUseCase()
+        body = {
+            "project_uuid": str(self.project.uuid),
+            "feature_uuid": "feat-123",
+        }
+
+        use_case.create_integrated_feature_object(body, [dto])
+
+        feature = IntegratedFeature.objects.get(project=self.project)
+        self.assertEqual(feature.feature, "feat-123")
+        self.assertEqual(len(feature.current_version), 1)
+        self.assertEqual(feature.current_version[0]["name"], "Sector")
+        self.assertEqual(feature.current_version[0]["queues"][0]["name"], "Q1")
+        self.assertEqual(feature.current_version[0]["queues"][0]["uuid"], "queue-uuid")

--- a/chats/apps/projects/tests/test_sector_setup_handler.py
+++ b/chats/apps/projects/tests/test_sector_setup_handler.py
@@ -1,0 +1,134 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from chats.apps.accounts.models import User
+from chats.apps.projects.models import Project, ProjectPermission, TemplateType
+from chats.apps.projects.usecases.sector_setup_handler import (
+    SectorSetupHandlerUseCase,
+)
+from chats.apps.queues.models import Queue, QueueAuthorization
+from chats.apps.sectors.models import Sector, SectorAuthorization
+
+
+class TestSectorSetupHandlerUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Setup Test Project")
+        self.user = User.objects.create(email="creator@test.com")
+        self.permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.user,
+            role=ProjectPermission.ROLE_ADMIN,
+        )
+
+    def _make_template_type(self, setup):
+        return TemplateType.objects.create(name="TT", setup=setup)
+
+    @patch(
+        "chats.apps.projects.usecases.sector_setup_handler.FlowsEDAClient.request_ticketer"
+    )
+    def test_setup_skips_sectors_without_queues(self, mock_request_ticketer):
+        template_type = self._make_template_type(
+            setup={
+                "sectors": [
+                    {
+                        "name": "Empty Sector",
+                        "rooms_limit": 1,
+                        "work_start": "08:00",
+                        "work_end": "18:00",
+                    }
+                ]
+            }
+        )
+
+        SectorSetupHandlerUseCase().setup_sectors_in_project(
+            project=self.project,
+            template_type=template_type,
+            creator_permission=self.permission,
+        )
+
+        self.assertFalse(Sector.objects.filter(project=self.project).exists())
+        mock_request_ticketer.assert_not_called()
+
+    @patch(
+        "chats.apps.projects.usecases.sector_setup_handler.FlowsEDAClient.request_ticketer"
+    )
+    def test_setup_skips_sectors_that_already_exist(self, mock_request_ticketer):
+        Sector.objects.create(
+            name="Existing Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start="08:00",
+            work_end="18:00",
+        )
+        template_type = self._make_template_type(
+            setup={
+                "sectors": [
+                    {
+                        "name": "Existing Sector",
+                        "rooms_limit": 5,
+                        "work_start": "08:00",
+                        "work_end": "18:00",
+                        "queues": [{"name": "Q1"}],
+                    }
+                ]
+            }
+        )
+
+        SectorSetupHandlerUseCase().setup_sectors_in_project(
+            project=self.project,
+            template_type=template_type,
+            creator_permission=self.permission,
+        )
+
+        # No authorizations or queues added; EDA not called
+        self.assertFalse(SectorAuthorization.objects.exists())
+        self.assertFalse(Queue.objects.exists())
+        mock_request_ticketer.assert_not_called()
+
+    @patch(
+        "chats.apps.projects.usecases.sector_setup_handler.FlowsEDAClient.request_ticketer"
+    )
+    def test_setup_creates_sectors_queues_and_authorizations(
+        self, mock_request_ticketer
+    ):
+        template_type = self._make_template_type(
+            setup={
+                "sectors": [
+                    {
+                        "name": "Setup Sector",
+                        "rooms_limit": 2,
+                        "work_start": "09:00",
+                        "work_end": "17:00",
+                        "queues": [{"name": "Q1"}, {"name": "Q2"}],
+                    }
+                ]
+            }
+        )
+
+        SectorSetupHandlerUseCase().setup_sectors_in_project(
+            project=self.project,
+            template_type=template_type,
+            creator_permission=self.permission,
+        )
+
+        sector = Sector.objects.get(name="Setup Sector", project=self.project)
+        self.assertEqual(sector.rooms_limit, 2)
+        self.assertEqual(Queue.objects.filter(sector=sector).count(), 2)
+        self.assertTrue(
+            SectorAuthorization.objects.filter(
+                permission=self.permission, sector=sector, role=1
+            ).exists()
+        )
+        self.assertEqual(
+            QueueAuthorization.objects.filter(
+                permission=self.permission, role=1
+            ).count(),
+            2,
+        )
+
+        mock_request_ticketer.assert_called_once()
+        content = mock_request_ticketer.call_args.kwargs["content"]
+        self.assertEqual(content["name"], "Setup Sector")
+        self.assertEqual(content["user_email"], self.user.email)
+        self.assertEqual({q["name"] for q in content["queues"]}, {"Q1", "Q2"})

--- a/chats/apps/projects/tests/test_send_room_info.py
+++ b/chats/apps/projects/tests/test_send_room_info.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase
+
+from chats.apps.projects.usecases.send_room_info import RoomInfoUseCase
+
+
+def _make_room(
+    *,
+    project_config=None,
+    secondary_project=None,
+    has_queue=True,
+    has_sector=True,
+    project_uuid=None,
+):
+    room = MagicMock()
+    room.uuid = uuid4()
+    room.created_on = datetime.now(timezone.utc)
+    room.contact.external_id = "external-123"
+
+    room.project = MagicMock()
+    room.project.uuid = project_uuid or uuid4()
+    room.project.config = project_config
+
+    if has_queue:
+        room.queue = MagicMock()
+        if has_sector:
+            room.queue.sector = MagicMock()
+            room.queue.sector.secondary_project = secondary_project
+        else:
+            room.queue.sector = None
+    else:
+        room.queue = None
+
+    return room
+
+
+class TestRoomInfoUseCase(TestCase):
+    @patch(
+        "chats.apps.projects.usecases.send_room_info.RoomsInfoMixin.request_room"
+    )
+    def test_get_room_publishes_principal_project_uuid_when_no_config(
+        self, mock_request_room
+    ):
+        room = _make_room(project_config=None)
+        RoomInfoUseCase().get_room(room)
+
+        content = mock_request_room.call_args.kwargs["content"]
+        self.assertEqual(content["project_uuid"], str(room.project.uuid))
+        self.assertEqual(content["external_id"], "external-123")
+        self.assertEqual(content["uuid"], str(room.uuid))
+
+    @patch(
+        "chats.apps.projects.usecases.send_room_info.RoomsInfoMixin.request_room"
+    )
+    def test_get_room_uses_principal_when_its_principal_false(
+        self, mock_request_room
+    ):
+        room = _make_room(project_config={"its_principal": False})
+        RoomInfoUseCase().get_room(room)
+        content = mock_request_room.call_args.kwargs["content"]
+        self.assertEqual(content["project_uuid"], str(room.project.uuid))
+
+    @patch(
+        "chats.apps.projects.usecases.send_room_info.RoomsInfoMixin.request_room"
+    )
+    def test_get_room_uses_secondary_uuid_from_dict(self, mock_request_room):
+        secondary_uuid = str(uuid4())
+        room = _make_room(
+            project_config={"its_principal": True},
+            secondary_project={"uuid": secondary_uuid},
+        )
+        RoomInfoUseCase().get_room(room)
+        content = mock_request_room.call_args.kwargs["content"]
+        self.assertEqual(content["project_uuid"], secondary_uuid)
+
+    @patch(
+        "chats.apps.projects.usecases.send_room_info.RoomsInfoMixin.request_room"
+    )
+    def test_get_room_uses_secondary_str(self, mock_request_room):
+        secondary_uuid = str(uuid4())
+        room = _make_room(
+            project_config={"its_principal": True},
+            secondary_project=secondary_uuid,
+        )
+        RoomInfoUseCase().get_room(room)
+        content = mock_request_room.call_args.kwargs["content"]
+        self.assertEqual(content["project_uuid"], secondary_uuid)
+
+    @patch(
+        "chats.apps.projects.usecases.send_room_info.RoomsInfoMixin.request_room"
+    )
+    def test_get_room_falls_back_to_principal_when_principal_but_no_queue_sector(
+        self, mock_request_room
+    ):
+        room = _make_room(
+            project_config={"its_principal": True},
+            has_queue=False,
+        )
+        RoomInfoUseCase().get_room(room)
+        content = mock_request_room.call_args.kwargs["content"]
+        self.assertEqual(content["project_uuid"], str(room.project.uuid))
+
+    @patch(
+        "chats.apps.projects.usecases.send_room_info.RoomsInfoMixin.request_room"
+    )
+    def test_get_room_falls_back_to_principal_when_principal_but_no_secondary(
+        self, mock_request_room
+    ):
+        room = _make_room(
+            project_config={"its_principal": True},
+            secondary_project=None,
+        )
+        RoomInfoUseCase().get_room(room)
+        content = mock_request_room.call_args.kwargs["content"]
+        self.assertEqual(content["project_uuid"], str(room.project.uuid))

--- a/chats/apps/projects/tests/test_status_service.py
+++ b/chats/apps/projects/tests/test_status_service.py
@@ -1,0 +1,295 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from chats.apps.accounts.models import User
+from chats.apps.projects.models import Project, ProjectPermission
+from chats.apps.projects.models.models import CustomStatus, CustomStatusType
+from chats.apps.projects.usecases.status_service import (
+    InServiceStatusService,
+    InServiceStatusTracker,
+)
+from chats.apps.queues.models import Queue
+from chats.apps.rooms.models import Room
+from chats.apps.sectors.models import Sector
+
+
+class _BaseStatusServiceTestCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Status Project")
+        self.user = User.objects.create(email="status-agent@test.com")
+        self.permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.user,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+        )
+        self.sector = Sector.objects.create(
+            name="Status Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        self.queue = Queue.objects.create(name="Status Queue", sector=self.sector)
+
+
+class TestGetOrCreateStatusType(_BaseStatusServiceTestCase):
+    def test_creates_status_type_once(self):
+        st1 = InServiceStatusService.get_or_create_status_type(self.project)
+        st2 = InServiceStatusService.get_or_create_status_type(self.project)
+        self.assertEqual(st1.pk, st2.pk)
+        self.assertEqual(st1.name, "In-Service")
+        self.assertEqual(st1.project, self.project)
+
+
+class TestHasPriorityStatus(_BaseStatusServiceTestCase):
+    def test_returns_false_when_no_status(self):
+        self.assertFalse(
+            InServiceStatusService.has_priority_status(self.user, self.project)
+        )
+
+    def test_returns_true_when_other_active_status(self):
+        other = CustomStatusType.objects.create(
+            name="Lunch", project=self.project, is_deleted=False, config={}
+        )
+        CustomStatus.objects.create(
+            user=self.user,
+            status_type=other,
+            is_active=True,
+            project=self.project,
+            break_time=0,
+        )
+        self.assertTrue(
+            InServiceStatusService.has_priority_status(self.user, self.project)
+        )
+
+
+class TestRoomAssigned(_BaseStatusServiceTestCase):
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_short_circuits_when_user_or_project_missing(self, mock_log):
+        InServiceStatusService.room_assigned(None, self.project)
+        InServiceStatusService.room_assigned(self.user, None)
+        mock_log.assert_not_called()
+
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_returns_early_when_no_permission(self, mock_log):
+        agent_no_perm = User.objects.create(email="no-perm@test.com")
+        InServiceStatusService.room_assigned(agent_no_perm, self.project)
+        mock_log.assert_not_called()
+
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_creates_in_service_status_when_first_room(self, mock_log):
+        Room.objects.create(queue=self.queue, user=self.user)
+
+        InServiceStatusService.room_assigned(self.user, self.project)
+
+        status_type = CustomStatusType.objects.get(
+            name="In-Service", project=self.project
+        )
+        self.assertTrue(
+            CustomStatus.objects.filter(
+                user=self.user,
+                status_type=status_type,
+                is_active=True,
+                project=self.project,
+            ).exists()
+        )
+        mock_log.assert_called_once()
+
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_does_not_create_status_when_user_offline(self, mock_log):
+        self.permission.status = "OFFLINE"
+        self.permission.save()
+        Room.objects.create(queue=self.queue, user=self.user)
+
+        InServiceStatusService.room_assigned(self.user, self.project)
+
+        self.assertFalse(
+            CustomStatus.objects.filter(
+                user=self.user, is_active=True, project=self.project
+            ).exists()
+        )
+        mock_log.assert_not_called()
+
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_does_not_create_when_priority_status_active(self, mock_log):
+        other = CustomStatusType.objects.create(
+            name="Lunch", project=self.project, is_deleted=False, config={}
+        )
+        CustomStatus.objects.create(
+            user=self.user,
+            status_type=other,
+            is_active=True,
+            project=self.project,
+            break_time=0,
+        )
+        Room.objects.create(queue=self.queue, user=self.user)
+
+        InServiceStatusService.room_assigned(self.user, self.project)
+
+        in_service_type = CustomStatusType.objects.get(
+            name="In-Service", project=self.project
+        )
+        self.assertFalse(
+            CustomStatus.objects.filter(
+                user=self.user, status_type=in_service_type, is_active=True
+            ).exists()
+        )
+        mock_log.assert_not_called()
+
+
+class TestRoomClosed(_BaseStatusServiceTestCase):
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_short_circuits_when_args_missing(self, mock_log):
+        InServiceStatusService.room_closed(None, self.project)
+        InServiceStatusService.room_closed(self.user, None)
+        mock_log.assert_not_called()
+
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_closes_status_when_no_more_active_rooms(self, mock_log):
+        status_type = InServiceStatusService.get_or_create_status_type(self.project)
+        status = CustomStatus.objects.create(
+            user=self.user,
+            status_type=status_type,
+            is_active=True,
+            project=self.project,
+            break_time=0,
+        )
+
+        InServiceStatusService.room_closed(self.user, self.project)
+
+        status.refresh_from_db()
+        self.assertFalse(status.is_active)
+        self.assertGreaterEqual(status.break_time, 0)
+        mock_log.assert_called_once()
+
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_no_status_to_close_logs_warning(self, mock_log):
+        InServiceStatusService.get_or_create_status_type(self.project)
+        InServiceStatusService.room_closed(self.user, self.project)
+        mock_log.assert_not_called()
+
+    @patch("chats.apps.projects.tasks.log_agent_status_change.delay")
+    def test_does_nothing_when_active_rooms_remain(self, mock_log):
+        status_type = InServiceStatusService.get_or_create_status_type(self.project)
+        CustomStatus.objects.create(
+            user=self.user,
+            status_type=status_type,
+            is_active=True,
+            project=self.project,
+            break_time=0,
+        )
+        Room.objects.create(queue=self.queue, user=self.user)
+
+        InServiceStatusService.room_closed(self.user, self.project)
+
+        # status remains active
+        self.assertTrue(
+            CustomStatus.objects.filter(
+                user=self.user, status_type=status_type, is_active=True
+            ).exists()
+        )
+        mock_log.assert_not_called()
+
+
+class TestSyncAgentStatus(_BaseStatusServiceTestCase):
+    def test_returns_when_user_does_not_exist(self):
+        # Should not raise
+        InServiceStatusService.sync_agent_status(999999, self.project)
+
+    def test_returns_when_project_does_not_exist(self):
+        import uuid
+
+        InServiceStatusService.sync_agent_status(self.user, str(uuid.uuid4()))
+
+    def test_creates_status_when_rooms_active_and_no_status(self):
+        Room.objects.create(queue=self.queue, user=self.user)
+        # Remove the In-Service status auto-created by Room.save() so we exercise
+        # the create-branch inside sync_agent_status itself.
+        CustomStatus.objects.all().delete()
+
+        InServiceStatusService.sync_agent_status(self.user, self.project)
+
+        st = CustomStatusType.objects.get(name="In-Service", project=self.project)
+        self.assertTrue(
+            CustomStatus.objects.filter(
+                user=self.user, status_type=st, is_active=True
+            ).exists()
+        )
+
+    def test_closes_status_when_no_rooms_and_status_active(self):
+        st = InServiceStatusService.get_or_create_status_type(self.project)
+        status = CustomStatus.objects.create(
+            user=self.user,
+            status_type=st,
+            is_active=True,
+            project=self.project,
+            break_time=0,
+        )
+
+        InServiceStatusService.sync_agent_status(self.user, self.project)
+
+        status.refresh_from_db()
+        self.assertFalse(status.is_active)
+
+    def test_does_nothing_when_priority_status_active(self):
+        other = CustomStatusType.objects.create(
+            name="Pause", project=self.project, is_deleted=False, config={}
+        )
+        CustomStatus.objects.create(
+            user=self.user,
+            status_type=other,
+            is_active=True,
+            project=self.project,
+            break_time=0,
+        )
+        Room.objects.create(queue=self.queue, user=self.user)
+
+        InServiceStatusService.sync_agent_status(self.user, self.project)
+
+        in_service_type = InServiceStatusService.get_or_create_status_type(self.project)
+        self.assertFalse(
+            CustomStatus.objects.filter(
+                user=self.user, status_type=in_service_type, is_active=True
+            ).exists()
+        )
+
+
+class TestScheduleSyncForAllAgents(_BaseStatusServiceTestCase):
+    @patch.object(InServiceStatusService, "sync_agent_status")
+    def test_dispatches_sync_for_each_active_agent(self, mock_sync):
+        Room.objects.create(queue=self.queue, user=self.user)
+        other_user = User.objects.create(email="other@test.com")
+        Room.objects.create(queue=self.queue, user=other_user)
+
+        InServiceStatusService.schedule_sync_for_all_agents()
+
+        self.assertEqual(mock_sync.call_count, 2)
+
+    @patch.object(InServiceStatusService, "sync_agent_status")
+    def test_continues_when_one_sync_raises(self, mock_sync):
+        mock_sync.side_effect = Exception("boom")
+        Room.objects.create(queue=self.queue, user=self.user)
+
+        # Should not raise
+        InServiceStatusService.schedule_sync_for_all_agents()
+
+        mock_sync.assert_called()
+
+
+class TestInServiceStatusTracker(_BaseStatusServiceTestCase):
+    @patch.object(InServiceStatusService, "room_assigned")
+    def test_tracker_room_assigned_delegates(self, mock_assigned):
+        InServiceStatusTracker.room_assigned(self.user, self.project)
+        mock_assigned.assert_called_once_with(self.user, self.project)
+
+    @patch.object(InServiceStatusService, "room_closed")
+    def test_tracker_room_closed_delegates(self, mock_closed):
+        InServiceStatusTracker.room_closed(self.user, self.project)
+        mock_closed.assert_called_once_with(self.user, self.project)
+
+    @patch.object(InServiceStatusService, "sync_agent_status")
+    def test_tracker_sync_delegates(self, mock_sync):
+        InServiceStatusTracker.sync_agent_status(self.user, self.project)
+        mock_sync.assert_called_once_with(self.user, self.project)

--- a/chats/apps/projects/tests/test_tasks.py
+++ b/chats/apps/projects/tests/test_tasks.py
@@ -1,0 +1,169 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from chats.apps.accounts.models import User
+from chats.apps.projects.models import Project, ProjectPermission
+from chats.apps.projects.models.models import AgentDisconnectLog, AgentStatusLog
+from chats.apps.projects.tasks import (
+    create_agent_disconnect_log,
+    log_agent_status_change,
+)
+
+
+class _BaseProjectTaskTestCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Task Project")
+        self.agent = User.objects.create(email="agent@test.com")
+        self.disconnector = User.objects.create(email="manager@test.com")
+        ProjectPermission.objects.create(
+            project=self.project,
+            user=self.agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+
+
+class TestCreateAgentDisconnectLog(_BaseProjectTaskTestCase):
+    def test_creates_log_entry(self):
+        create_agent_disconnect_log.run(
+            project_uuid=str(self.project.uuid),
+            agent_email=self.agent.email,
+            disconnected_by_email=self.disconnector.email,
+        )
+
+        log = AgentDisconnectLog.objects.get()
+        self.assertEqual(log.project, self.project)
+        self.assertEqual(log.agent, self.agent)
+        self.assertEqual(log.disconnected_by, self.disconnector)
+
+
+class TestLogAgentStatusChange(_BaseProjectTaskTestCase):
+    def _last_change(self, log):
+        return log.status_changes[-1]
+
+    def test_creates_initial_online_entry(self):
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="ONLINE",
+        )
+
+        log = AgentStatusLog.objects.get(agent=self.agent, project=self.project)
+        self.assertEqual(len(log.status_changes), 1)
+        entry = self._last_change(log)
+        self.assertEqual(entry["status"], "ONLINE")
+        self.assertIn("timestamp", entry)
+        self.assertNotIn("custom_status", entry)
+
+    def test_creates_offline_entry_when_no_custom_status(self):
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="OFFLINE",
+        )
+
+        log = AgentStatusLog.objects.get(agent=self.agent, project=self.project)
+        entry = self._last_change(log)
+        self.assertEqual(entry["status"], "OFFLINE")
+
+    def test_creates_in_service_custom_entry(self):
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="OFFLINE",
+            custom_status_name="In-Service",
+            custom_status_type_uuid="11111111-1111-1111-1111-111111111111",
+        )
+
+        log = AgentStatusLog.objects.get(agent=self.agent, project=self.project)
+        entry = self._last_change(log)
+        self.assertEqual(entry["status"], "In-Service")
+        self.assertEqual(entry["custom_status"], "In-Service")
+
+    def test_creates_break_custom_entry_for_other_status(self):
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="OFFLINE",
+            custom_status_name="Lunch",
+            custom_status_type_uuid="22222222-2222-2222-2222-222222222222",
+        )
+
+        log = AgentStatusLog.objects.get(agent=self.agent, project=self.project)
+        entry = self._last_change(log)
+        self.assertEqual(entry["status"], "BREAK")
+        self.assertEqual(entry["custom_status"], "Lunch")
+
+    def test_appends_new_entry_to_existing_log(self):
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="ONLINE",
+        )
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="OFFLINE",
+        )
+
+        log = AgentStatusLog.objects.get(agent=self.agent, project=self.project)
+        self.assertEqual(len(log.status_changes), 2)
+        self.assertEqual(log.status_changes[0]["status"], "ONLINE")
+        self.assertEqual(log.status_changes[1]["status"], "OFFLINE")
+
+    def test_dedup_when_appending_same_status(self):
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="ONLINE",
+        )
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="ONLINE",
+        )
+
+        log = AgentStatusLog.objects.get(agent=self.agent, project=self.project)
+        self.assertEqual(len(log.status_changes), 1)
+
+    @patch("chats.apps.projects.tasks.logger.error")
+    def test_logs_error_and_reraises_on_failure(self, mock_log_error):
+        with self.assertRaises(Exception):
+            log_agent_status_change.run(
+                agent_email="missing@test.com",
+                project_uuid=str(self.project.uuid),
+                status="ONLINE",
+            )
+
+        mock_log_error.assert_called()
+
+    @patch(
+        "chats.apps.projects.models.models.CustomStatus.objects.filter"
+    )
+    def test_infers_custom_status_from_active_status(self, mock_filter):
+        active = type(
+            "FakeStatus",
+            (),
+            {
+                "status_type": type(
+                    "T",
+                    (),
+                    {
+                        "name": "In-Service",
+                        "uuid": "33333333-3333-3333-3333-333333333333",
+                    },
+                )()
+            },
+        )()
+        mock_filter.return_value.first.return_value = active
+
+        log_agent_status_change.run(
+            agent_email=self.agent.email,
+            project_uuid=str(self.project.uuid),
+            status="OFFLINE",
+        )
+
+        log = AgentStatusLog.objects.get(agent=self.agent, project=self.project)
+        entry = self._last_change(log)
+        self.assertEqual(entry["status"], "In-Service")
+        self.assertEqual(entry["custom_status"], "In-Service")

--- a/chats/apps/projects/tests/test_template_type_consumer.py
+++ b/chats/apps/projects/tests/test_template_type_consumer.py
@@ -1,0 +1,57 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from chats.apps.projects.consumers.template_type_consumer import (
+    TemplateTypeConsumer,
+)
+
+
+class TestTemplateTypeConsumer(TestCase):
+    def setUp(self):
+        self.mock_channel = Mock()
+        self.mock_message = Mock()
+        self.mock_message.channel = self.mock_channel
+        self.mock_message.delivery_tag = "ttt"
+        self.mock_message.headers = {"x-error-count": 0}
+
+    @patch(
+        "chats.apps.projects.consumers.template_type_consumer.TemplateTypeCreation"
+    )
+    def test_consumes_valid_message_and_acks(self, mock_creation_class):
+        self.mock_message.body = b'{"uuid": "u-1", "name": "TT"}'
+
+        TemplateTypeConsumer.consume(self.mock_message)
+
+        mock_creation_class.assert_called_once_with(
+            config={"uuid": "u-1", "name": "TT"}
+        )
+        mock_creation_class.return_value.create.assert_called_once()
+        self.mock_channel.basic_ack.assert_called_once_with("ttt")
+
+    @patch(
+        "chats.apps.projects.consumers.template_type_consumer.TemplateTypeCreation"
+    )
+    def test_parse_error_is_rejected_by_decorator(self, mock_creation_class):
+        self.mock_message.body = b"{bad json"
+
+        TemplateTypeConsumer.consume(self.mock_message)
+
+        mock_creation_class.assert_not_called()
+        self.mock_channel.basic_reject.assert_called_once_with(
+            "ttt", requeue=False
+        )
+
+    @patch(
+        "chats.apps.projects.consumers.template_type_consumer.TemplateTypeCreation"
+    )
+    def test_usecase_exception_is_rejected(self, mock_creation_class):
+        self.mock_message.body = b'{"uuid": "u-1"}'
+        mock_creation_class.return_value.create.side_effect = Exception("boom")
+
+        TemplateTypeConsumer.consume(self.mock_message)
+
+        self.mock_channel.basic_reject.assert_called_once_with(
+            "ttt", requeue=False
+        )
+        self.mock_channel.basic_ack.assert_not_called()

--- a/chats/apps/projects/tests/test_template_type_creation.py
+++ b/chats/apps/projects/tests/test_template_type_creation.py
@@ -1,0 +1,87 @@
+import uuid
+
+from django.test import TestCase
+
+from chats.apps.projects.models import Project, TemplateType
+from chats.apps.projects.usecases.exceptions import InvalidTemplateTypeData
+from chats.apps.projects.usecases.template_type_creation import TemplateTypeCreation
+from chats.apps.sectors.models import Sector
+
+
+class TestTemplateTypeCreation(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="TT Test Project")
+        self.template_uuid = str(uuid.uuid4())
+
+    def test_create_raises_when_project_not_found(self):
+        config = {"project_uuid": str(uuid.uuid4()), "uuid": self.template_uuid, "name": "x"}
+        with self.assertRaises(InvalidTemplateTypeData):
+            TemplateTypeCreation(config=config).create()
+
+    def test_create_creates_template_with_setup_from_active_sectors(self):
+        sector_a = Sector.objects.create(
+            name="Sector A",
+            project=self.project,
+            rooms_limit=3,
+            work_start="08:00",
+            work_end="18:00",
+        )
+        sector_b = Sector.objects.create(
+            name="Sector B",
+            project=self.project,
+            rooms_limit=2,
+            work_start="09:00",
+            work_end="17:00",
+        )
+
+        config = {
+            "project_uuid": str(self.project.uuid),
+            "uuid": self.template_uuid,
+            "name": "My Template",
+        }
+        template_type = TemplateTypeCreation(config=config).create()
+
+        self.assertEqual(template_type.name, "My Template")
+        self.assertEqual(str(template_type.uuid), self.template_uuid)
+        sector_names = {s["name"] for s in template_type.setup["sectors"]}
+        self.assertEqual(sector_names, {sector_a.name, sector_b.name})
+
+    def test_create_excludes_deleted_sectors(self):
+        Sector.objects.create(
+            name="Active Sector",
+            project=self.project,
+            rooms_limit=3,
+            work_start="08:00",
+            work_end="18:00",
+        )
+        Sector.objects.create(
+            name="Deleted Sector",
+            project=self.project,
+            rooms_limit=3,
+            work_start="08:00",
+            work_end="18:00",
+            is_deleted=True,
+        )
+
+        config = {
+            "project_uuid": str(self.project.uuid),
+            "uuid": self.template_uuid,
+            "name": "Filtered Template",
+        }
+        template_type = TemplateTypeCreation(config=config).create()
+
+        sector_names = [s["name"] for s in template_type.setup["sectors"]]
+        self.assertEqual(sector_names, ["Active Sector"])
+
+    def test_create_updates_existing_template_type(self):
+        TemplateType.objects.create(uuid=self.template_uuid, name="Old", setup={})
+
+        config = {
+            "project_uuid": str(self.project.uuid),
+            "uuid": self.template_uuid,
+            "name": "New Name",
+        }
+        template_type = TemplateTypeCreation(config=config).create()
+
+        self.assertEqual(template_type.name, "New Name")
+        self.assertEqual(TemplateType.objects.filter(uuid=self.template_uuid).count(), 1)

--- a/chats/apps/quickmessages/tests/test_viewsets_additional.py
+++ b/chats/apps/quickmessages/tests/test_viewsets_additional.py
@@ -1,0 +1,85 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from chats.apps.accounts.models import User
+from chats.apps.api.utils import create_user_and_token
+from chats.apps.projects.models import Project, ProjectPermission
+from chats.apps.quickmessages.models import QuickMessage
+from chats.apps.queues.models import Queue
+from chats.apps.sectors.models import Sector, SectorAuthorization
+
+
+class TestQuickMessageOwnerPermissions(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user, token = create_user_and_token("owner")
+        self.other = User.objects.create_user(
+            email="other@test.com", password="pw"
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+        self.others_message = QuickMessage.objects.create(
+            user=self.other, shortcut="x", text="not mine"
+        )
+
+    def test_retrieve_returns_404_for_non_owner(self):
+        url = reverse("quickmessage-detail", kwargs={"pk": self.others_message.pk})
+        response = self.client.get(url)
+        # Non-owners cannot see the message via get_queryset filter -> 404
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class TestSectorQuickMessageViewset(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user, token = create_user_and_token("sector-mgr")
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+        self.project = Project.objects.create(name="SQM Project")
+        self.permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=self.user,
+            role=ProjectPermission.ROLE_ADMIN,
+        )
+        self.sector = Sector.objects.create(
+            name="SQM Sector",
+            project=self.project,
+            rooms_limit=2,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        SectorAuthorization.objects.create(
+            permission=self.permission, sector=self.sector
+        )
+        Queue.objects.create(name="SQM Queue", sector=self.sector)
+        self.sector_message = QuickMessage.objects.create(
+            user=self.user,
+            sector=self.sector,
+            shortcut="hello",
+            text="hi {first_name}",
+        )
+
+    def _list_url(self):
+        return reverse("sector_quick_message-list")
+
+    def test_list_with_project_filters_by_permission(self):
+        response = self.client.get(
+            f"{self._list_url()}?project={self.project.uuid}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = (
+            response.data["results"]
+            if isinstance(response.data, dict) and "results" in response.data
+            else response.data
+        )
+        shortcuts = [item["shortcut"] for item in results]
+        self.assertIn("hello", shortcuts)
+
+    def test_list_without_project_raises_api_exception(self):
+        response = self.client.get(self._list_url())
+        # The viewset raises APIException when there's no permission for the
+        # missing/empty project parameter.
+        self.assertEqual(
+            response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR
+        )

--- a/chats/apps/sectors/tests/test_automatic_messages_service.py
+++ b/chats/apps/sectors/tests/test_automatic_messages_service.py
@@ -1,0 +1,175 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from chats.apps.accounts.models import User
+from chats.apps.contacts.models import Contact
+from chats.apps.msgs.models import AutomaticMessage, Message
+from chats.apps.projects.models import Project
+from chats.apps.queues.models import Queue
+from chats.apps.rooms.models import Room
+from chats.apps.sectors.models import Sector
+from chats.apps.sectors.services import AutomaticMessagesService
+
+
+class _BaseAutoMessageTestCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="AM Project")
+        self.sector = Sector.objects.create(
+            name="AM Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start="09:00",
+            work_end="18:00",
+            is_automatic_message_active=True,
+            automatic_message_text="Default text",
+        )
+        self.queue = Queue.objects.create(name="AM Queue", sector=self.sector)
+        self.contact = Contact.objects.create(name="AM Contact")
+        self.user = User.objects.create(email="am-agent@test.com")
+        self.room = Room.objects.create(
+            queue=self.queue, contact=self.contact, user=self.user
+        )
+
+    def _service(self):
+        return AutomaticMessagesService()
+
+
+class TestSendAutomaticMessageEarlyReturns(_BaseAutoMessageTestCase):
+    def test_returns_false_when_automatic_disabled(self):
+        self.sector.is_automatic_message_active = False
+        self.sector.save()
+
+        result = self._service().send_automatic_message(
+            self.room, "hi", self.user
+        )
+        self.assertFalse(result)
+        self.assertFalse(Message.objects.filter(room=self.room).exists())
+
+    def test_returns_false_when_no_default_text(self):
+        self.sector.automatic_message_text = ""
+        self.sector.save()
+
+        result = self._service().send_automatic_message(
+            self.room, "hi", self.user
+        )
+        self.assertFalse(result)
+
+    def test_returns_false_when_user_message_already_exists(self):
+        Message.objects.create(room=self.room, user=self.user, text="manual")
+
+        result = self._service().send_automatic_message(
+            self.room, "hi", self.user
+        )
+        self.assertFalse(result)
+        # Pre-existing message remains; no automatic message was created
+        self.assertEqual(Message.objects.filter(room=self.room).count(), 1)
+        self.assertFalse(
+            AutomaticMessage.objects.filter(room=self.room).exists()
+        )
+
+    def test_returns_false_when_automatic_message_already_exists(self):
+        existing_msg = Message.objects.create(
+            room=self.room, user=self.user, text="prior"
+        )
+        AutomaticMessage.objects.create(room=self.room, message=existing_msg)
+
+        result = self._service().send_automatic_message(
+            self.room, "hi", self.user
+        )
+        self.assertFalse(result)
+
+
+class TestSendAutomaticMessageHappyPath(_BaseAutoMessageTestCase):
+    def test_creates_message_and_returns_true(self):
+        result = self._service().send_automatic_message(
+            self.room, "Hello!", self.user
+        )
+
+        self.assertTrue(result)
+        msg = Message.objects.get(room=self.room, user=self.user)
+        self.assertEqual(msg.text, "Hello!")
+        self.assertTrue(
+            AutomaticMessage.objects.filter(room=self.room, message=msg).exists()
+        )
+        self.room.refresh_from_db()
+        self.assertIsNotNone(self.room.automatic_message_sent_at)
+
+
+class TestSendAutomaticMessageExceptionPath(_BaseAutoMessageTestCase):
+    @patch("chats.apps.sectors.services.Message.objects.create")
+    def test_returns_false_when_message_creation_raises(self, mock_create):
+        mock_create.side_effect = RuntimeError("db down")
+
+        result = self._service().send_automatic_message(
+            self.room, "Hello", self.user
+        )
+
+        self.assertFalse(result)
+
+
+class TestSendAutomaticMessageTicketCheck(_BaseAutoMessageTestCase):
+    def setUp(self):
+        super().setUp()
+        self.room.ticket_uuid = uuid.uuid4()
+        self.room.save()
+
+    @patch("chats.apps.sectors.services.time.sleep", return_value=None)
+    @patch("chats.apps.sectors.services.FlowRESTClient")
+    def test_proceeds_when_ticket_is_found(
+        self, mock_flows_client_class, _mock_sleep
+    ):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"results": [{"id": "ticket-1"}]}
+        mock_flows_client_class.return_value.get_ticket.return_value = response
+
+        result = self._service().send_automatic_message(
+            self.room, "Hello", self.user, check_ticket=True
+        )
+
+        self.assertTrue(result)
+        mock_flows_client_class.return_value.get_ticket.assert_called()
+
+    @patch("chats.apps.sectors.services.FLOWS_GET_TICKET_RETRIES", 1)
+    @patch("chats.apps.sectors.services.time.sleep", return_value=None)
+    @patch("chats.apps.sectors.services.FlowRESTClient")
+    def test_raises_when_ticket_not_found_after_retries(
+        self, mock_flows_client_class, _mock_sleep
+    ):
+        response = MagicMock()
+        response.status_code = 404
+        mock_flows_client_class.return_value.get_ticket.return_value = response
+
+        with self.assertRaises(Exception):
+            self._service().send_automatic_message(
+                self.room, "Hello", self.user, check_ticket=True
+            )
+
+    @patch("chats.apps.sectors.services.FLOWS_GET_TICKET_RETRIES", 0)
+    @patch("chats.apps.sectors.services.time.sleep", return_value=None)
+    @patch("chats.apps.sectors.services.FlowRESTClient")
+    def test_uses_secondary_project_when_configured(
+        self, mock_flows_client_class, _mock_sleep
+    ):
+        secondary = Project.objects.create(
+            name="AM Secondary",
+        )
+        self.sector.secondary_project = {"uuid": str(secondary.uuid)}
+        self.sector.save()
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"results": [{"id": "ticket-1"}]}
+        mock_flows_client_class.return_value.get_ticket.return_value = response
+
+        result = self._service().send_automatic_message(
+            self.room, "Hello", self.user, check_ticket=True
+        )
+        self.assertTrue(result)
+
+        called_project = mock_flows_client_class.return_value.get_ticket.call_args[
+            0
+        ][0]
+        self.assertEqual(str(called_project.uuid), str(secondary.uuid))

--- a/chats/apps/sectors/tests/test_utils.py
+++ b/chats/apps/sectors/tests/test_utils.py
@@ -1,0 +1,400 @@
+from datetime import datetime, time
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+
+from chats.apps.projects.models import Project
+from chats.apps.sectors.models import Sector
+from chats.apps.sectors.utils import (
+    WorkingHoursValidator,
+    get_country_from_timezone,
+    get_country_holidays,
+    get_holidays_by_timezone,
+    working_hours_validator,
+)
+
+
+class _SectorTestBase(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.project = Project.objects.create(name="WH Test Project")
+        self.sector = Sector.objects.create(
+            name="WH Sector",
+            project=self.project,
+            rooms_limit=2,
+            work_start="09:00",
+            work_end="18:00",
+        )
+
+
+class TestWorkingHoursValidatorEmptyConfig(_SectorTestBase):
+    def test_returns_none_when_no_working_day(self):
+        self.assertIsNone(
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 10, 0)
+            )
+        )
+
+    def test_returns_none_when_empty_working_hours(self):
+        self.sector.working_day = {"working_hours": {}}
+        self.sector.save()
+
+        self.assertIsNone(
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 10, 0)
+            )
+        )
+
+
+class TestWorkingHoursValidatorClosedWeekdays(_SectorTestBase):
+    def test_raises_when_weekday_in_closed_weekdays(self):
+        # 2026-05-21 is Thursday (isoweekday 4)
+        self.sector.working_day = {"working_hours": {"closed_weekdays": [4]}}
+        self.sector.save()
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 10, 0)
+            )
+
+
+class TestWorkingHoursValidatorWeekdaySchedule(_SectorTestBase):
+    def test_passes_when_inside_dict_interval(self):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"thursday": {"start": "09:00", "end": "18:00"}}
+            }
+        }
+        self.sector.save()
+
+        WorkingHoursValidator().validate_working_hours(
+            self.sector, datetime(2026, 5, 21, 10, 0)
+        )
+
+    def test_raises_when_outside_dict_interval(self):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"thursday": {"start": "09:00", "end": "18:00"}}
+            }
+        }
+        self.sector.save()
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 20, 0)
+            )
+
+    def test_raises_when_dict_interval_missing_keys(self):
+        self.sector.working_day = {
+            "working_hours": {"schedules": {"thursday": {"start": "09:00"}}}
+        }
+        self.sector.save()
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 10, 0)
+            )
+
+    def test_passes_when_inside_one_of_list_intervals(self):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {
+                    "thursday": [
+                        {"start": "08:00", "end": "10:00"},
+                        {"start": "13:00", "end": "17:00"},
+                    ]
+                }
+            }
+        }
+        self.sector.save()
+
+        WorkingHoursValidator().validate_working_hours(
+            self.sector, datetime(2026, 5, 21, 14, 0)
+        )
+
+    def test_raises_when_outside_all_list_intervals(self):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {
+                    "thursday": [
+                        {"start": "08:00", "end": "10:00"},
+                        {"start": "13:00", "end": "17:00"},
+                    ]
+                }
+            }
+        }
+        self.sector.save()
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 12, 0)
+            )
+
+    def test_skips_invalid_list_interval(self):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {
+                    "thursday": [
+                        {"start": "08:00"},
+                        {"start": "13:00", "end": "17:00"},
+                    ]
+                }
+            }
+        }
+        self.sector.save()
+
+        WorkingHoursValidator().validate_working_hours(
+            self.sector, datetime(2026, 5, 21, 14, 0)
+        )
+
+    def test_raises_when_unknown_day_cfg_type(self):
+        self.sector.working_day = {
+            "working_hours": {"schedules": {"thursday": "weird"}}
+        }
+        self.sector.save()
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 10, 0)
+            )
+
+    def test_raises_when_weekday_not_configured(self):
+        # No schedules at all for the day
+        self.sector.working_day = {"working_hours": {"schedules": {}}}
+        self.sector.save()
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 10, 0)
+            )
+
+
+class TestWorkingHoursValidatorStaticHolidays(_SectorTestBase):
+    def test_static_holiday_closed_raises(self):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"thursday": {"start": "09:00", "end": "18:00"}},
+                "static_holidays": {"2026-05-21": {"closed": True}},
+            }
+        }
+        self.sector.save()
+
+        with self.assertRaises(ValidationError) as ctx:
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 10, 0)
+            )
+        self.assertIn("holiday", str(ctx.exception).lower())
+
+    def test_static_holiday_open_with_hours_passes_inside_window(self):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"thursday": {"start": "09:00", "end": "18:00"}},
+                "static_holidays": {
+                    "2026-05-21": {
+                        "closed": False,
+                        "start": "10:00",
+                        "end": "14:00",
+                    }
+                },
+            }
+        }
+        self.sector.save()
+
+        # Inside holiday window: no error from static_holiday but still
+        # needs to be inside the weekday schedule (also passing)
+        WorkingHoursValidator().validate_working_hours(
+            self.sector, datetime(2026, 5, 21, 12, 0)
+        )
+
+    def test_static_holiday_open_with_hours_raises_outside_window(self):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"thursday": {"start": "09:00", "end": "20:00"}},
+                "static_holidays": {
+                    "2026-05-21": {
+                        "closed": False,
+                        "start": "10:00",
+                        "end": "14:00",
+                    }
+                },
+            }
+        }
+        self.sector.save()
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 19, 0)
+            )
+
+
+class TestWorkingHoursValidatorDynamicHolidays(_SectorTestBase):
+    @patch("chats.apps.sectors.models.SectorHoliday")
+    def test_closed_dynamic_holiday_raises(self, mock_sector_holiday):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"thursday": {"start": "09:00", "end": "18:00"}}
+            }
+        }
+        self.sector.save()
+
+        fake_holiday = MagicMock()
+        fake_holiday.day_type = "closed"
+        fake_holiday.start_time = None
+        fake_holiday.end_time = None
+        fake_holiday.description = "Local holiday"
+        mock_sector_holiday.objects.filter.return_value.filter.return_value.first.return_value = (
+            fake_holiday
+        )
+
+        with self.assertRaises(ValidationError) as ctx:
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 10, 0)
+            )
+        self.assertIn("holiday", str(ctx.exception).lower())
+
+    @patch("chats.apps.sectors.models.SectorHoliday")
+    def test_custom_hours_holiday_passes_in_window(self, mock_sector_holiday):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"thursday": {"start": "09:00", "end": "18:00"}}
+            }
+        }
+        self.sector.save()
+
+        fake_holiday = MagicMock()
+        fake_holiday.day_type = "custom_hours"
+        fake_holiday.start_time = time(10, 0)
+        fake_holiday.end_time = time(14, 0)
+        fake_holiday.description = "Half day"
+        mock_sector_holiday.objects.filter.return_value.filter.return_value.first.return_value = (
+            fake_holiday
+        )
+
+        WorkingHoursValidator().validate_working_hours(
+            self.sector, datetime(2026, 5, 21, 12, 0)
+        )
+
+    @patch("chats.apps.sectors.models.SectorHoliday")
+    def test_custom_hours_holiday_raises_outside_window(self, mock_sector_holiday):
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"thursday": {"start": "09:00", "end": "18:00"}}
+            }
+        }
+        self.sector.save()
+
+        fake_holiday = MagicMock()
+        fake_holiday.day_type = "custom_hours"
+        fake_holiday.start_time = time(10, 0)
+        fake_holiday.end_time = time(14, 0)
+        fake_holiday.description = "Half day"
+        mock_sector_holiday.objects.filter.return_value.filter.return_value.first.return_value = (
+            fake_holiday
+        )
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 21, 15, 0)
+            )
+
+
+class TestWorkingHoursValidatorWeekend(_SectorTestBase):
+    def test_weekend_passes_when_inside_saturday_schedule(self):
+        # 2026-05-23 Saturday (isoweekday 6)
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {
+                    "saturday": {"start": "10:00", "end": "14:00"}
+                }
+            }
+        }
+        self.sector.save()
+
+        WorkingHoursValidator().validate_working_hours(
+            self.sector, datetime(2026, 5, 23, 11, 0)
+        )
+
+    def test_weekend_raises_when_no_saturday_schedule(self):
+        self.sector.working_day = {"working_hours": {"schedules": {}}}
+        self.sector.save()
+
+        with self.assertRaises(ValidationError):
+            WorkingHoursValidator().validate_working_hours(
+                self.sector, datetime(2026, 5, 23, 11, 0)
+            )
+
+    def test_weekend_sunday_schedule(self):
+        # 2026-05-24 Sunday (isoweekday 7)
+        self.sector.working_day = {
+            "working_hours": {
+                "schedules": {"sunday": {"start": "10:00", "end": "14:00"}}
+            }
+        }
+        self.sector.save()
+
+        WorkingHoursValidator().validate_working_hours(
+            self.sector, datetime(2026, 5, 24, 11, 0)
+        )
+
+
+class TestParseTimeCached(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def test_parses_and_caches_time(self):
+        first = WorkingHoursValidator._parse_time_cached("12:30")
+        cached = WorkingHoursValidator._parse_time_cached("12:30")
+        self.assertEqual(first, cached)
+        self.assertEqual(first, time(12, 30))
+
+
+class TestCountryHolidays(TestCase):
+    def test_returns_empty_for_unknown_country_code(self):
+        self.assertEqual(get_country_holidays("ZZ", year=2026), {})
+
+    def test_returns_empty_for_empty_country_code(self):
+        self.assertEqual(get_country_holidays("", year=2026), {})
+        self.assertEqual(get_country_holidays(None, year=2026), {})
+
+    def test_returns_known_country_holidays(self):
+        holidays = get_country_holidays("BR", year=2026)
+        self.assertIsInstance(holidays, dict)
+        # Expect at least one holiday for Brazil
+        self.assertTrue(len(holidays) > 0)
+
+    def test_falls_back_to_current_year_when_year_none(self):
+        # Should not raise; defaults to current year
+        result = get_country_holidays("BR")
+        self.assertIsInstance(result, dict)
+
+
+class TestCountryFromTimezone(TestCase):
+    def test_returns_none_for_empty_timezone(self):
+        self.assertIsNone(get_country_from_timezone(""))
+        self.assertIsNone(get_country_from_timezone(None))
+
+    def test_returns_country_for_known_timezone(self):
+        self.assertEqual(get_country_from_timezone("America/Sao_Paulo"), "BR")
+
+    def test_returns_country_case_insensitive(self):
+        self.assertEqual(get_country_from_timezone("america/sao_paulo"), "BR")
+
+    def test_returns_country_by_city_fallback(self):
+        # Use a city-only string to drive the city fallback
+        self.assertIsNotNone(get_country_from_timezone("Sao_Paulo"))
+
+    def test_returns_none_for_unknown_timezone(self):
+        self.assertIsNone(get_country_from_timezone("Unknown/Place"))
+
+
+class TestHolidaysByTimezone(TestCase):
+    def test_returns_holidays_for_known_timezone(self):
+        holidays = get_holidays_by_timezone("America/Sao_Paulo", year=2026)
+        self.assertIsInstance(holidays, dict)
+
+
+class TestSingletonInstance(TestCase):
+    def test_module_level_singleton_exists(self):
+        self.assertIsInstance(working_hours_validator, WorkingHoursValidator)


### PR DESCRIPTION
### What
Adds 12 new test modules under `chats/apps/projects/tests/`, `chats/apps/quickmessages/tests/`, and `chats/apps/sectors/tests/` (1,827 lines of new tests), covering previously untested components:

- `DeadLetterConsumer` and `DeadLetterHandler` (DLQ republish flow, header validation, requeue limits, error propagation)
- `SectorCreationUseCase`, `SectorSetupHandlerUseCase`, and the `send_room_info` flow (DTO building, sector/queue/tag persistence, idempotency, EDA client integration)
- `TemplateTypeConsumer` and template type creation use case
- Project `status_service` and project-related Celery `tasks`
- Quickmessages additional viewset coverage
- Sectors `utils` and `AutomaticMessagesService`

No production code changes — tests only, using `unittest.mock` to isolate external dependencies (EDA client, RabbitMQ channels, etc.).

### Why
These modules previously had little to no direct unit coverage, leaving regressions in messaging consumers, dead-letter handling, and sector setup flows hard to catch. Adding focused tests around handlers, use cases, services, and tasks raises confidence when refactoring the EDA pipeline and sector provisioning, and documents the expected behavior (ack/reject semantics, idempotent sector creation, validation errors) for future contributors.