### PR TITLE
feat: custom status in transfer endpoint

### DIFF
--- a/chats/apps/api/v1/queues/serializers.py
+++ b/chats/apps/api/v1/queues/serializers.py
@@ -212,16 +212,19 @@ class QueueAgentsSerializer(serializers.ModelSerializer):
 
         active_pause = (
             CustomStatus.objects.filter(
-                user=obj, project=project, is_active=True
+                user_id=obj.email, project=project, is_active=True
             )
             .exclude(status_type__name__iexact="in-service")
             .select_related("status_type")
+            .order_by("-created_on")
             .first()
         )
         if active_pause:
             return active_pause.status_type.name
 
-        project_permission = obj.project_permissions.filter(project=project).first()
+        project_permission = obj.project_permissions.filter(
+            project=project, is_deleted=False
+        ).first()
         if project_permission and project_permission.status == "ONLINE":
             return "online"
         return "offline"

--- a/chats/apps/api/v1/queues/serializers.py
+++ b/chats/apps/api/v1/queues/serializers.py
@@ -195,14 +195,35 @@ class QueueAgentsSerializer(serializers.ModelSerializer):
         ]
 
     def get_status(self, obj):
+        # Prefer annotations set by the view to avoid N+1 queries.
+        pause_name = getattr(obj, "_pause_name", None)
+        if pause_name:
+            return pause_name
+
+        is_online = getattr(obj, "_is_online", None)
+        if is_online is not None:
+            return "online" if is_online else "offline"
+
         project = self.context.get("project")
-        if project:
-            project_permission = obj.project_permissions.filter(project=project)
-            if (
-                project_permission.exists()
-                and project_permission.first().status == "ONLINE"
-            ):
-                return "online"
+        if not project:
+            return "offline"
+
+        from chats.apps.projects.models.models import CustomStatus
+
+        active_pause = (
+            CustomStatus.objects.filter(
+                user=obj, project=project, is_active=True
+            )
+            .exclude(status_type__name__iexact="in-service")
+            .select_related("status_type")
+            .first()
+        )
+        if active_pause:
+            return active_pause.status_type.name
+
+        project_permission = obj.project_permissions.filter(project=project).first()
+        if project_permission and project_permission.status == "ONLINE":
+            return "online"
         return "offline"
 
 

--- a/chats/apps/api/v1/queues/viewsets.py
+++ b/chats/apps/api/v1/queues/viewsets.py
@@ -2,6 +2,16 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db.models import (
+    Case,
+    CharField,
+    Exists,
+    IntegerField,
+    OuterRef,
+    Subquery,
+    Value,
+    When,
+)
 from django.utils.decorators import method_decorator
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.utils import swagger_auto_schema
@@ -25,7 +35,8 @@ from chats.apps.core.internal_domains import (
     exclude_vtex_internal_domains,
     is_vtex_internal_domain,
 )
-from chats.apps.projects.models.models import Project
+from chats.apps.projects.models import ProjectPermission
+from chats.apps.projects.models.models import CustomStatus, Project
 from chats.apps.projects.usecases.integrate_ticketers import IntegratedTicketers
 from chats.apps.queues.models import Queue, QueueAuthorization
 from chats.apps.queues.usecases.bulk_queue_creation import BulkQueueCreationUseCase
@@ -386,6 +397,33 @@ class QueueViewset(ModelViewSet):
 
         if not is_vtex_internal_domain(user_email):
             agents = exclude_vtex_internal_domains(agents)
+
+        pause_subquery = (
+            CustomStatus.objects.filter(
+                user=OuterRef("pk"),
+                project=project,
+                is_active=True,
+            )
+            .exclude(status_type__name__iexact="in-service")
+            .values("status_type__name")[:1]
+        )
+        online_subquery = ProjectPermission.objects.filter(
+            user=OuterRef("pk"),
+            project=project,
+            status="ONLINE",
+        )
+
+        agents = agents.annotate(
+            _pause_name=Subquery(pause_subquery, output_field=CharField()),
+            _is_online=Exists(online_subquery),
+        ).annotate(
+            _order=Case(
+                When(_pause_name__isnull=False, then=Value(1)),
+                When(_is_online=True, then=Value(0)),
+                default=Value(2),
+                output_field=IntegerField(),
+            )
+        ).order_by("_order", "first_name", "last_name")
 
         serializer = QueueAgentsSerializer(
             agents, many=True, context={"project": project}

--- a/chats/apps/api/v1/queues/viewsets.py
+++ b/chats/apps/api/v1/queues/viewsets.py
@@ -400,17 +400,19 @@ class QueueViewset(ModelViewSet):
 
         pause_subquery = (
             CustomStatus.objects.filter(
-                user=OuterRef("pk"),
+                user_id=OuterRef("email"),
                 project=project,
                 is_active=True,
             )
             .exclude(status_type__name__iexact="in-service")
+            .order_by("-created_on")
             .values("status_type__name")[:1]
         )
         online_subquery = ProjectPermission.objects.filter(
-            user=OuterRef("pk"),
+            user_id=OuterRef("email"),
             project=project,
             status="ONLINE",
+            is_deleted=False,
         )
 
         agents = agents.annotate(

--- a/chats/apps/queues/tests/test_viewsets.py
+++ b/chats/apps/queues/tests/test_viewsets.py
@@ -11,7 +11,11 @@ from chats.apps.accounts.models import User
 from chats.apps.contacts.models import Contact
 from chats.apps.core.internal_domains import get_vtex_internal_domains_with_at_symbol
 from chats.apps.projects.models import Project
-from chats.apps.projects.models.models import ProjectPermission
+from chats.apps.projects.models.models import (
+    CustomStatus,
+    CustomStatusType,
+    ProjectPermission,
+)
 from chats.apps.queues.models import Queue, QueueAuthorization
 from chats.apps.rooms.models import Room
 from chats.apps.sectors.models import Sector, SectorAuthorization
@@ -531,6 +535,274 @@ class QueueTransferAgentsTests(APITestCase):
 
         for domain in get_vtex_internal_domains_with_at_symbol():
             self.assertIn("internal" + domain, returned_emails)
+
+    @with_project_permission()
+    def test_transfer_agents_returns_online_status_for_online_agent(self):
+        online_agent = User.objects.create(
+            email="online@test.com", first_name="Online", last_name="Agent"
+        )
+        online_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=online_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=online_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data_by_email = {item["email"]: item for item in response.data}
+        self.assertEqual(data_by_email[online_agent.email]["status"], "online")
+
+    @with_project_permission()
+    def test_transfer_agents_returns_offline_status_for_offline_agent(self):
+        offline_agent = User.objects.create(
+            email="offline@test.com", first_name="Offline", last_name="Agent"
+        )
+        offline_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=offline_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_OFFLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=offline_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data_by_email = {item["email"]: item for item in response.data}
+        self.assertEqual(data_by_email[offline_agent.email]["status"], "offline")
+
+    @with_project_permission()
+    def test_transfer_agents_returns_pause_name_when_agent_has_active_custom_status(
+        self,
+    ):
+        paused_agent = User.objects.create(
+            email="paused@test.com", first_name="Paused", last_name="Agent"
+        )
+        paused_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=paused_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=paused_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        pause_type = CustomStatusType.objects.create(
+            name="Almoço", project=self.project
+        )
+        CustomStatus.objects.create(
+            user=paused_agent,
+            status_type=pause_type,
+            project=self.project,
+            is_active=True,
+        )
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data_by_email = {item["email"]: item for item in response.data}
+        self.assertEqual(data_by_email[paused_agent.email]["status"], "Almoço")
+
+    @with_project_permission()
+    def test_transfer_agents_ignores_in_service_custom_status(self):
+        agent = User.objects.create(
+            email="in-service@test.com", first_name="InService", last_name="Agent"
+        )
+        agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=agent_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        in_service_type = CustomStatusType.objects.create(
+            name="In-Service", project=self.project
+        )
+        CustomStatus.objects.create(
+            user=agent,
+            status_type=in_service_type,
+            project=self.project,
+            is_active=True,
+        )
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data_by_email = {item["email"]: item for item in response.data}
+        self.assertEqual(data_by_email[agent.email]["status"], "online")
+
+    @with_project_permission()
+    def test_transfer_agents_ignores_inactive_custom_status(self):
+        agent = User.objects.create(
+            email="inactive-pause@test.com",
+            first_name="InactivePause",
+            last_name="Agent",
+        )
+        agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_OFFLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=agent_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        pause_type = CustomStatusType.objects.create(
+            name="Reunião", project=self.project
+        )
+        pause = CustomStatus(
+            user=agent,
+            status_type=pause_type,
+            project=self.project,
+            is_active=True,
+        )
+        pause.save()
+        # Deactivate without triggering the auto-deactivation logic on save.
+        CustomStatus.objects.filter(pk=pause.pk).update(is_active=False)
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data_by_email = {item["email"]: item for item in response.data}
+        self.assertEqual(data_by_email[agent.email]["status"], "offline")
+
+    @with_project_permission()
+    def test_transfer_agents_orders_online_then_pause_then_offline(self):
+        online_agent = User.objects.create(
+            email="a-online@test.com", first_name="AOnline", last_name="Z"
+        )
+        online_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=online_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=online_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        paused_agent = User.objects.create(
+            email="b-paused@test.com", first_name="BPaused", last_name="Z"
+        )
+        paused_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=paused_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=paused_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+        pause_type = CustomStatusType.objects.create(
+            name="Almoço", project=self.project
+        )
+        CustomStatus.objects.create(
+            user=paused_agent,
+            status_type=pause_type,
+            project=self.project,
+            is_active=True,
+        )
+
+        offline_agent = User.objects.create(
+            email="c-offline@test.com", first_name="COffline", last_name="Z"
+        )
+        offline_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=offline_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_OFFLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=offline_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        target_emails = {online_agent.email, paused_agent.email, offline_agent.email}
+        filtered = [
+            item for item in response.data if item["email"] in target_emails
+        ]
+        ordered_emails = [item["email"] for item in filtered]
+
+        self.assertEqual(
+            ordered_emails,
+            [online_agent.email, paused_agent.email, offline_agent.email],
+        )
+
+        statuses = [item["status"] for item in filtered]
+        self.assertEqual(statuses, ["online", "Almoço", "offline"])
+
+    @with_project_permission()
+    def test_transfer_agents_pause_takes_priority_over_online(self):
+        agent = User.objects.create(
+            email="online-but-paused@test.com",
+            first_name="Online",
+            last_name="ButPaused",
+        )
+        agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=agent_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        pause_type = CustomStatusType.objects.create(
+            name="Reunião", project=self.project
+        )
+        CustomStatus.objects.create(
+            user=agent,
+            status_type=pause_type,
+            project=self.project,
+            is_active=True,
+        )
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data_by_email = {item["email"]: item for item in response.data}
+        self.assertEqual(data_by_email[agent.email]["status"], "Reunião")
 
 
 class QueueEndAllChatsTests(APITestCase):


### PR DESCRIPTION
### **What**
Enriches the `GET /queues/{uuid}/transfer_agents/` response with a more detailed agent status and a meaningful default ordering, while keeping the endpoint efficient.

- The `status` field returned for each agent now reflects three states:
  - `online` — agent has an active `ProjectPermission` with `status=ONLINE` in the project.
  - `<pause name>` — agent has an active `CustomStatus` in the project (e.g. `"Almoço"`, `"Reunião"`). The technical `in-service` status type is intentionally ignored.
  - `offline` — none of the above.
- Pause takes precedence over `online` when both exist for the same agent.
- Agents are returned ordered by availability: online first, then paused, then offline. Within each bucket, agents are sorted alphabetically by `first_name` / `last_name`.
- The view annotates the queryset with `_pause_name` (Subquery on `CustomStatus`) and `_is_online` (Exists on `ProjectPermission`), so the serializer no longer hits the database per agent.
- `QueueAgentsSerializer.get_status` prefers these annotations and keeps a safe fallback for callers that use the serializer outside of this view.
- Adds tests covering: online, offline, active pause, `in-service` ignored, inactive `CustomStatus` ignored, pause priority over online, and the online → pause → offline ordering.

### **Why**
The previous response only exposed `online` / `offline`, derived from a per-agent query inside the serializer (N+1). Operations and supervisors needed to know **why** an agent was unavailable (lunch, meeting, training, etc.) before transferring a chat, and ordering by availability makes the picker far more useful in queues with many agents.

Pushing the status logic into annotated subqueries collapses the N+1 into a single query, makes the response order deterministic on the database side, and keeps the serializer simple. Ignoring the `in-service` custom status avoids surfacing a purely technical state as if it were a human-facing pause.