### PR TITLE
feat: Add edaconsume and edaconsumenmsg commands to docker-entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -78,6 +78,31 @@ elif [[ "celery-beat" == "$1" ]]; then
         -A "${CELERY_APP}" --workdir="${PROJECT_PATH}" beat \
         --loglevel="${LOG_LEVEL}" \
         -s "${CELERY_BEAT_DATABASE_FILE}"
+elif [[ "edaconsume" == "$1" ]]; then
+    shift 1
+    group="eda"
+    if [[ "$1" == "template" ]]; then
+        group="template"
+        shift 1
+    fi
+    do_gosu "${PROJECT_USER}:${PROJECT_GROUP}" exec python manage.py edaconsume --group "$group" "$@"
+elif [[ "edaconsumemsg" == "$1" ]]; then
+    shift 1
+    group="eda"
+    if [[ "$1" == "template" ]]; then
+        group="template"
+        shift 1
+    fi
+    do_gosu "${PROJECT_USER}:${PROJECT_GROUP}" exec python manage.py msg_edaconsume --group "$group" "$@"
+elif [[ "edaconsume" == "$1" ]]; then
+    shift 1
+    group="eda"
+    if [[ "$1" == "template" ]]; then
+        group="template"
+        shift 1
+    fi
+    do_gosu "${PROJECT_USER}:${PROJECT_GROUP}" exec python manage.py msg_edaconsume_amq --group "$group" "$@"
 fi
+
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -94,7 +94,7 @@ elif [[ "edaconsumemsg" == "$1" ]]; then
         shift 1
     fi
     do_gosu "${PROJECT_USER}:${PROJECT_GROUP}" exec python manage.py msg_edaconsume --group "$group" "$@"
-elif [[ "edaconsume" == "$1" ]]; then
+elif [[ "edaconsumemsg-amq" == "$1" ]]; then
     shift 1
     group="eda"
     if [[ "$1" == "template" ]]; then


### PR DESCRIPTION

### **What**

Adiciona comandos de EDA consumer no `docker-entrypoint.sh`.

Novos comandos disponíveis via entrypoint:

| Comando | Management command |
|---|---|
| `edaconsume` | `python manage.py edaconsume` |
| `edaconsumemsg` | `python manage.py msg_edaconsume` |
| `edaconsumemsg-amq` | `python manage.py msg_edaconsume_amq` |

Cada comando aceita o argumento opcional `template` para selecionar o grupo de consumers.

---

### **Why**

Os deployments de EDA no Kubernetes (`chats-eda-consumer`, `chats-eda-consumer-messages` e `chats-eda-consumer-messages-amq`) precisam iniciar consumers distintos a partir da mesma imagem Docker.

Centralizar esses comandos no entrypoint:

- Padroniza com outros serviços da plataforma (ex.: flows)
- Permite configurar os manifests com `args` em vez de `command` completo
- Facilita execução local e debug via Docker