### PR TITLE
refactor: address review feedback for inactivity feature

### DIFF
--- a/chats/apps/history/serializers/rooms.py
+++ b/chats/apps/history/serializers/rooms.py
@@ -9,31 +9,41 @@ from chats.apps.rooms.models import Room
 from chats.apps.sectors.models import SectorTag
 
 
-def build_closed_by_payload(room: Room) -> Optional[dict]:
+class ClosedBySerializer(serializers.Serializer):
     """
-    Build the `closed_by` payload for room history endpoints.
-
-    The contract requires `automatic_closed` to live *inside* the closed_by
-    object so the front can render the closure context (manual vs automatic)
-    in a single place. When the room was closed automatically without an
-    agent (typical for inactivity), we still return the object with
-    null user fields and `automatic_closed=True`.
-
-    Returns None only when neither a user nor an automatic flag is set
-    (preserves the current behavior for older rooms).
+    Serializes the closure context for a room (the agent who closed it, plus
+    whether the closure was automatic). The `automatic_closed` flag lives
+    inside this payload so the front can render manual vs automatic closure
+    from a single object.
     """
-    user = room.closed_by
-    automatic_closed = bool(getattr(room, "automatic_closed", False))
 
-    if user is None and not automatic_closed:
+    first_name = serializers.SerializerMethodField()
+    last_name = serializers.SerializerMethodField()
+    email = serializers.SerializerMethodField()
+    automatic_closed = serializers.SerializerMethodField()
+
+    def get_first_name(self, room: Room) -> Optional[str]:
+        return getattr(room.closed_by, "first_name", None)
+
+    def get_last_name(self, room: Room) -> Optional[str]:
+        return getattr(room.closed_by, "last_name", None)
+
+    def get_email(self, room: Room) -> Optional[str]:
+        return getattr(room.closed_by, "email", None)
+
+    def get_automatic_closed(self, room: Room) -> bool:
+        return bool(getattr(room, "automatic_closed", False))
+
+
+def _serialize_closed_by(room: Room) -> Optional[dict]:
+    """
+    Returns the serialized `closed_by` payload, or None when the room has
+    neither a closing agent nor the automatic flag set (preserves the legacy
+    behavior for older rooms).
+    """
+    if room.closed_by is None and not getattr(room, "automatic_closed", False):
         return None
-
-    return {
-        "first_name": getattr(user, "first_name", None),
-        "last_name": getattr(user, "last_name", None),
-        "email": getattr(user, "email", None),
-        "automatic_closed": automatic_closed,
-    }
+    return ClosedBySerializer(room).data
 
 
 class ContactOptimizedSerializer(serializers.ModelSerializer):
@@ -82,7 +92,7 @@ class RoomHistorySerializer(serializers.ModelSerializer):
         ).data
 
     def get_closed_by(self, obj: Room) -> Optional[dict]:
-        return build_closed_by_payload(obj)
+        return _serialize_closed_by(obj)
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
@@ -124,7 +134,7 @@ class RoomDetailSerializer(serializers.ModelSerializer):
         ]
 
     def get_closed_by(self, obj: Room) -> Optional[dict]:
-        return build_closed_by_payload(obj)
+        return _serialize_closed_by(obj)
 
     def get_contact(self, obj):
         contact_data = ContactSimpleSerializer(obj.contact).data

--- a/chats/apps/history/tests/test_serializers.py
+++ b/chats/apps/history/tests/test_serializers.py
@@ -6,7 +6,7 @@ from chats.apps.contacts.models import Contact
 from chats.apps.history.serializers.rooms import (
     RoomDetailSerializer,
     RoomHistorySerializer,
-    build_closed_by_payload,
+    _serialize_closed_by,
 )
 from chats.apps.projects.models.models import Project
 from chats.apps.queues.models import Queue
@@ -14,7 +14,7 @@ from chats.apps.rooms.models import Room
 from chats.apps.sectors.models import Sector
 
 
-class TestBuildClosedByPayload(TestCase):
+class TestSerializeClosedBy(TestCase):
     """
     The contract requires `automatic_closed` to be carried *inside* the
     `closed_by` object. This payload must be coherent across three cases:
@@ -48,11 +48,11 @@ class TestBuildClosedByPayload(TestCase):
 
     def test_returns_none_when_no_user_and_not_automatic(self):
         room = self._make_room()
-        self.assertIsNone(build_closed_by_payload(room))
+        self.assertIsNone(_serialize_closed_by(room))
 
     def test_returns_user_with_automatic_false_for_manual_close(self):
         room = self._make_room(closed_by=self.user)
-        payload = build_closed_by_payload(room)
+        payload = _serialize_closed_by(room)
         self.assertEqual(payload["first_name"], "Agent")
         self.assertEqual(payload["last_name"], "Smith")
         self.assertEqual(payload["email"], "agent@example.com")
@@ -60,13 +60,13 @@ class TestBuildClosedByPayload(TestCase):
 
     def test_returns_user_with_automatic_true_when_both_set(self):
         room = self._make_room(closed_by=self.user, automatic_closed=True)
-        payload = build_closed_by_payload(room)
+        payload = _serialize_closed_by(room)
         self.assertEqual(payload["email"], "agent@example.com")
         self.assertTrue(payload["automatic_closed"])
 
     def test_returns_payload_with_null_user_for_inactivity_close(self):
         room = self._make_room(closed_by=None, automatic_closed=True)
-        payload = build_closed_by_payload(room)
+        payload = _serialize_closed_by(room)
         self.assertIsNone(payload["first_name"])
         self.assertIsNone(payload["last_name"])
         self.assertIsNone(payload["email"])

--- a/chats/apps/rooms/tests/test_serializers.py
+++ b/chats/apps/rooms/tests/test_serializers.py
@@ -1,4 +1,5 @@
 import uuid
+from django.conf import settings
 from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
@@ -12,10 +13,7 @@ from chats.apps.api.v1.rooms.serializers import (
 )
 from chats.apps.contacts.models import Contact
 from chats.apps.rooms.models import Room
-from chats.apps.sectors.constants import (
-    DEFAULT_MESSAGE_TIMEOUT_TIME,
-    get_default_inactivity_timeout,
-)
+from chats.apps.sectors.constants import get_default_inactivity_timeout
 from chats.apps.sectors.models import SectorTag
 from chats.apps.projects.models.models import Project
 from chats.apps.queues.models import Queue
@@ -122,7 +120,7 @@ class TestRoomInactivityTimeoutHelper(TestCase):
 
         result = _get_room_inactivity_timeout_time(self.room)
 
-        self.assertEqual(result, DEFAULT_MESSAGE_TIMEOUT_TIME)
+        self.assertEqual(result, settings.DEFAULT_MESSAGE_TIMEOUT_TIME)
 
     def test_returns_sector_value_when_configured(self):
         self.sector.inactivity_timeout = {
@@ -154,7 +152,7 @@ class TestRoomInactivityTimeoutHelper(TestCase):
         self.room.refresh_from_db()
         result = _get_room_inactivity_timeout_time(self.room)
 
-        self.assertEqual(result, DEFAULT_MESSAGE_TIMEOUT_TIME)
+        self.assertEqual(result, settings.DEFAULT_MESSAGE_TIMEOUT_TIME)
 
 
 class TestRoomIsInactiveField(TestCase):

--- a/chats/apps/rooms/usecases/inactivity.py
+++ b/chats/apps/rooms/usecases/inactivity.py
@@ -81,7 +81,9 @@ def _eligible_warn_queryset():
     - room is open and assigned to an agent (not in queue);
     - not currently flagged as inactive;
     - not waiting for a flow start;
-    - the agent was the last one to talk (`last_message_user` populated).
+    - the agent was the last one to talk (`last_message_user` populated);
+    - the sector has the inactivity warning feature enabled (so we don't
+      pull rooms from sectors that won't be processed anyway).
 
     The final timeout comparison happens in Python because the timeout value
     lives inside the sector's JSON config and varies per sector.
@@ -92,6 +94,7 @@ def _eligible_warn_queryset():
         is_waiting=False,
         user__isnull=False,
         last_message_user__isnull=False,
+        queue__sector__inactivity_timeout__is_message_timeout_enabled=True,
     ).select_related("queue__sector", "user")
 
 
@@ -99,6 +102,9 @@ def _eligible_close_queryset():
     """
     Base queryset for rooms that already received the warning and may need to
     be closed for inactivity.
+
+    Restricted to sectors with the automatic closure feature enabled, so the
+    database does not have to return rooms from sectors that won't be closed.
     """
     return Room.objects.filter(
         is_active=True,
@@ -106,6 +112,7 @@ def _eligible_close_queryset():
         is_waiting=False,
         user__isnull=False,
         last_message_user__isnull=False,
+        queue__sector__inactivity_timeout__is_close_room_enabled=True,
     ).select_related("queue__sector", "user")
 
 
@@ -131,10 +138,7 @@ class InactivityService:
         warned = 0
 
         for room in _eligible_warn_queryset().iterator():
-            config = _read_inactivity_config(room)
-
-            if not config or not config.get("is_message_timeout_enabled"):
-                continue
+            config = _read_inactivity_config(room) or {}
 
             timeout = config.get("message_timeout_time") or 0
             if timeout <= 0:
@@ -163,10 +167,7 @@ class InactivityService:
         closed = 0
 
         for room in _eligible_close_queryset().iterator():
-            config = _read_inactivity_config(room)
-
-            if not config or not config.get("is_close_room_enabled"):
-                continue
+            config = _read_inactivity_config(room) or {}
 
             warn_timeout = config.get("message_timeout_time") or 0
             close_timeout = config.get("close_room_timeout_time") or 0

--- a/chats/apps/sectors/constants.py
+++ b/chats/apps/sectors/constants.py
@@ -1,11 +1,5 @@
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-
-
-# Default warning time in seconds (10 minutes)
-DEFAULT_MESSAGE_TIMEOUT_TIME = 600
-
-# Default closure time in seconds (1 minute)
-DEFAULT_CLOSE_ROOM_TIMEOUT_TIME = 60
 
 
 def get_default_inactivity_timeout() -> dict:
@@ -26,7 +20,7 @@ def get_default_inactivity_timeout() -> dict:
                 "If there's no response, this conversation will be closed soon."
             )
         ),
-        "message_timeout_time": DEFAULT_MESSAGE_TIMEOUT_TIME,
+        "message_timeout_time": settings.DEFAULT_MESSAGE_TIMEOUT_TIME,
         "is_close_room_enabled": False,
         "close_room_message_text": str(
             _(
@@ -34,5 +28,5 @@ def get_default_inactivity_timeout() -> dict:
                 "Get in touch again if needed."
             )
         ),
-        "close_room_timeout_time": DEFAULT_CLOSE_ROOM_TIMEOUT_TIME,
+        "close_room_timeout_time": settings.DEFAULT_CLOSE_ROOM_TIMEOUT_TIME,
     }

--- a/chats/apps/sectors/tests/test_serializers.py
+++ b/chats/apps/sectors/tests/test_serializers.py
@@ -12,11 +12,7 @@ from chats.apps.api.v1.sectors.serializers import (
     validate_custom_csat_flow_uuid,
 )
 from chats.apps.projects.models import Project
-from chats.apps.sectors.constants import (
-    DEFAULT_CLOSE_ROOM_TIMEOUT_TIME,
-    DEFAULT_MESSAGE_TIMEOUT_TIME,
-    get_default_inactivity_timeout,
-)
+from chats.apps.sectors.constants import get_default_inactivity_timeout
 from chats.apps.sectors.models import Sector
 
 
@@ -267,11 +263,11 @@ class TestSectorSerializerInactivityTimeout(TestCase):
         self.assertEqual(data["inactivity_timeout"], get_default_inactivity_timeout())
         self.assertEqual(
             data["inactivity_timeout"]["message_timeout_time"],
-            DEFAULT_MESSAGE_TIMEOUT_TIME,
+            settings.DEFAULT_MESSAGE_TIMEOUT_TIME,
         )
         self.assertEqual(
             data["inactivity_timeout"]["close_room_timeout_time"],
-            DEFAULT_CLOSE_ROOM_TIMEOUT_TIME,
+            settings.DEFAULT_CLOSE_ROOM_TIMEOUT_TIME,
         )
         self.assertFalse(data["inactivity_timeout"]["is_message_timeout_enabled"])
         self.assertFalse(data["inactivity_timeout"]["is_close_room_enabled"])

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -487,6 +487,14 @@ CHATS_CACHE_TIME = env.int("CHATS_CACHE_TIME", default=1 * 60 * 60)
 
 DISCUSSION_AGENTS_LIMIT = env.int("DISCUSSION_AGENTS_LIMIT", default=5)
 
+# Inactivity feature defaults (in seconds)
+DEFAULT_MESSAGE_TIMEOUT_TIME = env.int(
+    "DEFAULT_MESSAGE_TIMEOUT_TIME", default=600
+)
+DEFAULT_CLOSE_ROOM_TIMEOUT_TIME = env.int(
+    "DEFAULT_CLOSE_ROOM_TIMEOUT_TIME", default=60
+)
+
 # Celery
 
 METRICS_CUSTOM_QUEUE = env("METRICS_CUSTOM_QUEUE", default="celery")


### PR DESCRIPTION
### **What**
Apply review feedback from the inactivity feature PRs (#1028, #1029, #1030, #1032, #1033, #1035, #1038, #1039, #1041, #1048).

Changes:
- Move inactivity timeout defaults (`DEFAULT_MESSAGE_TIMEOUT_TIME`, `DEFAULT_CLOSE_ROOM_TIMEOUT_TIME`) from `chats/apps/sectors/constants.py` to `settings.py`, reading from environment variables with the previous hardcoded values as defaults.
- Pre-filter `_eligible_warn_queryset` and `_eligible_close_queryset` in `chats/apps/rooms/usecases/inactivity.py` by the sector's `inactivity_timeout` feature flags (`is_message_timeout_enabled` and `is_close_room_enabled`), so the database does not return rooms from sectors that won't be processed.
- Remove the now-redundant `if not config or not config.get(...)` checks inside `warn_inactive_rooms` and `close_inactive_rooms`, since the queryset already guarantees the feature is enabled.
- Replace the `build_closed_by_payload` helper in `chats/apps/history/serializers/rooms.py` with a dedicated `ClosedBySerializer`, keeping the same output contract.

### **Why**
Review comments left on the previous PRs (by @kallilsouza):

1. **`chats/apps/sectors/constants.py`** — "I think it would be interesting to get these default times from `settings.py` and use environment variables instead of having these hardcoded values. It makes it a little easier to change if needed."
2. **`chats/apps/rooms/usecases/inactivity.py` (`_eligible_warn_queryset` and `_eligible_close_queryset`)** — "Filtering out the rooms from projects / sectors that do not have the feature active may be better because the number of rooms that the database returns here can be high."
3. **`chats/apps/rooms/usecases/inactivity.py` (warn loop)** — "Once the queryset only returns the rooms that are actually eligible for this, this part here can be removed."
4. **`chats/apps/history/serializers/rooms.py`** — "Instead of this function here, you can create a serializer for the closed by, adding the `closed_by` field (or property) in the model, that optionally would return the user. The new serializer would just serialize this user data."

These were addressed in a single follow-up PR instead of going back to each original PR, since all the PRs were already approved and the suggestions are non-breaking quality/performance improvements rather than bug fixes.

### **Notes on merge conflicts**
This PR was the last one of the inactivity feature stack to be merged into `main`. After all other PRs were merged, this branch had conflicts with `main` in the following files:

- `chats/apps/api/v1/rooms/serializers.py`
- `chats/apps/api/v1/sectors/serializers.py`
- `chats/apps/rooms/tasks.py`
- `chats/apps/sectors/tests/test_serializers.py`
- `chats/locale/{es,pt_BR}/LC_MESSAGES/django.{po,mo}`
- Migration leaf conflicts in `rooms` and `sectors` apps

Resolution:
- Merged `origin/main` into the branch and resolved each Python conflict by keeping both sides (HEAD's inactivity-related code and main's parallel features such as `automatic_message_queue`, `RoomNoteMedia`, `room_export` tasks, and `custom_csat_flow_uuid`), since they touch different fields/classes and do not overlap.
- Combined translation strings from both sides in the `.po` files and recompiled the `.mo` files with `compilemessages`.
- For the migration graph conflict (`makemigrations --merge` would have been the standard fix, but since this PR was not yet on `main`, the cleaner solution was to renumber this branch's migrations to chain after main's leafs):
  - `rooms/0030_room_is_inactive.py` → `0031_room_is_inactive.py` (depends on `0030_roomnotemedia`)
  - `rooms/0031_rooms_inactivity_idx.py` → `0032_rooms_inactivity_idx.py`
  - `rooms/0032_room_automatic_closed.py` → `0033_room_automatic_closed.py`
  - `sectors/0025_sector_inactivity_timeout.py` → `0027_sector_inactivity_timeout.py` (depends on `0026_sector_automatic_message_queue_and_more`)

No behavioral or contract changes were introduced by the conflict resolution or the review feedback fixes: defaults, JSON payloads, and endpoint responses remain identical.