### PR TITLE
fix: Flow template info

### DIFF
--- a/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
+++ b/chats/apps/api/v1/internal/rest_clients/flows_rest_client.py
@@ -268,12 +268,12 @@ class FlowRESTClient(
             ]
         return flows
 
-    def retrieve_flow_definitions(self, project, flow_uuid):
+    def retrieve_flow_definitions(self, project, flow_uuid, dependencies="all"):
         response = retry_request_and_refresh_flows_auth_token(
             project=project,
             request_method=requests.get,
             headers=self.project_headers(project.flows_authorization),
-            url=f"{self.base_url}/api/v2/definitions.json?flow={flow_uuid}",
+            url=f"{self.base_url}/api/v2/definitions.json?flow={flow_uuid}&dependencies={dependencies}",
         )
         try:
             flows = response.json()
@@ -355,9 +355,7 @@ class FlowRESTClient(
         except requests.RequestException as exc:
             raise FlowsTicketerNotFoundError(
                 sector_uuid=str(sector_uuid),
-                message=(
-                    f"Failed to request ticketer for sector {sector_uuid}: {exc}"
-                ),
+                message=(f"Failed to request ticketer for sector {sector_uuid}: {exc}"),
             ) from exc
 
         if response.status_code != status.HTTP_200_OK:

--- a/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
+++ b/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
@@ -37,11 +37,12 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         self.channel_uuid = str(uuid.uuid4())
         self.waba_id = "111222333444"
 
-    def _make_definition_with_template(
+    def _make_flow_with_template(
         self,
         template_uuid,
         template_name,
         variables=None,
+        flow_uuid=None,
     ):
         if variables is None:
             variables = [
@@ -49,52 +50,64 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                 "@trigger.params.agentname",
             ]
         return {
-            "flows": [
+            "uuid": flow_uuid or self.flow_uuid,
+            "nodes": [
                 {
-                    "nodes": [
+                    "uuid": str(uuid.uuid4()),
+                    "actions": [
                         {
+                            "type": "send_msg",
                             "uuid": str(uuid.uuid4()),
-                            "actions": [
-                                {
-                                    "type": "send_msg",
-                                    "uuid": str(uuid.uuid4()),
-                                    "text": "",
-                                    "templating": {
-                                        "uuid": str(uuid.uuid4()),
-                                        "template": {
-                                            "uuid": template_uuid,
-                                            "name": template_name,
-                                        },
-                                        "variables": variables,
-                                    },
-                                }
-                            ],
+                            "text": "",
+                            "templating": {
+                                "uuid": str(uuid.uuid4()),
+                                "template": {
+                                    "uuid": template_uuid,
+                                    "name": template_name,
+                                },
+                                "variables": variables,
+                            },
                         }
-                    ]
+                    ],
                 }
+            ],
+        }
+
+    def _make_definition_with_template(
+        self,
+        template_uuid,
+        template_name,
+        variables=None,
+        flow_uuid=None,
+    ):
+        return {
+            "flows": [
+                self._make_flow_with_template(
+                    template_uuid, template_name, variables, flow_uuid
+                )
             ]
         }
 
-    def _make_definition_without_template(self):
+    def _make_flow_without_template(self, flow_uuid=None):
         return {
-            "flows": [
+            "uuid": flow_uuid or self.flow_uuid,
+            "nodes": [
                 {
-                    "nodes": [
+                    "uuid": str(uuid.uuid4()),
+                    "actions": [
                         {
+                            "type": "set_run_result",
                             "uuid": str(uuid.uuid4()),
-                            "actions": [
-                                {
-                                    "type": "set_run_result",
-                                    "uuid": str(uuid.uuid4()),
-                                    "name": "params",
-                                    "value": "@trigger.params",
-                                }
-                            ],
+                            "name": "params",
+                            "value": "@trigger.params",
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
+
+    def _make_definition_without_template(self):
+        return {"flows": [self._make_flow_without_template()]}
 
     def _make_flows_template_response(self, channel_uuid, channel_name="Channel"):
         return {
@@ -180,6 +193,7 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         definition = {
             "flows": [
                 {
+                    "uuid": self.flow_uuid,
                     "nodes": [
                         {
                             "uuid": str(uuid.uuid4()),
@@ -221,7 +235,7 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                                 }
                             ],
                         },
-                    ]
+                    ],
                 }
             ]
         }
@@ -254,6 +268,7 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         definition = {
             "flows": [
                 {
+                    "uuid": self.flow_uuid,
                     "nodes": [
                         {
                             "uuid": str(uuid.uuid4()),
@@ -295,7 +310,7 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                                 }
                             ],
                         },
-                    ]
+                    ],
                 }
             ]
         }
@@ -379,11 +394,11 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         self.assertIn("exc_info", call_kwargs.kwargs)
 
     def test_extract_templates_from_definition_finds_templating_in_actions(self):
-        definition = self._make_definition_with_template(
+        flow = self._make_flow_with_template(
             self.template_uuid, self.template_name
         )
 
-        result = self.use_case._extract_templates_from_definition(definition)
+        result = self.use_case._extract_templates_from_definition(flow)
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["uuid"], self.template_uuid)
@@ -393,14 +408,14 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         )
 
     def test_extract_templates_ignores_actions_without_templating(self):
-        definition = self._make_definition_without_template()
+        flow = self._make_flow_without_template()
 
-        result = self.use_case._extract_templates_from_definition(definition)
+        result = self.use_case._extract_templates_from_definition(flow)
 
         self.assertEqual(result, [])
 
     def test_extract_templates_filters_only_trigger_params_variables(self):
-        definition = self._make_definition_with_template(
+        flow = self._make_flow_with_template(
             self.template_uuid,
             self.template_name,
             variables=[
@@ -411,7 +426,7 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
             ],
         )
 
-        result = self.use_case._extract_templates_from_definition(definition)
+        result = self.use_case._extract_templates_from_definition(flow)
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["variables"], ["contactname", "url"])
@@ -427,3 +442,59 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
 
         with self.assertRaises(FlowTemplateChannelsNotFound):
             self.use_case.execute(flow_uuid=self.flow_uuid)
+
+    def test_get_flow_definition_filters_response_by_flow_uuid(self):
+        other_flow_uuid = str(uuid.uuid4())
+        other_template_uuid = str(uuid.uuid4())
+
+        definition = {
+            "flows": [
+                self._make_flow_with_template(
+                    other_template_uuid,
+                    "other_template",
+                    flow_uuid=other_flow_uuid,
+                ),
+                self._make_flow_with_template(
+                    self.template_uuid,
+                    self.template_name,
+                ),
+            ]
+        }
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        self.mock_flows_templates_usecase.execute.return_value = (
+            self._make_flows_template_response(self.channel_uuid)
+        )
+        self.mock_channels_usecase.execute.return_value = [
+            self._make_project_channel(self.channel_uuid, self.waba_id)
+        ]
+        meta_template = self._make_meta_template()
+        self.mock_meta_client.get_templates_list.return_value = {
+            "data": [meta_template]
+        }
+
+        result = self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.assertEqual(len(result.templates), 1)
+        self.assertEqual(result.templates[0].id, meta_template["id"])
+        self.mock_flows_templates_usecase.execute.assert_called_once_with(
+            name=self.template_name, uuid=self.template_uuid
+        )
+
+    def test_get_flow_definition_returns_empty_when_no_flow_matches(self):
+        definition = {
+            "flows": [
+                self._make_flow_with_template(
+                    str(uuid.uuid4()),
+                    "other_template",
+                    flow_uuid=str(uuid.uuid4()),
+                )
+            ]
+        }
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        result = self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.assertEqual(result, FlowTemplatesData(uuid=self.flow_uuid, templates=[]))
+        self.mock_flows_templates_usecase.execute.assert_not_called()
+        self.mock_meta_client.get_templates_list.assert_not_called()

--- a/chats/apps/projects/usecases/flow_templates.py
+++ b/chats/apps/projects/usecases/flow_templates.py
@@ -33,7 +33,9 @@ class GetFlowTemplatesDataUseCase:
     def _get_flow_definition(self, flow_uuid):
         project = Project.objects.get(uuid=self.project_uuid)
 
-        response_data = self.flows_client.retrieve_flow_definitions(project, flow_uuid)
+        response_data = self.flows_client.retrieve_flow_definitions(
+            project, flow_uuid, dependencies="none"
+        )
 
         definition = {}
 

--- a/chats/apps/projects/usecases/flow_templates.py
+++ b/chats/apps/projects/usecases/flow_templates.py
@@ -32,7 +32,17 @@ class GetFlowTemplatesDataUseCase:
 
     def _get_flow_definition(self, flow_uuid):
         project = Project.objects.get(uuid=self.project_uuid)
-        return self.flows_client.retrieve_flow_definitions(project, flow_uuid)
+
+        response_data = self.flows_client.retrieve_flow_definitions(project, flow_uuid)
+
+        definition = {}
+
+        for flow in response_data.get("flows", []):
+            if flow.get("uuid") == flow_uuid:
+                definition = flow
+                break
+
+        return definition
 
     TRIGGER_PARAMS_PREFIX = "@trigger.params."
 
@@ -40,39 +50,38 @@ class GetFlowTemplatesDataUseCase:
         seen_uuids = set()
         templates_info = []
 
-        for flow in definition.get("flows", []):
-            for node in flow.get("nodes", []):
-                for action in node.get("actions", []):
-                    templating = action.get("templating")
-                    if not templating:
-                        continue
+        for node in definition.get("nodes", []):
+            for action in node.get("actions", []):
+                templating = action.get("templating")
+                if not templating:
+                    continue
 
-                    template = templating.get("template", {})
-                    template_uuid = template.get("uuid")
-                    template_name = template.get("name")
+                template = templating.get("template", {})
+                template_uuid = template.get("uuid")
+                template_name = template.get("name")
 
-                    if not template_uuid or not template_name:
-                        continue
+                if not template_uuid or not template_name:
+                    continue
 
-                    if template_uuid in seen_uuids:
-                        continue
+                if template_uuid in seen_uuids:
+                    continue
 
-                    seen_uuids.add(template_uuid)
+                seen_uuids.add(template_uuid)
 
-                    prefix_len = len(self.TRIGGER_PARAMS_PREFIX)
-                    variables = [
-                        var[prefix_len:]
-                        for var in templating.get("variables", [])
-                        if var.startswith(self.TRIGGER_PARAMS_PREFIX)
-                    ]
+                prefix_len = len(self.TRIGGER_PARAMS_PREFIX)
+                variables = [
+                    var[prefix_len:]
+                    for var in templating.get("variables", [])
+                    if var.startswith(self.TRIGGER_PARAMS_PREFIX)
+                ]
 
-                    templates_info.append(
-                        {
-                            "uuid": template_uuid,
-                            "name": template_name,
-                            "variables": variables,
-                        }
-                    )
+                templates_info.append(
+                    {
+                        "uuid": template_uuid,
+                        "name": template_name,
+                        "variables": variables,
+                    }
+                )
 
         return templates_info
 
@@ -147,23 +156,17 @@ class GetFlowTemplatesDataUseCase:
                     f"in flow '{flow_uuid}'"
                 )
 
-            waba_id = self._resolve_waba_id(
-                template_channels, project_channels_map
-            )
+            waba_id = self._resolve_waba_id(template_channels, project_channels_map)
             if not waba_id:
                 continue
 
-            meta_template = self._fetch_meta_template(
-                waba_id, template_info["name"]
-            )
+            meta_template = self._fetch_meta_template(waba_id, template_info["name"])
             flow_template = FlowTemplate(
                 id=meta_template["id"],
                 name=meta_template["name"],
                 data=meta_template,
                 variables=template_info.get("variables", []),
             )
-            return FlowTemplatesData(
-                uuid=flow_uuid, templates=[flow_template]
-            )
+            return FlowTemplatesData(uuid=flow_uuid, templates=[flow_template])
 
         return FlowTemplatesData(uuid=flow_uuid, templates=[])


### PR DESCRIPTION
### What
- Extend `FlowRESTClient.retrieve_flow_definitions` with a new `dependencies` keyword argument (defaults to `"all"`) that is forwarded to the upstream Flows endpoint as the `dependencies` query parameter. The URL is now `/api/v2/definitions.json?flow={flow_uuid}&dependencies={dependencies}`.
- Update `GetFlowTemplatesDataUseCase._get_flow_definition` to:
  - Call `retrieve_flow_definitions` with `dependencies="none"`, since the use case only needs the flow itself and not its referenced sub-flows / groups / fields.
  - Add a client-side safeguard that filters the response payload by `flow_uuid`, returning only the flow whose `uuid` matches the requested one (or an empty dict if no match).
- Simplify `_extract_templates_from_definition`: it now receives a single flow object instead of the wrapper, so the outer `for flow in definition.get("flows", [])` loop was removed and the templating-extraction logic iterates directly over `nodes`.
- Update the test suite for `GetFlowTemplatesDataUseCase`:
  - Split the existing fixtures into flow-level (`_make_flow_with_template`, `_make_flow_without_template`) and wrapper-level (`_make_definition_with_template`, `_make_definition_without_template`) helpers, and ensure every inner flow carries a `uuid` that matches `self.flow_uuid`.
  - Direct-call tests for `_extract_templates_from_definition` now pass a flow object instead of the wrapper.
  - Add `test_get_flow_definition_filters_response_by_flow_uuid` — covers the case where the API returns multiple flows and only the one matching `flow_uuid` must be processed.
  - Add `test_get_flow_definition_returns_empty_when_no_flow_matches` — covers the case where no flow in the payload matches `flow_uuid`, ensuring an empty `FlowTemplatesData` is returned and no downstream calls are made.

### Why
This was done to handle the case where the Flows API endpoint backing `retrieve_flow_definitions` does not filter the definitions by the `flow` query parameter correctly: it may return additional flows alongside (or instead of) the requested one. Previously, `_extract_templates_from_definition` walked over every flow in the response, which could surface templates that belong to unrelated flows and cause `GetFlowTemplatesDataUseCase` to return WhatsApp template metadata that doesn't actually exist in the requested flow.

This PR adds a defensive filter on our side so the use case only ever inspects the flow whose `uuid` matches the `flow_uuid` argument. It's a safeguard until the Flows API filter is fixed upstream — no public API of the use case changes.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Caller
    participant UseCase as GetFlowTemplatesDataUseCase
    participant FlowsClient as FlowRESTClient
    participant FlowsAPI as Flows API
    participant TemplatesUC as FlowsTemplatesUseCase
    participant ChannelsUC as GetProjectChannelsInfoUseCase
    participant Meta as MetaGraphAPIClient

    Caller->>UseCase: execute(flow_uuid)
    UseCase->>UseCase: _get_flow_definition(flow_uuid)
    UseCase->>FlowsClient: retrieve_flow_definitions(project, flow_uuid, dependencies="none")
    FlowsClient->>FlowsAPI: GET /flow/definitions?flow=flow_uuid&dependencies=none
    FlowsAPI-->>FlowsClient: response with flows list
    FlowsClient-->>UseCase: response_data

    Note over UseCase: Safeguard - pick the flow whose<br/>uuid matches flow_uuid<br/>otherwise return empty dict

    UseCase->>UseCase: _extract_templates_from_definition(flow)
    Note over UseCase: Walk nodes and actions,<br/>dedup by template uuid,<br/>strip @trigger.params. prefix

    alt no templates found
        UseCase-->>Caller: FlowTemplatesData(uuid, templates=[])
    else templates found
        UseCase->>ChannelsUC: execute()
        ChannelsUC-->>UseCase: project channels
        UseCase->>UseCase: build channel_uuid to waba_id map

        loop for each template_info
            UseCase->>TemplatesUC: execute(name, uuid)
            TemplatesUC-->>UseCase: template translations and channels

            alt no template channels
                UseCase-->>Caller: raise FlowTemplateChannelsNotFound
            else channels available
                UseCase->>UseCase: _resolve_waba_id(template_channels, channels_map)
                alt no waba_id matches
                    Note over UseCase: continue to next template
                else waba_id resolved
                    UseCase->>Meta: get_templates_list(waba_id, name)
                    alt template missing in Meta
                        Meta-->>UseCase: empty data
                        UseCase-->>Caller: raise FlowTemplateNotFound
                    else template found
                        Meta-->>UseCase: meta_template
                        UseCase-->>Caller: FlowTemplatesData(uuid, templates=[flow_template])
                    end
                end
            end
        end

        Note over UseCase: If loop ended without a return,<br/>respond with empty templates
        UseCase-->>Caller: FlowTemplatesData(uuid, templates=[])
    end