### PR TITLE
feat: improve room archiving logic and transaction handling

### DIFF
--- a/chats/apps/archive_chats/services.py
+++ b/chats/apps/archive_chats/services.py
@@ -173,8 +173,12 @@ class ArchiveChatsService(BaseArchiveChatsService):
             except Exception as e:
                 sentry_event_id = capture_exception(e)
                 room_archived_conversation.register_error(e, sentry_event_id)
+                log_msg = (
+                    f"[ArchiveChatsService] Error archiving room history "
+                    f"for room {room.uuid} with job {job.uuid}: {e}"
+                )
                 logger.error(
-                    f"[ArchiveChatsService] Error archiving room history for room {room.uuid} with job {job.uuid}: {e}",
+                    log_msg,
                     exc_info=True,
                 )
 

--- a/chats/apps/archive_chats/services.py
+++ b/chats/apps/archive_chats/services.py
@@ -87,62 +87,100 @@ class ArchiveChatsService(BaseArchiveChatsService):
             f"[ArchiveChatsService] Archiving room history for room {room.uuid} with job {job.uuid}"
         )
 
-        room_archived_conversation = self._get_or_create_room_archived_conversation(
-            room, job
-        )
-
-        if room_archived_conversation.status == ArchiveConversationsJobStatus.FINISHED:
-            logger.info(
-                f"[ArchiveChatsService] Room {room.uuid} is already archived "
-                f"(conversation {room_archived_conversation.uuid}), skipping"
+        with transaction.atomic():
+            room_archived_conversation = (
+                RoomArchivedConversation.objects.select_for_update(skip_locked=True)
+                .filter(room=room)
+                .first()
             )
-            return room_archived_conversation
 
-        try:
-            if self._needs_processing_and_upload(room_archived_conversation):
-                messages_data = self.process_messages(room_archived_conversation)
-                self.upload_messages_file(room_archived_conversation, messages_data)
-            else:
-                logger.info(
-                    f"[ArchiveChatsService] Skipping message processing and upload "
-                    f"for room {room.uuid} - file already uploaded"
-                )
-
-            room_archived_conversation.refresh_from_db()
-
-            if self._needs_message_deletion(room_archived_conversation):
-                if (
-                    room_archived_conversation.status
-                    != ArchiveConversationsJobStatus.MESSAGES_FILE_UPLOADED
-                ):
-                    room_archived_conversation.status = (
-                        ArchiveConversationsJobStatus.MESSAGES_FILE_UPLOADED
+            if room_archived_conversation is None:
+                if RoomArchivedConversation.objects.filter(room=room).exists():
+                    logger.info(
+                        f"[ArchiveChatsService] Room {room.uuid} is being processed "
+                        f"by another worker, skipping"
                     )
-                    room_archived_conversation.save(update_fields=["status"])
-                self.delete_room_messages(room_archived_conversation)
-            else:
+                    return None
+
+                room_archived_conversation = RoomArchivedConversation.objects.create(
+                    job=job,
+                    room=room,
+                    status=ArchiveConversationsJobStatus.PENDING,
+                )
                 logger.info(
-                    f"[ArchiveChatsService] Skipping message deletion "
-                    f"for room {room.uuid} - messages already deleted"
+                    f"[ArchiveChatsService] Room archived conversation created: "
+                    f"{room_archived_conversation.uuid} with status "
+                    f"{room_archived_conversation.status} for room {room.uuid} "
+                    f"and job {job.uuid}"
+                )
+
+            if (
+                room_archived_conversation.status
+                == ArchiveConversationsJobStatus.FINISHED
+            ):
+                logger.info(
+                    f"[ArchiveChatsService] Room {room.uuid} is already archived "
+                    f"(conversation {room_archived_conversation.uuid}), skipping"
+                )
+                return room_archived_conversation
+
+            if room_archived_conversation.job_id != job.uuid:
+                logger.info(
+                    f"[ArchiveChatsService] Resuming room archived conversation "
+                    f"{room_archived_conversation.uuid} with status "
+                    f"{room_archived_conversation.status} "
+                    f"for room {room.uuid} and job {job.uuid}"
+                )
+                room_archived_conversation.job = job
+                room_archived_conversation.save(update_fields=["job"])
+
+            try:
+                if self._needs_processing_and_upload(room_archived_conversation):
+                    messages_data = self.process_messages(room_archived_conversation)
+                    self.upload_messages_file(room_archived_conversation, messages_data)
+                else:
+                    logger.info(
+                        f"[ArchiveChatsService] Skipping message processing and upload "
+                        f"for room {room.uuid} - file already uploaded"
+                    )
+
+                room_archived_conversation.refresh_from_db()
+
+                if self._needs_message_deletion(room_archived_conversation):
+                    if (
+                        room_archived_conversation.status
+                        != ArchiveConversationsJobStatus.MESSAGES_FILE_UPLOADED
+                    ):
+                        room_archived_conversation.status = (
+                            ArchiveConversationsJobStatus.MESSAGES_FILE_UPLOADED
+                        )
+                        room_archived_conversation.save(update_fields=["status"])
+                    self.delete_room_messages(room_archived_conversation)
+                else:
+                    logger.info(
+                        f"[ArchiveChatsService] Skipping message deletion "
+                        f"for room {room.uuid} - messages already deleted"
+                    )
+
+                room_archived_conversation.refresh_from_db()
+                room_archived_conversation.status = (
+                    ArchiveConversationsJobStatus.FINISHED
+                )
+                room_archived_conversation.archive_process_finished_at = timezone.now()
+                room_archived_conversation.save(
+                    update_fields=["status", "archive_process_finished_at"]
+                )
+            except Exception as e:
+                sentry_event_id = capture_exception(e)
+                room_archived_conversation.register_error(e, sentry_event_id)
+                logger.error(
+                    f"[ArchiveChatsService] Error archiving room history for room {room.uuid} with job {job.uuid}: {e}",
+                    exc_info=True,
                 )
 
             room_archived_conversation.refresh_from_db()
-            room_archived_conversation.status = ArchiveConversationsJobStatus.FINISHED
-            room_archived_conversation.archive_process_finished_at = timezone.now()
-            room_archived_conversation.save(
-                update_fields=["status", "archive_process_finished_at"]
-            )
-        except Exception as e:
-            sentry_event_id = capture_exception(e)
-            room_archived_conversation.register_error(e, sentry_event_id)
-            logger.error(
-                f"[ArchiveChatsService] Error archiving room history for room {room.uuid} with job {job.uuid}: {e}",
-                exc_info=True,
-            )
 
-        room_archived_conversation.refresh_from_db()
-
-        return room_archived_conversation
+            return room_archived_conversation
 
     def _get_or_create_room_archived_conversation(
         self, room: Room, job: ArchiveConversationsJob
@@ -259,9 +297,7 @@ class ArchiveChatsService(BaseArchiveChatsService):
 
         with tempfile.SpooledTemporaryFile(max_size=5 * 1024 * 1024) as tmp:
             for message in messages:
-                tmp.write(
-                    json.dumps(message, ensure_ascii=False).encode("utf-8")
-                )
+                tmp.write(json.dumps(message, ensure_ascii=False).encode("utf-8"))
                 tmp.write(b"\n")
 
             room_archived_conversation.status = (

--- a/chats/apps/archive_chats/services.py
+++ b/chats/apps/archive_chats/services.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import timedelta
 import json
 import logging
 import tempfile
@@ -13,7 +14,7 @@ from django.utils import timezone
 from django.core.files.base import File
 from sentry_sdk import capture_exception
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from weni.feature_flags.services import FeatureFlagsService
 
 
@@ -87,6 +88,94 @@ class ArchiveChatsService(BaseArchiveChatsService):
             f"[ArchiveChatsService] Archiving room history for room {room.uuid} with job {job.uuid}"
         )
 
+        room_archived_conversation = self._claim_room_for_archive(room, job)
+
+        if room_archived_conversation is None:
+            return None
+
+        if (
+            room_archived_conversation.status
+            == ArchiveConversationsJobStatus.FINISHED
+        ):
+            return room_archived_conversation
+
+        try:
+            if self._needs_processing_and_upload(room_archived_conversation):
+                messages_data = self.process_messages(room_archived_conversation)
+                self.upload_messages_file(room_archived_conversation, messages_data)
+            else:
+                logger.info(
+                    f"[ArchiveChatsService] Skipping message processing and upload "
+                    f"for room {room.uuid} - file already uploaded"
+                )
+
+            room_archived_conversation.refresh_from_db()
+
+            if self._needs_message_deletion(room_archived_conversation):
+                if (
+                    room_archived_conversation.status
+                    != ArchiveConversationsJobStatus.MESSAGES_FILE_UPLOADED
+                ):
+                    room_archived_conversation.status = (
+                        ArchiveConversationsJobStatus.MESSAGES_FILE_UPLOADED
+                    )
+                    room_archived_conversation.save(update_fields=["status"])
+                self.delete_room_messages(room_archived_conversation)
+            else:
+                logger.info(
+                    f"[ArchiveChatsService] Skipping message deletion "
+                    f"for room {room.uuid} - messages already deleted"
+                )
+
+            room_archived_conversation.refresh_from_db()
+            room_archived_conversation.status = (
+                ArchiveConversationsJobStatus.FINISHED
+            )
+            room_archived_conversation.archive_process_finished_at = timezone.now()
+            room_archived_conversation.save(
+                update_fields=["status", "archive_process_finished_at"]
+            )
+        except Exception as e:
+            sentry_event_id = capture_exception(e)
+            room_archived_conversation.register_error(e, sentry_event_id)
+            log_msg = (
+                f"[ArchiveChatsService] Error archiving room history "
+                f"for room {room.uuid} with job {job.uuid}: {e}"
+            )
+            logger.error(
+                log_msg,
+                exc_info=True,
+            )
+
+        room_archived_conversation.refresh_from_db()
+
+        return room_archived_conversation
+
+    def _claim_room_for_archive(
+        self, room: Room, job: ArchiveConversationsJob
+    ) -> "RoomArchivedConversation | None":
+        """
+        Acquire a brief row-level lock to claim a room for archiving.
+
+        The lock is only held long enough to:
+          * read or create the RoomArchivedConversation row,
+          * verify no other worker is actively processing it,
+          * stamp ``archive_process_started_at`` and re-point ``job``.
+
+        The heavy work (message iteration, S3 upload, batched DB deletes)
+        runs OUTSIDE the lock so the transaction is open for milliseconds
+        rather than for the duration of the upload. Concurrency is then
+        protected by:
+          * the row lock during the claim itself,
+          * the unique constraint on ``room``,
+          * the soft lock (``_is_actively_processed``) for the rare case
+            where a duplicate task is dispatched while a previous attempt
+            is still in flight.
+
+        Returns the row when it is safe to proceed, an already-FINISHED
+        row (which the caller should short-circuit on), or ``None`` when
+        another worker holds or has recently claimed the row.
+        """
         with transaction.atomic():
             room_archived_conversation = (
                 RoomArchivedConversation.objects.select_for_update(skip_locked=True)
@@ -102,11 +191,22 @@ class ArchiveChatsService(BaseArchiveChatsService):
                     )
                     return None
 
-                room_archived_conversation = RoomArchivedConversation.objects.create(
-                    job=job,
-                    room=room,
-                    status=ArchiveConversationsJobStatus.PENDING,
-                )
+                try:
+                    with transaction.atomic():
+                        room_archived_conversation = (
+                            RoomArchivedConversation.objects.create(
+                                job=job,
+                                room=room,
+                                status=ArchiveConversationsJobStatus.PENDING,
+                            )
+                        )
+                except IntegrityError:
+                    logger.info(
+                        f"[ArchiveChatsService] Room {room.uuid} was concurrently "
+                        f"created by another worker, skipping"
+                    )
+                    return None
+
                 logger.info(
                     f"[ArchiveChatsService] Room archived conversation created: "
                     f"{room_archived_conversation.uuid} with status "
@@ -124,6 +224,19 @@ class ArchiveChatsService(BaseArchiveChatsService):
                 )
                 return room_archived_conversation
 
+            if self._is_actively_processed(room_archived_conversation):
+                logger.info(
+                    f"[ArchiveChatsService] Room {room.uuid} is already being "
+                    f"processed (conversation {room_archived_conversation.uuid}, "
+                    f"status {room_archived_conversation.status}, "
+                    f"started_at {room_archived_conversation.archive_process_started_at}), "
+                    f"skipping"
+                )
+                return None
+
+            update_fields = ["archive_process_started_at"]
+            room_archived_conversation.archive_process_started_at = timezone.now()
+
             if room_archived_conversation.job_id != job.uuid:
                 logger.info(
                     f"[ArchiveChatsService] Resuming room archived conversation "
@@ -132,59 +245,47 @@ class ArchiveChatsService(BaseArchiveChatsService):
                     f"for room {room.uuid} and job {job.uuid}"
                 )
                 room_archived_conversation.job = job
-                room_archived_conversation.save(update_fields=["job"])
+                update_fields.append("job")
 
-            try:
-                if self._needs_processing_and_upload(room_archived_conversation):
-                    messages_data = self.process_messages(room_archived_conversation)
-                    self.upload_messages_file(room_archived_conversation, messages_data)
-                else:
-                    logger.info(
-                        f"[ArchiveChatsService] Skipping message processing and upload "
-                        f"for room {room.uuid} - file already uploaded"
-                    )
-
-                room_archived_conversation.refresh_from_db()
-
-                if self._needs_message_deletion(room_archived_conversation):
-                    if (
-                        room_archived_conversation.status
-                        != ArchiveConversationsJobStatus.MESSAGES_FILE_UPLOADED
-                    ):
-                        room_archived_conversation.status = (
-                            ArchiveConversationsJobStatus.MESSAGES_FILE_UPLOADED
-                        )
-                        room_archived_conversation.save(update_fields=["status"])
-                    self.delete_room_messages(room_archived_conversation)
-                else:
-                    logger.info(
-                        f"[ArchiveChatsService] Skipping message deletion "
-                        f"for room {room.uuid} - messages already deleted"
-                    )
-
-                room_archived_conversation.refresh_from_db()
-                room_archived_conversation.status = (
-                    ArchiveConversationsJobStatus.FINISHED
-                )
-                room_archived_conversation.archive_process_finished_at = timezone.now()
-                room_archived_conversation.save(
-                    update_fields=["status", "archive_process_finished_at"]
-                )
-            except Exception as e:
-                sentry_event_id = capture_exception(e)
-                room_archived_conversation.register_error(e, sentry_event_id)
-                log_msg = (
-                    f"[ArchiveChatsService] Error archiving room history "
-                    f"for room {room.uuid} with job {job.uuid}: {e}"
-                )
-                logger.error(
-                    log_msg,
-                    exc_info=True,
-                )
-
-            room_archived_conversation.refresh_from_db()
+            room_archived_conversation.save(update_fields=update_fields)
 
             return room_archived_conversation
+
+    def _is_actively_processed(
+        self, room_archived_conversation: "RoomArchivedConversation"
+    ) -> bool:
+        """
+        Soft-lock detection used after the row lock is released.
+
+        A row is considered actively processed when its status indicates
+        an in-progress pipeline step and ``archive_process_started_at``
+        is recent enough that another worker is plausibly still running.
+
+        FINISHED and FAILED rows are never considered active, since they
+        represent terminal-or-retriable states that must be allowed to
+        progress (FINISHED short-circuits in the caller; FAILED is
+        explicitly resumable).
+
+        The threshold is configurable via the
+        ``ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS`` setting and defaults
+        to 12 hours, which is comfortably above the configured task
+        expiration but short enough to recover from a crashed worker
+        within a day.
+        """
+        if room_archived_conversation.status in {
+            ArchiveConversationsJobStatus.FINISHED,
+            ArchiveConversationsJobStatus.FAILED,
+        }:
+            return False
+
+        started_at = room_archived_conversation.archive_process_started_at
+        if started_at is None:
+            return False
+
+        threshold_hours = getattr(
+            settings, "ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS", 12
+        )
+        return timezone.now() - started_at < timedelta(hours=threshold_hours)
 
     def _get_or_create_room_archived_conversation(
         self, room: Room, job: ArchiveConversationsJob

--- a/chats/apps/archive_chats/tasks.py
+++ b/chats/apps/archive_chats/tasks.py
@@ -8,6 +8,7 @@ import logging
 from celery import group, shared_task
 from dateutil.relativedelta import relativedelta as rdelta
 from django.conf import settings
+from django.db import transaction
 
 from chats.apps.archive_chats.choices import ArchiveConversationsJobStatus
 from chats.apps.archive_chats.expiration import calculate_archive_task_expiration_dt
@@ -91,34 +92,48 @@ def start_archive_rooms_messages():
 
 def _create_pending_records(room_uuids, job):
     """
-    Bulk-create PENDING RoomArchivedConversation records at dispatch time so
-    subsequent scheduler runs exclude already-queued rooms via the 24-hour
-    job filter.
+    Prepare RoomArchivedConversation rows for dispatch:
+
+    - Re-point existing non-FINISHED rows to the current ``job`` so the 24-hour
+      filter in the scheduler excludes them on subsequent runs even if no
+      worker has picked the task up yet.
+    - Bulk-create PENDING rows for rooms that have no conversation at all.
+
+    Both operations run inside a single transaction so the dispatch-time
+    bookkeeping is consistent with the tasks queued immediately after.
     """
     if not room_uuids:
         return
 
-    new_room_ids = (
-        Room.objects.filter(uuid__in=room_uuids)
-        .exclude(archived_conversations__isnull=False)
-        .values_list("uuid", flat=True)
-    )
-
-    if new_room_ids:
-        RoomArchivedConversation.objects.bulk_create(
-            [
-                RoomArchivedConversation(
-                    room_id=room_id,
-                    job=job,
-                    status=ArchiveConversationsJobStatus.PENDING,
-                )
-                for room_id in new_room_ids
-            ],
-            batch_size=settings.ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE,
+    with transaction.atomic():
+        repointed = (
+            RoomArchivedConversation.objects.filter(room_id__in=room_uuids)
+            .exclude(status=ArchiveConversationsJobStatus.FINISHED)
+            .update(job=job)
         )
 
+        new_room_ids = list(
+            Room.objects.filter(uuid__in=room_uuids)
+            .exclude(archived_conversations__isnull=False)
+            .values_list("uuid", flat=True)
+        )
+
+        if new_room_ids:
+            RoomArchivedConversation.objects.bulk_create(
+                [
+                    RoomArchivedConversation(
+                        room_id=room_id,
+                        job=job,
+                        status=ArchiveConversationsJobStatus.PENDING,
+                    )
+                    for room_id in new_room_ids
+                ],
+                batch_size=settings.ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE,
+            )
+
     logger.info(
-        f"[start_archive_rooms_messages] Created {len(new_room_ids)} archived conversations rows"
+        f"[start_archive_rooms_messages] Repointed {repointed} existing rows "
+        f"and created {len(new_room_ids)} new archived conversation rows"
     )
 
 

--- a/chats/apps/archive_chats/tests/test_services.py
+++ b/chats/apps/archive_chats/tests/test_services.py
@@ -1,8 +1,10 @@
 import json
+from datetime import timedelta
 from unittest.mock import patch, MagicMock
 
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.db import IntegrityError
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from chats.apps.archive_chats.choices import ArchiveConversationsJobStatus
@@ -134,6 +136,142 @@ class TestArchiveChatsService(TestCase):
         existing.refresh_from_db()
         self.assertEqual(existing.status, ArchiveConversationsJobStatus.PENDING)
         self.assertEqual(existing.job_id, job_a.uuid)
+
+    @override_settings(ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS=12)
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
+    def test_archive_room_history_soft_locks_recently_started_in_progress_row(
+        self, mock_process_messages
+    ):
+        job_a = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+        job_b = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+
+        existing = RoomArchivedConversation.objects.create(
+            room=self.room,
+            job=job_a,
+            status=ArchiveConversationsJobStatus.PROCESSING_MESSAGES,
+            archive_process_started_at=timezone.now() - timedelta(minutes=5),
+        )
+
+        result = self.service.archive_room_history(self.room, job_b)
+
+        self.assertIsNone(result)
+        mock_process_messages.assert_not_called()
+
+        existing.refresh_from_db()
+        self.assertEqual(
+            existing.status, ArchiveConversationsJobStatus.PROCESSING_MESSAGES
+        )
+        self.assertEqual(existing.job_id, job_a.uuid)
+
+    @override_settings(ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS=12)
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.delete_room_messages")
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
+    def test_archive_room_history_reclaims_stale_in_progress_row(
+        self, mock_process_messages, mock_delete_messages
+    ):
+        mock_process_messages.return_value = []
+        job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+
+        stale_started_at = timezone.now() - timedelta(hours=24)
+        RoomArchivedConversation.objects.create(
+            room=self.room,
+            job=job,
+            status=ArchiveConversationsJobStatus.PROCESSING_MESSAGES,
+            archive_process_started_at=stale_started_at,
+        )
+
+        result = self.service.archive_room_history(self.room, job)
+
+        self.assertIsNotNone(result)
+        mock_process_messages.assert_called_once()
+        self.assertGreater(result.archive_process_started_at, stale_started_at)
+
+    @override_settings(ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS=12)
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
+    def test_archive_room_history_allows_retry_for_recently_failed_row(
+        self, mock_process_messages
+    ):
+        mock_process_messages.return_value = []
+        job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+
+        RoomArchivedConversation.objects.create(
+            room=self.room,
+            job=job,
+            status=ArchiveConversationsJobStatus.FAILED,
+            archive_process_started_at=timezone.now() - timedelta(minutes=1),
+            failed_at=timezone.now() - timedelta(seconds=30),
+        )
+
+        result = self.service.archive_room_history(self.room, job)
+
+        self.assertIsNotNone(result)
+        mock_process_messages.assert_called_once()
+
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
+    def test_archive_room_history_skips_when_create_loses_race(
+        self, mock_process_messages
+    ):
+        job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+
+        empty_qs = MagicMock()
+        empty_qs.filter.return_value.first.return_value = None
+
+        original_create = RoomArchivedConversation.objects.create
+
+        def raising_create(*args, **kwargs):
+            original_create(
+                room=self.room,
+                job=job,
+                status=ArchiveConversationsJobStatus.PENDING,
+            )
+            raise IntegrityError("simulated unique_violation")
+
+        with patch.object(
+            RoomArchivedConversation.objects,
+            "select_for_update",
+            return_value=empty_qs,
+        ), patch.object(
+            RoomArchivedConversation.objects,
+            "create",
+            side_effect=raising_create,
+        ):
+            result = self.service.archive_room_history(self.room, job)
+
+        self.assertIsNone(result)
+        mock_process_messages.assert_not_called()
+
+        self.assertEqual(
+            RoomArchivedConversation.objects.filter(room=self.room).count(), 1
+        )
+
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.upload_messages_file")
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
+    def test_archive_room_history_does_not_hold_transaction_during_heavy_work(
+        self, mock_process_messages, mock_upload
+    ):
+        """
+        The S3 upload and message deletion must run outside the transaction
+        that the claim phase opens, otherwise the row lock is held for the
+        duration of network I/O. This is asserted indirectly by checking
+        that no atomic block is active while the heavy work is being called.
+        """
+        from django.db import transaction as _transaction
+
+        mock_process_messages.return_value = []
+        observed = {}
+
+        def record_atomic_state(*args, **kwargs):
+            observed["in_atomic_block"] = _transaction.get_connection().in_atomic_block
+            return None
+
+        mock_upload.side_effect = record_atomic_state
+
+        job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+        self.service.archive_room_history(self.room, job)
+
+        mock_upload.assert_called_once()
+        self.assertIn("in_atomic_block", observed)
+        self.assertFalse(observed["in_atomic_block"])
 
     def test_process_messages(self):
         message_a = Message.objects.create(

--- a/chats/apps/archive_chats/tests/test_services.py
+++ b/chats/apps/archive_chats/tests/test_services.py
@@ -104,6 +104,37 @@ class TestArchiveChatsService(TestCase):
             archived_conversation.errors[0]["sentry_event_id"], "test-event-id"
         )
 
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
+    def test_archive_room_history_skips_when_row_locked_by_another_worker(
+        self, mock_process_messages
+    ):
+        job_a = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+        job_b = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+
+        existing = RoomArchivedConversation.objects.create(
+            room=self.room,
+            job=job_a,
+            status=ArchiveConversationsJobStatus.PENDING,
+        )
+
+        locked_qs = MagicMock()
+        locked_qs.filter.return_value.first.return_value = None
+
+        with patch.object(
+            RoomArchivedConversation.objects,
+            "select_for_update",
+            return_value=locked_qs,
+        ) as mock_lock:
+            result = self.service.archive_room_history(self.room, job_b)
+
+        mock_lock.assert_called_once_with(skip_locked=True)
+        self.assertIsNone(result)
+        mock_process_messages.assert_not_called()
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.status, ArchiveConversationsJobStatus.PENDING)
+        self.assertEqual(existing.job_id, job_a.uuid)
+
     def test_process_messages(self):
         message_a = Message.objects.create(
             room=self.room,
@@ -318,7 +349,9 @@ class TestArchiveChatsService(TestCase):
     def test_get_or_create_room_archived_conversation_creates_new(self):
         job = self.service.start_archive_job()
 
-        self.assertFalse(RoomArchivedConversation.objects.filter(room=self.room).exists())
+        self.assertFalse(
+            RoomArchivedConversation.objects.filter(room=self.room).exists()
+        )
 
         result = self.service._get_or_create_room_archived_conversation(self.room, job)
 
@@ -329,7 +362,9 @@ class TestArchiveChatsService(TestCase):
             RoomArchivedConversation.objects.filter(room=self.room).count(), 1
         )
 
-    def test_get_or_create_room_archived_conversation_reuses_existing_and_updates_job(self):
+    def test_get_or_create_room_archived_conversation_reuses_existing_and_updates_job(
+        self,
+    ):
         job_a = self.service.start_archive_job()
         job_b = self.service.start_archive_job()
 
@@ -350,7 +385,9 @@ class TestArchiveChatsService(TestCase):
             RoomArchivedConversation.objects.filter(room=self.room).count(), 1
         )
 
-    def test_get_or_create_room_archived_conversation_does_not_update_finished_job(self):
+    def test_get_or_create_room_archived_conversation_does_not_update_finished_job(
+        self,
+    ):
         job_a = self.service.start_archive_job()
         job_b = self.service.start_archive_job()
 
@@ -474,9 +511,7 @@ class TestArchiveChatsService(TestCase):
         self.assertEqual(result.status, ArchiveConversationsJobStatus.FINISHED)
         mock_process_messages.assert_not_called()
 
-    @patch(
-        "chats.apps.archive_chats.services.ArchiveChatsService.delete_room_messages"
-    )
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.delete_room_messages")
     @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
     def test_archive_room_history_resumes_from_uploaded_skips_processing(
         self, mock_process_messages, mock_delete_messages
@@ -494,9 +529,7 @@ class TestArchiveChatsService(TestCase):
         mock_process_messages.assert_not_called()
         mock_delete_messages.assert_called_once()
 
-    @patch(
-        "chats.apps.archive_chats.services.ArchiveChatsService.delete_room_messages"
-    )
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.delete_room_messages")
     @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
     def test_archive_room_history_resumes_from_failed_with_file(
         self, mock_process_messages, mock_delete_messages
@@ -515,12 +548,8 @@ class TestArchiveChatsService(TestCase):
         mock_process_messages.assert_not_called()
         mock_delete_messages.assert_called_once()
 
-    @patch(
-        "chats.apps.archive_chats.services.ArchiveChatsService.delete_room_messages"
-    )
-    @patch(
-        "chats.apps.archive_chats.services.ArchiveChatsService.upload_messages_file"
-    )
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.delete_room_messages")
+    @patch("chats.apps.archive_chats.services.ArchiveChatsService.upload_messages_file")
     @patch("chats.apps.archive_chats.services.ArchiveChatsService.process_messages")
     def test_archive_room_history_resumes_from_failed_with_messages_deleted(
         self, mock_process_messages, mock_upload, mock_delete_messages

--- a/chats/apps/archive_chats/tests/test_services.py
+++ b/chats/apps/archive_chats/tests/test_services.py
@@ -211,19 +211,25 @@ class TestArchiveChatsService(TestCase):
     def test_archive_room_history_skips_when_create_loses_race(
         self, mock_process_messages
     ):
+        """
+        Simulate the race where ``select_for_update`` finds nothing and the
+        existence check confirms the row is absent, but a concurrent worker
+        commits the row before our ``create`` call lands. PostgreSQL then
+        raises ``IntegrityError`` on our insert and the service must catch
+        it, return ``None``, and not leave a partial row from our worker.
+
+        The conflicting worker's row cannot be simulated from inside the
+        same connection, because any insert we make here lives inside the
+        service's savepoint and is rolled back together with our failed
+        ``create``. We therefore assert what the service actually
+        guarantees: no duplicate row is left behind by us.
+        """
         job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
 
         empty_qs = MagicMock()
         empty_qs.filter.return_value.first.return_value = None
 
-        original_create = RoomArchivedConversation.objects.create
-
         def raising_create(*args, **kwargs):
-            original_create(
-                room=self.room,
-                job=job,
-                status=ArchiveConversationsJobStatus.PENDING,
-            )
             raise IntegrityError("simulated unique_violation")
 
         with patch.object(
@@ -241,7 +247,7 @@ class TestArchiveChatsService(TestCase):
         mock_process_messages.assert_not_called()
 
         self.assertEqual(
-            RoomArchivedConversation.objects.filter(room=self.room).count(), 1
+            RoomArchivedConversation.objects.filter(room=self.room).count(), 0
         )
 
     @patch("chats.apps.archive_chats.services.ArchiveChatsService.upload_messages_file")
@@ -252,26 +258,33 @@ class TestArchiveChatsService(TestCase):
         """
         The S3 upload and message deletion must run outside the transaction
         that the claim phase opens, otherwise the row lock is held for the
-        duration of network I/O. This is asserted indirectly by checking
-        that no atomic block is active while the heavy work is being called.
+        duration of network I/O.
+
+        Django's ``TestCase`` wraps every test method in an outer
+        ``transaction.atomic()`` so ``connection.in_atomic_block`` is always
+        ``True`` during the test, regardless of what the service does.
+        Instead, we capture the savepoint depth before the call and assert
+        that the heavy work runs at the same depth, i.e. the service did
+        not push an extra savepoint of its own around the upload.
         """
-        from django.db import transaction as _transaction
+        from django.db import connection
 
         mock_process_messages.return_value = []
+        baseline_savepoints = len(connection.savepoint_ids)
         observed = {}
 
-        def record_atomic_state(*args, **kwargs):
-            observed["in_atomic_block"] = _transaction.get_connection().in_atomic_block
+        def record_savepoint_depth(*args, **kwargs):
+            observed["savepoint_count"] = len(connection.savepoint_ids)
             return None
 
-        mock_upload.side_effect = record_atomic_state
+        mock_upload.side_effect = record_savepoint_depth
 
         job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
         self.service.archive_room_history(self.room, job)
 
         mock_upload.assert_called_once()
-        self.assertIn("in_atomic_block", observed)
-        self.assertFalse(observed["in_atomic_block"])
+        self.assertIn("savepoint_count", observed)
+        self.assertEqual(observed["savepoint_count"], baseline_savepoints)
 
     def test_process_messages(self):
         message_a = Message.objects.create(

--- a/chats/apps/archive_chats/tests/test_tasks.py
+++ b/chats/apps/archive_chats/tests/test_tasks.py
@@ -316,21 +316,95 @@ class TestCreatePendingRecords(TestCase):
         assert RoomArchivedConversation.objects.filter(room=existing_room).count() == 1
 
     @override_settings(ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE=100)
-    def test_does_not_create_records_when_all_rooms_already_archived(self):
-        job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+    def test_repoints_existing_non_finished_rows_to_current_job(self):
+        old_job = ArchiveConversationsJob.objects.create(
+            started_at=timezone.now() - rdelta(days=3)
+        )
+        new_job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
         room = Room.objects.create(
             is_active=False,
             ended_at=timezone.now() - rdelta(years=1),
         )
-        RoomArchivedConversation.objects.create(
+        existing = RoomArchivedConversation.objects.create(
             room=room,
-            job=job,
+            job=old_job,
             status=ArchiveConversationsJobStatus.PENDING,
         )
 
-        _create_pending_records([room.uuid], job)
+        _create_pending_records([room.uuid], new_job)
 
+        existing.refresh_from_db()
         assert RoomArchivedConversation.objects.count() == 1
+        assert existing.job_id == new_job.uuid
+        assert existing.status == ArchiveConversationsJobStatus.PENDING
+
+    @override_settings(ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE=100)
+    def test_does_not_repoint_finished_rows(self):
+        old_job = ArchiveConversationsJob.objects.create(
+            started_at=timezone.now() - rdelta(days=3)
+        )
+        new_job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+        room = Room.objects.create(
+            is_active=False,
+            ended_at=timezone.now() - rdelta(years=1),
+        )
+        finished = RoomArchivedConversation.objects.create(
+            room=room,
+            job=old_job,
+            status=ArchiveConversationsJobStatus.FINISHED,
+        )
+
+        _create_pending_records([room.uuid], new_job)
+
+        finished.refresh_from_db()
+        assert finished.job_id == old_job.uuid
+        assert finished.status == ArchiveConversationsJobStatus.FINISHED
+
+    @override_settings(ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE=100)
+    def test_mixed_create_and_repoint(self):
+        old_job = ArchiveConversationsJob.objects.create(
+            started_at=timezone.now() - rdelta(days=3)
+        )
+        new_job = ArchiveConversationsJob.objects.create(started_at=timezone.now())
+
+        new_room = Room.objects.create(
+            is_active=False,
+            ended_at=timezone.now() - rdelta(years=1),
+        )
+        stale_room = Room.objects.create(
+            is_active=False,
+            ended_at=timezone.now() - rdelta(years=1),
+        )
+        stale_existing = RoomArchivedConversation.objects.create(
+            room=stale_room,
+            job=old_job,
+            status=ArchiveConversationsJobStatus.FAILED,
+        )
+        finished_room = Room.objects.create(
+            is_active=False,
+            ended_at=timezone.now() - rdelta(years=1),
+        )
+        finished_existing = RoomArchivedConversation.objects.create(
+            room=finished_room,
+            job=old_job,
+            status=ArchiveConversationsJobStatus.FINISHED,
+        )
+
+        _create_pending_records(
+            [new_room.uuid, stale_room.uuid, finished_room.uuid], new_job
+        )
+
+        new_record = RoomArchivedConversation.objects.get(room=new_room)
+        assert new_record.job_id == new_job.uuid
+        assert new_record.status == ArchiveConversationsJobStatus.PENDING
+
+        stale_existing.refresh_from_db()
+        assert stale_existing.job_id == new_job.uuid
+        assert stale_existing.status == ArchiveConversationsJobStatus.FAILED
+
+        finished_existing.refresh_from_db()
+        assert finished_existing.job_id == old_job.uuid
+        assert finished_existing.status == ArchiveConversationsJobStatus.FINISHED
 
 
 class TestArchiveRoomMessages(TestCase):

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -766,6 +766,12 @@ ARCHIVE_CHATS_BATCH_SIZE = env.int("ARCHIVE_CHATS_BATCH_SIZE", default=500)
 ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE = env.int(
     "ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE", default=2000
 )
+# Soft-lock threshold used by ArchiveChatsService to decide whether an
+# in-progress RoomArchivedConversation is still being processed by another
+# worker or stale enough to be reclaimed.
+ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS = env.int(
+    "ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS", default=12
+)
 
 # Internal API Token
 INTERNAL_API_TOKEN = env.str("INTERNAL_API_TOKEN")


### PR DESCRIPTION
### What
This branch increases the effective throughput of the room-archiving pipeline and removes a class of duplicate-processing races. Three coordinated changes:
1. **Dispatch-time repointing** in `_create_pending_records` (`chats/apps/archive_chats/tasks.py`). The function now runs inside a single `transaction.atomic()` block and, before bulk-creating PENDING rows for new rooms, issues an `update(job=current_job)` against every existing non-FINISHED `RoomArchivedConversation` row in the dispatch batch. After this, the scheduler's 24-hour filter on `archived_conversations__job__started_at` reliably excludes those rooms on subsequent runs.
2. **Worker-side claim with soft lock** in `chats/apps/archive_chats/services.py`. `archive_room_history` no longer calls `_get_or_create_room_archived_conversation`. It now calls a new `_claim_room_for_archive` that:
   - Opens a short transaction and runs `select_for_update(skip_locked=True)` against the room's row.
   - Returns `None` (skip) when another worker holds the row, when the row is in an in-progress status with a recent `archive_process_started_at`, or when an `IntegrityError` proves a concurrent create lost the race.
   - Treats `FINISHED` as a short-circuit and `FAILED` as resumable.
   - Stamps `archive_process_started_at = now()`, re-points `job` if needed, commits, and only then runs the heavy work (`process_messages`, S3 upload, batched message deletion).
   - Reclaims rows whose `archive_process_started_at` exceeds `ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS` so a crashed worker's row does not stay locked forever.
3. **New setting** `ARCHIVE_CHATS_IN_PROGRESS_TIMEOUT_HOURS` (default `12`) in `chats/settings.py`, env-overridable, controlling the soft-lock window.
Tests: `tests/test_services.py` adds coverage for row-locked skip, recent in-progress soft-lock, stale-row reclaim, FAILED retry, `IntegrityError` race on create, and an explicit assertion that the heavy work runs outside the claim transaction. `tests/test_tasks.py` adds repoint-of-non-finished, no-repoint-of-finished, and a mixed create-and-repoint scenario. No migrations.
### Why
The scheduler caps each run at `ARCHIVE_CHATS_MAX_ROOMS` and excludes rooms whose `RoomArchivedConversation.job.started_at` is within the last 24 hours. Previously, `_create_pending_records` only created rows for rooms that had no `RoomArchivedConversation` at all — existing non-FINISHED rows kept pointing to whatever job dispatched them last. As soon as that job aged past 24 hours without the worker reaching FINISHED (long task, transient error, worker scale-down, crash), the scheduler picked the same room up again on the next run. The result was twofold:
- Per-run dispatch slots were spent re-queuing the same backlog instead of advancing through new candidates ordered by `ended_at`, so the number of rooms actually archived per run was lower than `ARCHIVE_CHATS_MAX_ROOMS` would suggest.
- When a duplicate task did fire while a previous attempt was still running, both workers ran the full archive pipeline against the same row with no row lock and no soft lock — overlapping S3 uploads and overlapping message deletions, which can produce a corrupted archive file (a worker reads messages that the other has just deleted).
Repointing at dispatch time closes the scheduler-side leak so the 24h filter does its job, and the row-level `select_for_update(skip_locked=True)` plus a configurable soft-lock window closes the worker-side race for the cases where a duplicate still slips through (overlapping scheduler runs, manual replay, retry-after-crash). Moving the heavy I/O outside the transaction keeps the row lock to milliseconds rather than holding it open for the duration of an S3 upload.
### Sequence diagram
```mermaid
sequenceDiagram
    autonumber
    participant Sched as Scheduler task
    participant DB as Database
    participant Q as Celery queue
    participant W as Worker (archive_room_messages)
    participant Svc as ArchiveChatsService
    participant S3 as S3
    Sched->>DB: Select rooms (ended >1y, not FINISHED, job.started < now-24h)
    Sched->>DB: BEGIN
    Sched->>DB: UPDATE non-FINISHED rows SET job = current_job
    Sched->>DB: BULK INSERT PENDING rows for rooms with no row
    Sched->>DB: COMMIT
    Sched->>Q: Dispatch archive_room_messages(room, job) per room
    Q->>W: Deliver task
    W->>Svc: archive_room_history(room, job)
    Svc->>DB: BEGIN (claim transaction)
    Svc->>DB: SELECT ... FOR UPDATE SKIP LOCKED WHERE room = ?
    alt Row locked by another worker
        DB-->>Svc: no row returned, but row exists
        Svc->>DB: ROLLBACK
        Svc-->>W: return None (skip)
    else Row missing entirely
        Svc->>DB: INSERT RoomArchivedConversation (PENDING)
        opt Concurrent insert wins the race
            DB-->>Svc: IntegrityError
            Svc->>DB: ROLLBACK
            Svc-->>W: return None (skip)
        end
    else Row already FINISHED
        Svc->>DB: COMMIT
        Svc-->>W: return row (caller short-circuits)
    else Row in-progress and started_at within timeout
        Svc->>DB: COMMIT
        Svc-->>W: return None (soft-lock skip)
    else Row reclaimable (PENDING, FAILED, or stale in-progress)
        Svc->>DB: UPDATE archive_process_started_at = now, job = current_job
        Svc->>DB: COMMIT (lock released)
        Svc->>DB: Iterate messages in batches
        Svc->>S3: Upload archive file
        S3-->>Svc: OK
        Svc->>DB: Mark MESSAGES_FILE_UPLOADED
        Svc->>DB: Batched delete of messages
        Svc->>DB: Mark FINISHED + archive_process_finished_at
        Svc-->>W: return row
    end
```