### PR TITLE
fix: Restrict accounts userdata endpoint

### DIFF
--- a/chats/apps/accounts/tests/test_viewsets.py
+++ b/chats/apps/accounts/tests/test_viewsets.py
@@ -4,6 +4,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
 from chats.apps.accounts.models import User
+from chats.apps.accounts.tests.decorators import with_internal_auth
 
 
 class UserDataTests(APITestCase):
@@ -12,26 +13,54 @@ class UserDataTests(APITestCase):
     def setUp(self) -> None:
         self.user = User.objects.get(pk=9)
         self.request_user = User.objects.get(pk=4)
+        self.other_project_user = User.objects.get(pk=2)
         self.login_token = Token.objects.get_or_create(user=self.user)[0]
+
+    def _auth_client(self):
+        client = self.client
+        client.credentials(HTTP_AUTHORIZATION="Token " + self.login_token.key)
+        return client
 
     def test_get_existent_user(self):
         url = reverse("user_data-detail")
-        client = self.client
-        client.credentials(HTTP_AUTHORIZATION="Token " + self.login_token.key)
+        client = self._auth_client()
         response = client.get(url, data={"user_email": self.request_user.email})
         self.assertEqual(response.data.get("first_name"), self.request_user.first_name)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_get_non_existent_user(self):
         url = reverse("user_data-detail")
-        client = self.client
-        client.credentials(HTTP_AUTHORIZATION="Token " + self.login_token.key)
+        client = self._auth_client()
         response = client.get(url, data={"user_email": "nonexistent@weni.ai"})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_get_without_user(self):
+    def test_get_without_user_email_returns_400(self):
         url = reverse("user_data-detail")
-        client = self.client
-        client.credentials(HTTP_AUTHORIZATION="Token " + self.login_token.key)
+        client = self._auth_client()
         response = client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("user_email", response.data)
+
+    def test_get_user_in_different_project_returns_404(self):
+        url = reverse("user_data-detail")
+        client = self._auth_client()
+        response = client.get(url, data={"user_email": self.other_project_user.email})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @with_internal_auth
+    def test_get_user_in_different_project_internal_user_returns_200(self):
+        url = reverse("user_data-detail")
+        client = self._auth_client()
+        response = client.get(url, data={"user_email": self.other_project_user.email})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data.get("first_name"), self.other_project_user.first_name
+        )
+
+    @with_internal_auth
+    def test_get_existent_user_internal_user(self):
+        url = reverse("user_data-detail")
+        client = self._auth_client()
+        response = client.get(url, data={"user_email": self.request_user.email})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("first_name"), self.request_user.first_name)

--- a/chats/apps/api/v1/accounts/serializers.py
+++ b/chats/apps/api/v1/accounts/serializers.py
@@ -41,3 +41,7 @@ class UserNameEmailSerializer(serializers.ModelSerializer):
             "last_name",
             "email",
         ]
+
+
+class UserDataQueryParamsSerializer(serializers.Serializer):
+    user_email = serializers.EmailField(required=True)

--- a/chats/apps/api/v1/accounts/viewsets.py
+++ b/chats/apps/api/v1/accounts/viewsets.py
@@ -7,8 +7,11 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from chats.apps.accounts.models import User
-from chats.apps.api.v1.accounts.serializers import LoginSerializer, UserNameSerializer
-from chats.core.cache_utils import get_user_id_by_email_cached
+from chats.apps.api.v1.accounts.serializers import (
+    LoginSerializer,
+    UserDataQueryParamsSerializer,
+    UserNameSerializer,
+)
 
 
 @method_decorator(
@@ -52,17 +55,24 @@ class UserDataViewset(viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated]
     lookup_field = None
 
-    def get_object(self):
-        user_email = self.request.query_params.get("user_email")
-        uid = get_user_id_by_email_cached(user_email)
-        if uid is None:
-            raise User.DoesNotExist()
-        return User.objects.only("email", "first_name", "last_name").get(pk=uid)
+    def get_queryset(self):
+        qs = super().get_queryset()
+        user = self.request.user
+
+        if user.has_perm("accounts.can_communicate_internally"):
+            return qs
+
+        shared_project_ids = user.project_permissions.values("project")
+        return qs.filter(project_permissions__project__in=shared_project_ids).distinct()
 
     def retrieve(self, request, *args, **kwargs):
-        try:
-            instance = self.get_object()
-        except User.DoesNotExist:
+        params = UserDataQueryParamsSerializer(data=request.query_params)
+        params.is_valid(raise_exception=True)
+        user_email = params.validated_data["user_email"]
+
+        user = self.get_queryset().filter(email=user_email).first()
+        if user is None:
             return Response({"detail": "Email not found"}, status.HTTP_404_NOT_FOUND)
-        serializer = self.get_serializer(instance)
+
+        serializer = self.get_serializer(user)
         return Response(serializer.data)


### PR DESCRIPTION
### What
Restrict access to the `GET /v1/accounts/userdata` endpoint so requesters can only read data for users that share at least one project with them. Users that hold the `accounts.can_communicate_internally` permission (internal services) keep unrestricted access. The endpoint now also validates the `user_email` query param through a serializer, returning `400 Bad Request` when it's missing or malformed instead of the previous `404`.

Changes:
- `chats/apps/api/v1/accounts/viewsets.py`: replaced the cache-based email lookup in `UserDataViewset` with a scoped `get_queryset` that filters users by shared projects, plus an internal-permission bypass. `retrieve` now validates the query params with a serializer before resolving the user.
- `chats/apps/api/v1/accounts/serializers.py`: added `UserDataQueryParamsSerializer` to validate `user_email`.
- `chats/apps/accounts/tests/test_viewsets.py`: extracted an `_auth_client` helper, renamed the missing-param test to assert `400`, and added coverage for cross-project access (404) and internal-user bypass (200) via the `with_internal_auth` decorator.

### Why
The previous implementation let any authenticated user resolve another user's name and email just by knowing their address, regardless of whether they shared any project. This widened the surface for account enumeration and unintended data exposure. Scoping the lookup to shared projects (with an explicit internal-permission escape hatch for service-to-service traffic) closes that gap while preserving existing internal integrations. Validating the query string up-front also returns a more accurate `400` for malformed requests, making the API contract clearer.

### Sequence diagram
```mermaid
sequenceDiagram
    participant Client
    participant UserDataViewset
    participant UserDataQueryParamsSerializer
    participant UserQuerySet as User queryset
    participant DB

    Client->>UserDataViewset: GET /user_data?user_email=<email>
    UserDataViewset->>UserDataQueryParamsSerializer: validate query params
    alt user_email missing or invalid
        UserDataQueryParamsSerializer-->>UserDataViewset: ValidationError
        UserDataViewset-->>Client: 400 Bad Request
    else valid email
        UserDataQueryParamsSerializer-->>UserDataViewset: validated user_email
        UserDataViewset->>UserDataViewset: get_queryset()
        alt requester has can_communicate_internally
            UserDataViewset->>UserQuerySet: all users
        else regular requester
            UserDataViewset->>UserQuerySet: users sharing a project with requester
        end
        UserDataViewset->>DB: filter(email=user_email).first()
        alt user not found in scope
            DB-->>UserDataViewset: None
            UserDataViewset-->>Client: 404 Email not found
        else user found
            DB-->>UserDataViewset: User instance
            UserDataViewset->>UserDataViewset: serialize(user)
            UserDataViewset-->>Client: 200 {first_name, last_name, email}
        end
    end
```