### PR TITLE
feat: add external room history endpoint with throttling and caching

### DIFF
--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
 
@@ -7,9 +5,7 @@ from chats.apps.api.utils import create_reply_index
 from chats.apps.api.v1.accounts.serializers import UserSerializer
 from chats.apps.api.v1.contacts.serializers import ContactRelationsSerializer
 from chats.apps.api.v1.msgs.serializers import MessageMediaSerializer
-from chats.apps.msgs.models import ChatMessageReplyIndex, Message, MessageMedia
-
-LOGGER = logging.getLogger(__name__)
+from chats.apps.msgs.models import Message, MessageMedia
 
 
 class AttachmentSerializer(serializers.ModelSerializer):
@@ -220,14 +216,12 @@ class RoomHistoryMessageSerializer(serializers.ModelSerializer):
         if not replied_id:
             return None
 
-        try:
-            reply_index = ChatMessageReplyIndex.objects.select_related("message").get(
-                external_id=replied_id
-            )
-        except ChatMessageReplyIndex.DoesNotExist:
+        reply_index_map = self.context.get("reply_index_map")
+        if reply_index_map is None:
             return None
-        except Exception as error:
-            LOGGER.error("Error resolving replied message for room history: %s", error)
+
+        reply_index = reply_index_map.get(replied_id)
+        if reply_index is None:
             return None
 
         return {

--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
 
@@ -5,7 +7,9 @@ from chats.apps.api.utils import create_reply_index
 from chats.apps.api.v1.accounts.serializers import UserSerializer
 from chats.apps.api.v1.contacts.serializers import ContactRelationsSerializer
 from chats.apps.api.v1.msgs.serializers import MessageMediaSerializer
-from chats.apps.msgs.models import Message, MessageMedia
+from chats.apps.msgs.models import ChatMessageReplyIndex, Message, MessageMedia
+
+LOGGER = logging.getLogger(__name__)
 
 
 class AttachmentSerializer(serializers.ModelSerializer):
@@ -131,3 +135,102 @@ class MsgFlowSerializer(serializers.ModelSerializer):
 
         create_reply_index(msg)
         return msg
+
+
+class RoomHistoryQuerySerializer(serializers.Serializer):
+    """Validates query params for the external room history endpoint."""
+
+    room = serializers.UUIDField(
+        required=True,
+        help_text="UUID of the room whose message history will be returned",
+    )
+
+
+class RoomHistoryUserSerializer(serializers.Serializer):
+    """Minimal user payload used inside the room history response."""
+
+    name = serializers.SerializerMethodField()
+    email = serializers.EmailField(read_only=True)
+
+    def get_name(self, user) -> str:
+        first_name = getattr(user, "first_name", "") or ""
+        last_name = getattr(user, "last_name", "") or ""
+        full_name = f"{first_name} {last_name}".strip()
+        return full_name or (getattr(user, "email", "") or "")
+
+
+class RoomHistoryContactSerializer(serializers.Serializer):
+    """Minimal contact payload used inside the room history response."""
+
+    uuid = serializers.UUIDField(read_only=True)
+    name = serializers.CharField(read_only=True)
+
+
+class RoomHistoryMessageMediaSerializer(serializers.ModelSerializer):
+    """Read-only media payload returned inside the room history response."""
+
+    url = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = MessageMedia
+        fields = ["content_type", "url", "created_on"]
+        read_only_fields = ["content_type", "url", "created_on"]
+        ref_name = "ExternalRoomHistoryMessageMediaSerializer"
+
+    def get_url(self, media: MessageMedia) -> str:
+        return media.public_url
+
+
+class RoomHistoryMessageSerializer(serializers.ModelSerializer):
+    """
+    Read-only serializer for messages of a closed room exposed via the
+    external room history endpoint.
+    """
+
+    user = RoomHistoryUserSerializer(read_only=True, allow_null=True)
+    contact = RoomHistoryContactSerializer(read_only=True, allow_null=True)
+    media = RoomHistoryMessageMediaSerializer(
+        many=True, read_only=True, source="medias"
+    )
+    replied_message = serializers.SerializerMethodField(read_only=True)
+    is_automatic_message = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = Message
+        fields = [
+            "user",
+            "contact",
+            "created_on",
+            "replied_message",
+            "media",
+            "is_automatic_message",
+        ]
+        read_only_fields = fields
+        ref_name = "ExternalRoomHistoryMessageSerializer"
+
+    def get_replied_message(self, obj: Message):
+        metadata = obj.metadata or {}
+        context = metadata.get("context") if isinstance(metadata, dict) else None
+        if not context or not isinstance(context, dict):
+            return None
+
+        replied_id = context.get("id")
+        if not replied_id:
+            return None
+
+        try:
+            reply_index = ChatMessageReplyIndex.objects.select_related("message").get(
+                external_id=replied_id
+            )
+        except ChatMessageReplyIndex.DoesNotExist:
+            return None
+        except Exception as error:
+            LOGGER.error(
+                "Error resolving replied message for room history: %s", error
+            )
+            return None
+
+        return {
+            "uuid": str(reply_index.message.uuid),
+            "text": reply_index.message.text or "",
+        }

--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -198,6 +198,8 @@ class RoomHistoryMessageSerializer(serializers.ModelSerializer):
     class Meta:
         model = Message
         fields = [
+            "uuid",
+            "text",
             "user",
             "contact",
             "created_on",
@@ -225,9 +227,7 @@ class RoomHistoryMessageSerializer(serializers.ModelSerializer):
         except ChatMessageReplyIndex.DoesNotExist:
             return None
         except Exception as error:
-            LOGGER.error(
-                "Error resolving replied message for room history: %s", error
-            )
+            LOGGER.error("Error resolving replied message for room history: %s", error)
             return None
 
         return {

--- a/chats/apps/api/v1/external/msgs/tests/test_room_history_viewset.py
+++ b/chats/apps/api/v1/external/msgs/tests/test_room_history_viewset.py
@@ -1,0 +1,527 @@
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from chats.apps.api.v1.external.msgs.viewsets import RoomHistoryMessagesViewSet
+from chats.apps.api.v1.external.throttling import (
+    ExternalRoomHistoryHourRateThrottle,
+    ExternalRoomHistoryMinuteRateThrottle,
+    ExternalRoomHistorySecondRateThrottle,
+)
+from chats.apps.contacts.models import Contact
+from chats.apps.msgs.models import (
+    ChatMessageReplyIndex,
+    Message,
+    MessageMedia,
+)
+from chats.apps.projects.models import Project
+from chats.apps.queues.models import Queue
+from chats.apps.rooms.models import Room, RoomNote
+from chats.apps.sectors.models import Sector
+
+User = get_user_model()
+
+NO_THROTTLE_RATES = {
+    "DEFAULT_THROTTLE_RATES": {
+        "external_room_history_second": None,
+        "external_room_history_minute": None,
+        "external_room_history_hour": None,
+    }
+}
+
+
+class BaseRoomHistoryTest(APITestCase):
+    """Shared setup for the external room history endpoint."""
+
+    def setUp(self):
+        cache.clear()
+
+        self.agent = User.objects.create_user(
+            email="agent@test.com",
+            password="testpass123",
+            first_name="Ana",
+            last_name="Agent",
+        )
+        self.contact = Contact.objects.create(name="Maria Cliente")
+
+        self.project = Project.objects.create(name="Test Project", timezone="UTC")
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=10,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.room = Room.objects.create(
+            contact=self.contact,
+            queue=self.queue,
+            user=self.agent,
+            is_active=True,
+        )
+        self.open_room = Room.objects.create(
+            contact=Contact.objects.create(name="Open Customer"),
+            queue=self.queue,
+            user=self.agent,
+            is_active=True,
+        )
+
+    def tearDown(self):
+        cache.clear()
+
+    def close_room(self, room=None):
+        """Close a room by bypassing the Message save validation."""
+        target = room or self.room
+        Room.objects.filter(pk=target.pk).update(is_active=False)
+        target.refresh_from_db()
+        return target
+
+    @property
+    def url(self):
+        return reverse("external_room_messages-list")
+
+    def auth(self, token=None):
+        t = token or self.project.external_token.uuid
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {t}")
+
+    def get(self, params=None):
+        return self.client.get(self.url, params or {})
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
+class TestRoomHistoryAuth(BaseRoomHistoryTest):
+    def test_unauthenticated_request_returns_401(self):
+        self.close_room()
+        response = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_bearer_token_returns_401(self):
+        self.close_room()
+        self.client.credentials(
+            HTTP_AUTHORIZATION="Bearer 00000000-0000-0000-0000-000000000000"
+        )
+        response = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_bearer_token_is_rejected_by_project_admin_auth(self):
+        self.close_room()
+        self.client.credentials(HTTP_AUTHORIZATION="Token some-internal-token")
+        response = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_valid_bearer_token_returns_200(self):
+        self.close_room()
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
+class TestRoomHistoryQueryValidation(BaseRoomHistoryTest):
+    def test_missing_room_returns_400(self):
+        self.auth()
+        response = self.get()
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("room", response.data)
+
+    def test_invalid_room_uuid_returns_400(self):
+        self.auth()
+        response = self.get({"room": "not-a-uuid"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("room", response.data)
+
+    def test_unknown_room_returns_404(self):
+        self.auth()
+        response = self.get({"room": "00000000-0000-0000-0000-000000000000"})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_room_from_other_project_returns_404(self):
+        other_project = Project.objects.create(name="Other", timezone="UTC")
+        other_sector = Sector.objects.create(
+            name="Other sector",
+            project=other_project,
+            rooms_limit=10,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        other_queue = Queue.objects.create(name="Other queue", sector=other_sector)
+        other_room = Room.objects.create(
+            contact=Contact.objects.create(name="Outside"),
+            queue=other_queue,
+            is_active=True,
+        )
+        self.close_room(other_room)
+
+        self.auth()
+        response = self.get({"room": str(other_room.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
+class TestRoomHistoryClosedRoomRequirement(BaseRoomHistoryTest):
+    def test_open_room_returns_403_with_message(self):
+        self.auth()
+        response = self.get({"room": str(self.open_room.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn("detail", response.data)
+        self.assertIn("closed rooms", str(response.data["detail"]).lower())
+
+    def test_closed_room_returns_200(self):
+        self.close_room()
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
+class TestRoomHistoryPayloadShape(BaseRoomHistoryTest):
+    def test_response_returns_documented_fields(self):
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="Hello!"
+        )
+        Message.objects.create(
+            room=self.room, user=self.agent, text="Hi, how can I help?"
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("results", response.data)
+        self.assertEqual(len(response.data["results"]), 2)
+
+        expected_fields = {
+            "user",
+            "contact",
+            "created_on",
+            "replied_message",
+            "media",
+            "is_automatic_message",
+        }
+        for item in response.data["results"]:
+            self.assertEqual(set(item.keys()), expected_fields)
+
+    def test_user_payload_has_name_and_email_or_is_null(self):
+        Message.objects.create(room=self.room, user=self.agent, text="From agent")
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="From contact"
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        agent_payload = None
+        contact_payload = None
+        for item in response.data["results"]:
+            if item["user"] is not None:
+                agent_payload = item
+            else:
+                contact_payload = item
+
+        self.assertIsNotNone(agent_payload)
+        self.assertEqual(set(agent_payload["user"].keys()), {"name", "email"})
+        self.assertEqual(agent_payload["user"]["email"], self.agent.email)
+        self.assertEqual(agent_payload["user"]["name"], "Ana Agent")
+
+        self.assertIsNotNone(contact_payload)
+        self.assertIsNone(contact_payload["user"])
+
+    def test_contact_payload_has_uuid_and_name_or_is_null(self):
+        Message.objects.create(room=self.room, user=self.agent, text="From agent")
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="From contact"
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        agent_payload = None
+        contact_payload = None
+        for item in response.data["results"]:
+            if item["user"] is not None:
+                agent_payload = item
+            else:
+                contact_payload = item
+
+        self.assertIsNotNone(contact_payload)
+        self.assertEqual(set(contact_payload["contact"].keys()), {"uuid", "name"})
+        self.assertEqual(contact_payload["contact"]["uuid"], str(self.contact.uuid))
+        self.assertEqual(contact_payload["contact"]["name"], self.contact.name)
+
+        self.assertIsNotNone(agent_payload)
+        self.assertIsNone(agent_payload["contact"])
+
+    def test_media_is_serialized_with_url_content_type_and_created_on(self):
+        msg = Message.objects.create(
+            room=self.room, user=self.agent, text="See attached"
+        )
+        MessageMedia.objects.create(
+            message=msg,
+            content_type="image/jpeg",
+            media_url="https://example.com/img.jpg",
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        target = next(
+            (
+                m
+                for m in response.data["results"]
+                if m["media"] and len(m["media"]) > 0
+            ),
+            None,
+        )
+        self.assertIsNotNone(target)
+        self.assertEqual(len(target["media"]), 1)
+        self.assertEqual(
+            set(target["media"][0].keys()), {"content_type", "url", "created_on"}
+        )
+        self.assertEqual(target["media"][0]["content_type"], "image/jpeg")
+
+    def test_is_automatic_message_field_present(self):
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="Regular message"
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        self.assertEqual(response.data["results"][0]["is_automatic_message"], False)
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
+class TestRoomHistoryInternalNoteFilter(BaseRoomHistoryTest):
+    def test_internal_note_messages_are_excluded(self):
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="Visible"
+        )
+        hidden_msg = Message.objects.create(room=self.room, user=self.agent, text="")
+        RoomNote.objects.create(
+            room=self.room,
+            user=self.agent,
+            text="Internal observation",
+            message=hidden_msg,
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 1)
+
+        only_item = response.data["results"][0]
+        self.assertIsNone(only_item["user"])
+        self.assertIsNotNone(only_item["contact"])
+        self.assertEqual(only_item["contact"]["uuid"], str(self.contact.uuid))
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
+class TestRoomHistoryRepliedMessage(BaseRoomHistoryTest):
+    def test_replied_message_resolves_through_reply_index(self):
+        original = Message.objects.create(
+            room=self.room,
+            contact=self.contact,
+            text="What are your business hours?",
+            external_id="ext-123",
+        )
+        ChatMessageReplyIndex.objects.create(
+            external_id="ext-123", message=original
+        )
+        Message.objects.create(
+            room=self.room,
+            user=self.agent,
+            text="We operate from 9am to 6pm",
+            metadata={"context": {"id": "ext-123"}},
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        target = next(
+            (m for m in response.data["results"] if m["replied_message"] is not None),
+            None,
+        )
+        self.assertIsNotNone(target)
+        self.assertEqual(target["replied_message"]["uuid"], str(original.uuid))
+        self.assertEqual(
+            target["replied_message"]["text"], "What are your business hours?"
+        )
+        self.assertEqual(set(target["replied_message"].keys()), {"uuid", "text"})
+
+    def test_replied_message_is_none_when_index_missing(self):
+        Message.objects.create(
+            room=self.room,
+            contact=self.contact,
+            text="Reply to nothing",
+            metadata={"context": {"id": "non-existent-id"}},
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data["results"][0]["replied_message"])
+
+    def test_replied_message_is_none_when_metadata_empty(self):
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="empty meta", metadata={}
+        )
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="null meta", metadata=None
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for item in response.data["results"]:
+            self.assertIsNone(item["replied_message"])
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
+class TestRoomHistoryPagination(BaseRoomHistoryTest):
+    def test_pagination_keys_present(self):
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="hello"
+        )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        self.assertIn("next", response.data)
+        self.assertIn("previous", response.data)
+        self.assertIn("results", response.data)
+
+    def test_pagination_caps_results_at_100(self):
+        for i in range(120):
+            Message.objects.create(
+                room=self.room, contact=self.contact, text=f"msg {i}"
+            )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid)})
+
+        self.assertEqual(len(response.data["results"]), 100)
+        self.assertIsNotNone(response.data["next"])
+
+    def test_page_size_query_param_cannot_exceed_100(self):
+        for i in range(120):
+            Message.objects.create(
+                room=self.room, contact=self.contact, text=f"msg {i}"
+            )
+        self.close_room()
+
+        self.auth()
+        response = self.get({"room": str(self.room.uuid), "page_size": "500"})
+
+        self.assertLessEqual(len(response.data["results"]), 100)
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
+class TestRoomHistoryCaching(BaseRoomHistoryTest):
+    def test_second_identical_request_returns_cached_payload(self):
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="first call"
+        )
+        self.close_room()
+
+        self.auth()
+        first = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        first_count = len(first.data["results"])
+
+        self.room.is_active = True
+        self.room.save(update_fields=["is_active"])
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="added after cache"
+        )
+        self.close_room()
+
+        second = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(second.data["results"]), first_count)
+
+        cache.clear()
+        third = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(len(third.data["results"]), first_count + 1)
+
+    def test_cache_key_changes_with_cursor(self):
+        for i in range(120):
+            Message.objects.create(
+                room=self.room, contact=self.contact, text=f"msg {i}"
+            )
+        self.close_room()
+
+        self.auth()
+        first = self.get({"room": str(self.room.uuid)})
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(first.data["next"])
+
+        cursor_value = first.data["next"].split("cursor=")[-1]
+        second = self.get({"room": str(self.room.uuid), "cursor": cursor_value})
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+
+        first_timestamps = {m["created_on"] for m in first.data["results"]}
+        second_timestamps = {m["created_on"] for m in second.data["results"]}
+        self.assertEqual(first_timestamps & second_timestamps, set())
+
+    @override_settings(ROOM_HISTORY_CACHE_TTL=123)
+    def test_uses_room_history_cache_ttl_from_settings(self):
+        Message.objects.create(
+            room=self.room, contact=self.contact, text="payload"
+        )
+        self.close_room()
+
+        self.auth()
+        with mock.patch(
+            "chats.apps.api.v1.external.msgs.viewsets.cache.set"
+        ) as mocked_set:
+            response = self.get({"room": str(self.room.uuid)})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mocked_set.assert_called_once()
+        args, _kwargs = mocked_set.call_args
+        self.assertEqual(args[2], 123)
+
+
+class TestRoomHistoryThrottleWiring(BaseRoomHistoryTest):
+    def test_three_throttle_classes_are_attached(self):
+        self.assertEqual(
+            RoomHistoryMessagesViewSet.throttle_classes,
+            [
+                ExternalRoomHistorySecondRateThrottle,
+                ExternalRoomHistoryMinuteRateThrottle,
+                ExternalRoomHistoryHourRateThrottle,
+            ],
+        )
+
+    def test_throttle_scopes_match_settings_keys(self):
+        self.assertEqual(
+            ExternalRoomHistorySecondRateThrottle.scope,
+            "external_room_history_second",
+        )
+        self.assertEqual(
+            ExternalRoomHistoryMinuteRateThrottle.scope,
+            "external_room_history_minute",
+        )
+        self.assertEqual(
+            ExternalRoomHistoryHourRateThrottle.scope,
+            "external_room_history_hour",
+        )

--- a/chats/apps/api/v1/external/msgs/tests/test_room_history_viewset.py
+++ b/chats/apps/api/v1/external/msgs/tests/test_room_history_viewset.py
@@ -182,9 +182,7 @@ class TestRoomHistoryClosedRoomRequirement(BaseRoomHistoryTest):
 @override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
 class TestRoomHistoryPayloadShape(BaseRoomHistoryTest):
     def test_response_returns_documented_fields(self):
-        Message.objects.create(
-            room=self.room, contact=self.contact, text="Hello!"
-        )
+        Message.objects.create(room=self.room, contact=self.contact, text="Hello!")
         Message.objects.create(
             room=self.room, user=self.agent, text="Hi, how can I help?"
         )
@@ -204,6 +202,8 @@ class TestRoomHistoryPayloadShape(BaseRoomHistoryTest):
             "replied_message",
             "media",
             "is_automatic_message",
+            "uuid",
+            "text",
         }
         for item in response.data["results"]:
             self.assertEqual(set(item.keys()), expected_fields)
@@ -275,11 +275,7 @@ class TestRoomHistoryPayloadShape(BaseRoomHistoryTest):
         response = self.get({"room": str(self.room.uuid)})
 
         target = next(
-            (
-                m
-                for m in response.data["results"]
-                if m["media"] and len(m["media"]) > 0
-            ),
+            (m for m in response.data["results"] if m["media"] and len(m["media"]) > 0),
             None,
         )
         self.assertIsNotNone(target)
@@ -304,9 +300,7 @@ class TestRoomHistoryPayloadShape(BaseRoomHistoryTest):
 @override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
 class TestRoomHistoryInternalNoteFilter(BaseRoomHistoryTest):
     def test_internal_note_messages_are_excluded(self):
-        Message.objects.create(
-            room=self.room, contact=self.contact, text="Visible"
-        )
+        Message.objects.create(room=self.room, contact=self.contact, text="Visible")
         hidden_msg = Message.objects.create(room=self.room, user=self.agent, text="")
         RoomNote.objects.create(
             room=self.room,
@@ -337,9 +331,7 @@ class TestRoomHistoryRepliedMessage(BaseRoomHistoryTest):
             text="What are your business hours?",
             external_id="ext-123",
         )
-        ChatMessageReplyIndex.objects.create(
-            external_id="ext-123", message=original
-        )
+        ChatMessageReplyIndex.objects.create(external_id="ext-123", message=original)
         Message.objects.create(
             room=self.room,
             user=self.agent,
@@ -397,9 +389,7 @@ class TestRoomHistoryRepliedMessage(BaseRoomHistoryTest):
 @override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
 class TestRoomHistoryPagination(BaseRoomHistoryTest):
     def test_pagination_keys_present(self):
-        Message.objects.create(
-            room=self.room, contact=self.contact, text="hello"
-        )
+        Message.objects.create(room=self.room, contact=self.contact, text="hello")
         self.close_room()
 
         self.auth()
@@ -438,9 +428,7 @@ class TestRoomHistoryPagination(BaseRoomHistoryTest):
 @override_settings(REST_FRAMEWORK=NO_THROTTLE_RATES)
 class TestRoomHistoryCaching(BaseRoomHistoryTest):
     def test_second_identical_request_returns_cached_payload(self):
-        Message.objects.create(
-            room=self.room, contact=self.contact, text="first call"
-        )
+        Message.objects.create(room=self.room, contact=self.contact, text="first call")
         self.close_room()
 
         self.auth()
@@ -485,9 +473,7 @@ class TestRoomHistoryCaching(BaseRoomHistoryTest):
 
     @override_settings(ROOM_HISTORY_CACHE_TTL=123)
     def test_uses_room_history_cache_ttl_from_settings(self):
-        Message.objects.create(
-            room=self.room, contact=self.contact, text="payload"
-        )
+        Message.objects.create(room=self.room, contact=self.contact, text="payload")
         self.close_room()
 
         self.auth()

--- a/chats/apps/api/v1/external/msgs/tests/test_room_history_viewset.py
+++ b/chats/apps/api/v1/external/msgs/tests/test_room_history_viewset.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
@@ -447,8 +448,8 @@ class TestRoomHistoryCaching(BaseRoomHistoryTest):
         self.assertEqual(first.status_code, status.HTTP_200_OK)
         first_count = len(first.data["results"])
 
-        self.room.is_active = True
-        self.room.save(update_fields=["is_active"])
+        Room.objects.filter(pk=self.room.pk).update(is_active=True)
+        self.room.refresh_from_db()
         Message.objects.create(
             room=self.room, contact=self.contact, text="added after cache"
         )
@@ -474,7 +475,7 @@ class TestRoomHistoryCaching(BaseRoomHistoryTest):
         self.assertEqual(first.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(first.data["next"])
 
-        cursor_value = first.data["next"].split("cursor=")[-1]
+        cursor_value = parse_qs(urlparse(first.data["next"]).query)["cursor"][0]
         second = self.get({"room": str(self.room.uuid), "cursor": cursor_value})
         self.assertEqual(second.status_code, status.HTTP_200_OK)
 

--- a/chats/apps/api/v1/external/msgs/viewsets.py
+++ b/chats/apps/api/v1/external/msgs/viewsets.py
@@ -1,23 +1,40 @@
 from functools import cached_property
 
+from django.conf import settings
+from django.core.cache import cache
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg.utils import swagger_auto_schema
-from rest_framework import filters, mixins, viewsets
+from rest_framework import filters, mixins, status, viewsets
+from rest_framework.pagination import CursorPagination
+from rest_framework.response import Response
 
 from chats.apps.accounts.authentication.drf.authorization import (
+    ProjectAdminAuthentication,
     get_token_auth_classes,
 )
+from chats.apps.accounts.permissions import IsExternalProject
 from chats.apps.api.authentication.permissions import InternalAPITokenRequiredPermission
 from chats.apps.api.v1.external.msgs.filters import MessageFilter
-from chats.apps.api.v1.external.msgs.serializers import MsgFlowSerializer
+from chats.apps.api.v1.external.msgs.serializers import (
+    MsgFlowSerializer,
+    RoomHistoryMessageSerializer,
+    RoomHistoryQuerySerializer,
+)
 from chats.apps.api.v1.external.permissions import IsAdminPermission
 from chats.apps.api.v1.external.throttling import (
     ExternalHourRateThrottle,
     ExternalMinuteRateThrottle,
+    ExternalRoomHistoryHourRateThrottle,
+    ExternalRoomHistoryMinuteRateThrottle,
+    ExternalRoomHistorySecondRateThrottle,
     ExternalSecondRateThrottle,
 )
 from chats.apps.api.v1.internal.permissions import ModuleHasPermission
 from chats.apps.msgs.models import Message as ChatMessage
+from chats.apps.msgs.usecases.get_room_messages_history import (
+    GetRoomMessagesHistoryUseCase,
+)
+from chats.apps.rooms.models import Room
 
 
 class MessageFlowViewset(
@@ -100,3 +117,88 @@ class MessageFlowViewset(
     def perform_update(self, serializer):
         instance = serializer.save()
         instance.notify_room("update")
+
+
+class RoomHistoryMessagesPagination(CursorPagination):
+    page_size = 100
+    max_page_size = 100
+    ordering = "-created_on"
+    cursor_query_param = "cursor"
+
+
+class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
+    """
+    Read-only endpoint that returns the message history of a closed room.
+
+    Authenticated exclusively via project admin Bearer tokens. Internal notes
+    are excluded at the database level. Responses are cached per
+    ``(room, cursor)`` for ``settings.ROOM_HISTORY_CACHE_TTL`` seconds.
+    Rate limited: 5/sec, 100/min, 4000/hour.
+    """
+
+    swagger_tag = "Integrations"
+    serializer_class = RoomHistoryMessageSerializer
+    authentication_classes = [ProjectAdminAuthentication]
+    permission_classes = [IsExternalProject]
+    throttle_classes = [
+        ExternalRoomHistorySecondRateThrottle,
+        ExternalRoomHistoryMinuteRateThrottle,
+        ExternalRoomHistoryHourRateThrottle,
+    ]
+    pagination_class = RoomHistoryMessagesPagination
+
+    @staticmethod
+    def _cache_key(room_uuid: str, cursor: str) -> str:
+        return f"external:room_history:{room_uuid}:{cursor or ''}"
+
+    @swagger_auto_schema(auto_schema=None)
+    def list(self, request, *args, **kwargs):
+        """List the message history of a closed room with cursor pagination."""
+        query_serializer = RoomHistoryQuerySerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        room_uuid = query_serializer.validated_data["room"]
+
+        room = (
+            Room.objects.filter(
+                uuid=room_uuid,
+                queue__sector__project=request.auth.project,
+            )
+            .only("uuid", "is_active")
+            .first()
+        )
+        if room is None:
+            return Response(
+                {"detail": "Room not found."}, status=status.HTTP_404_NOT_FOUND
+            )
+
+        if room.is_active:
+            return Response(
+                {
+                    "detail": (
+                        "Room history is only available for closed rooms. "
+                        "Close the room before requesting its history."
+                    )
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        cursor = request.query_params.get(
+            RoomHistoryMessagesPagination.cursor_query_param, ""
+        )
+        cache_key = self._cache_key(str(room.uuid), cursor)
+        cached_payload = cache.get(cache_key)
+        if cached_payload is not None:
+            return Response(cached_payload, status=status.HTTP_200_OK)
+
+        queryset = GetRoomMessagesHistoryUseCase().execute(room)
+        page = self.paginate_queryset(queryset)
+        serializer = self.get_serializer(page, many=True)
+        paginated_response = self.get_paginated_response(serializer.data)
+
+        cache.set(
+            cache_key,
+            paginated_response.data,
+            settings.ROOM_HISTORY_CACHE_TTL,
+        )
+
+        return paginated_response

--- a/chats/apps/api/v1/external/msgs/viewsets.py
+++ b/chats/apps/api/v1/external/msgs/viewsets.py
@@ -31,7 +31,7 @@ from chats.apps.api.v1.external.throttling import (
 )
 from chats.apps.api.v1.internal.permissions import ModuleHasPermission
 from chats.apps.msgs.exceptions import RoomNotFoundError, RoomStillActiveError
-from chats.apps.msgs.models import Message as ChatMessage
+from chats.apps.msgs.models import ChatMessageReplyIndex, Message as ChatMessage
 from chats.apps.msgs.usecases.get_room_messages_history import (
     GetRoomMessagesHistoryUseCase,
 )
@@ -151,6 +151,31 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
     def _cache_key(room_uuid: str, cursor: str) -> str:
         return f"external:room_history:{room_uuid}:{cursor or ''}"
 
+    @staticmethod
+    def _build_reply_index_map(messages) -> dict:
+        """
+        Bulk-fetch ChatMessageReplyIndex rows for every replied-to
+        external_id in the page, returning a dict keyed by external_id.
+        """
+        external_ids = set()
+        for msg in messages:
+            metadata = msg.metadata if isinstance(msg.metadata, dict) else {}
+            context = metadata.get("context")
+            if isinstance(context, dict):
+                ext_id = context.get("id")
+                if ext_id:
+                    external_ids.add(ext_id)
+
+        if not external_ids:
+            return {}
+
+        return {
+            ri.external_id: ri
+            for ri in ChatMessageReplyIndex.objects.select_related("message").filter(
+                external_id__in=external_ids
+            )
+        }
+
     @swagger_auto_schema(auto_schema=None)
     def list(self, request, *args, **kwargs):
         """List the message history of a closed room with cursor pagination."""
@@ -187,7 +212,12 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
             )
 
         page = self.paginate_queryset(queryset)
-        serializer = self.get_serializer(page, many=True)
+
+        reply_index_map = self._build_reply_index_map(page)
+
+        serializer = self.get_serializer(
+            page, many=True, context={"reply_index_map": reply_index_map}
+        )
         paginated_response = self.get_paginated_response(serializer.data)
 
         cache.set(

--- a/chats/apps/api/v1/external/msgs/viewsets.py
+++ b/chats/apps/api/v1/external/msgs/viewsets.py
@@ -122,7 +122,7 @@ class MessageFlowViewset(
 class RoomHistoryMessagesPagination(CursorPagination):
     page_size = 100
     max_page_size = 100
-    ordering = "-created_on"
+    ordering = "created_on"
     cursor_query_param = "cursor"
 
 

--- a/chats/apps/api/v1/external/msgs/viewsets.py
+++ b/chats/apps/api/v1/external/msgs/viewsets.py
@@ -30,11 +30,11 @@ from chats.apps.api.v1.external.throttling import (
     ExternalSecondRateThrottle,
 )
 from chats.apps.api.v1.internal.permissions import ModuleHasPermission
+from chats.apps.msgs.exceptions import RoomNotFoundError, RoomStillActiveError
 from chats.apps.msgs.models import Message as ChatMessage
 from chats.apps.msgs.usecases.get_room_messages_history import (
     GetRoomMessagesHistoryUseCase,
 )
-from chats.apps.rooms.models import Room
 
 
 class MessageFlowViewset(
@@ -158,20 +158,24 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
         query_serializer.is_valid(raise_exception=True)
         room_uuid = query_serializer.validated_data["room"]
 
-        room = (
-            Room.objects.filter(
-                uuid=room_uuid,
-                queue__sector__project=request.auth.project,
-            )
-            .only("uuid", "is_active")
-            .first()
+        cursor = request.query_params.get(
+            RoomHistoryMessagesPagination.cursor_query_param, ""
         )
-        if room is None:
+        cache_key = self._cache_key(str(room_uuid), cursor)
+        cached_payload = cache.get(cache_key)
+        if cached_payload is not None:
+            return Response(cached_payload, status=status.HTTP_200_OK)
+
+        try:
+            queryset = GetRoomMessagesHistoryUseCase().execute(
+                room_uuid=room_uuid,
+                project=request.auth.project,
+            )
+        except RoomNotFoundError:
             return Response(
                 {"detail": "Room not found."}, status=status.HTTP_404_NOT_FOUND
             )
-
-        if room.is_active:
+        except RoomStillActiveError:
             return Response(
                 {
                     "detail": (
@@ -182,15 +186,6 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        cursor = request.query_params.get(
-            RoomHistoryMessagesPagination.cursor_query_param, ""
-        )
-        cache_key = self._cache_key(str(room.uuid), cursor)
-        cached_payload = cache.get(cache_key)
-        if cached_payload is not None:
-            return Response(cached_payload, status=status.HTTP_200_OK)
-
-        queryset = GetRoomMessagesHistoryUseCase().execute(room)
         page = self.paginate_queryset(queryset)
         serializer = self.get_serializer(page, many=True)
         paginated_response = self.get_paginated_response(serializer.data)

--- a/chats/apps/api/v1/external/throttling.py
+++ b/chats/apps/api/v1/external/throttling.py
@@ -60,3 +60,21 @@ class ExternalCriticalRateThrottle(ExternalBaseThrottle):
     """Para endpoints como POST rooms com volume muito alto"""
 
     scope = "external_critical"
+
+
+class ExternalRoomHistorySecondRateThrottle(ExternalBaseThrottle):
+    """Per-second throttle for the external room history endpoint"""
+
+    scope = "external_room_history_second"
+
+
+class ExternalRoomHistoryMinuteRateThrottle(ExternalBaseThrottle):
+    """Per-minute throttle for the external room history endpoint"""
+
+    scope = "external_room_history_minute"
+
+
+class ExternalRoomHistoryHourRateThrottle(ExternalBaseThrottle):
+    """Per-hour throttle for the external room history endpoint"""
+
+    scope = "external_room_history_hour"

--- a/chats/apps/api/v1/routers.py
+++ b/chats/apps/api/v1/routers.py
@@ -10,7 +10,10 @@ from chats.apps.api.v1.external.agents.viewsets import (
 from chats.apps.api.v1.external.dashboard.viewsets import (
     ExternalFinishedRoomsStatusViewSet,
 )
-from chats.apps.api.v1.external.msgs.viewsets import MessageFlowViewset
+from chats.apps.api.v1.external.msgs.viewsets import (
+    MessageFlowViewset,
+    RoomHistoryMessagesViewSet,
+)
 from chats.apps.api.v1.external.queues.viewsets import QueueFlowViewset
 from chats.apps.api.v1.external.rooms.viewsets import (
     CustomFieldsUserExternalViewSet,
@@ -208,6 +211,11 @@ router.register(
 
 # External
 router.register("external/msgs", MessageFlowViewset, basename="external_message")
+router.register(
+    "external/room_messages",
+    RoomHistoryMessagesViewSet,
+    basename="external_room_messages",
+)
 router.register("external/rooms", RoomFlowViewSet, basename="external_rooms")
 router.register(
     "external/room_agent", RoomUserExternalViewSet, basename="external_roomagent"

--- a/chats/apps/msgs/exceptions.py
+++ b/chats/apps/msgs/exceptions.py
@@ -1,0 +1,10 @@
+class RoomNotFoundError(Exception):
+    """Raised when a room cannot be found within the given project."""
+
+    pass
+
+
+class RoomStillActiveError(Exception):
+    """Raised when the requested room is still active (not yet closed)."""
+
+    pass

--- a/chats/apps/msgs/tests/test_get_room_messages_history_usecase.py
+++ b/chats/apps/msgs/tests/test_get_room_messages_history_usecase.py
@@ -1,7 +1,10 @@
+import uuid
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from chats.apps.contacts.models import Contact
+from chats.apps.msgs.exceptions import RoomNotFoundError, RoomStillActiveError
 from chats.apps.msgs.models import Message
 from chats.apps.msgs.usecases.get_room_messages_history import (
     GetRoomMessagesHistoryUseCase,
@@ -47,6 +50,33 @@ class GetRoomMessagesHistoryUseCaseTests(TestCase):
 
         self.usecase = GetRoomMessagesHistoryUseCase()
 
+    def close_room(self, room=None):
+        target = room or self.room
+        Room.objects.filter(pk=target.pk).update(is_active=False)
+        target.refresh_from_db()
+        return target
+
+    def test_raises_room_not_found_when_uuid_does_not_exist(self):
+        self.close_room()
+        with self.assertRaises(RoomNotFoundError):
+            self.usecase.execute(
+                room_uuid=uuid.uuid4(), project=self.project
+            )
+
+    def test_raises_room_not_found_when_room_belongs_to_another_project(self):
+        other_project = Project.objects.create(name="Other Project")
+        self.close_room()
+        with self.assertRaises(RoomNotFoundError):
+            self.usecase.execute(
+                room_uuid=self.room.uuid, project=other_project
+            )
+
+    def test_raises_room_still_active_when_room_is_open(self):
+        with self.assertRaises(RoomStillActiveError):
+            self.usecase.execute(
+                room_uuid=self.room.uuid, project=self.project
+            )
+
     def test_returns_only_messages_from_the_given_room(self):
         msg_in_room = Message.objects.create(
             room=self.room, contact=self.contact, text="Hello room"
@@ -56,8 +86,11 @@ class GetRoomMessagesHistoryUseCaseTests(TestCase):
             contact=self.other_room.contact,
             text="From another room",
         )
+        self.close_room()
 
-        result = list(self.usecase.execute(self.room))
+        result = list(
+            self.usecase.execute(room_uuid=self.room.uuid, project=self.project)
+        )
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].uuid, msg_in_room.uuid)
@@ -73,8 +106,14 @@ class GetRoomMessagesHistoryUseCaseTests(TestCase):
             text="Internal observation",
             message=note_msg,
         )
+        self.close_room()
 
-        result_uuids = [m.uuid for m in self.usecase.execute(self.room)]
+        result_uuids = [
+            m.uuid
+            for m in self.usecase.execute(
+                room_uuid=self.room.uuid, project=self.project
+            )
+        ]
 
         self.assertIn(regular_msg.uuid, result_uuids)
         self.assertNotIn(note_msg.uuid, result_uuids)
@@ -89,8 +128,14 @@ class GetRoomMessagesHistoryUseCaseTests(TestCase):
             text="Note without anchor",
             message=None,
         )
+        self.close_room()
 
-        result_uuids = [m.uuid for m in self.usecase.execute(self.room)]
+        result_uuids = [
+            m.uuid
+            for m in self.usecase.execute(
+                room_uuid=self.room.uuid, project=self.project
+            )
+        ]
 
         self.assertIn(msg.uuid, result_uuids)
 
@@ -104,8 +149,11 @@ class GetRoomMessagesHistoryUseCaseTests(TestCase):
         msg3 = Message.objects.create(
             room=self.room, contact=self.contact, text="third"
         )
+        self.close_room()
 
-        result = list(self.usecase.execute(self.room))
+        result = list(
+            self.usecase.execute(room_uuid=self.room.uuid, project=self.project)
+        )
 
         self.assertEqual(
             [m.uuid for m in result],
@@ -115,6 +163,9 @@ class GetRoomMessagesHistoryUseCaseTests(TestCase):
     def test_returns_queryset_instance(self):
         from django.db.models.query import QuerySet
 
-        result = self.usecase.execute(self.room)
+        self.close_room()
+        result = self.usecase.execute(
+            room_uuid=self.room.uuid, project=self.project
+        )
 
         self.assertIsInstance(result, QuerySet)

--- a/chats/apps/msgs/tests/test_get_room_messages_history_usecase.py
+++ b/chats/apps/msgs/tests/test_get_room_messages_history_usecase.py
@@ -1,0 +1,120 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from chats.apps.contacts.models import Contact
+from chats.apps.msgs.models import Message
+from chats.apps.msgs.usecases.get_room_messages_history import (
+    GetRoomMessagesHistoryUseCase,
+)
+from chats.apps.projects.models import Project
+from chats.apps.queues.models import Queue
+from chats.apps.rooms.models import Room, RoomNote
+from chats.apps.sectors.models import Sector
+
+User = get_user_model()
+
+
+class GetRoomMessagesHistoryUseCaseTests(TestCase):
+    def setUp(self):
+        self.agent = User.objects.create_user(
+            email="agent@test.com",
+            password="testpass123",
+            first_name="Ana",
+            last_name="Agent",
+        )
+        self.contact = Contact.objects.create(name="Customer")
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=10,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.room = Room.objects.create(
+            contact=self.contact,
+            queue=self.queue,
+            user=self.agent,
+            is_active=True,
+        )
+        self.other_room = Room.objects.create(
+            contact=Contact.objects.create(name="Other Customer"),
+            queue=self.queue,
+            user=self.agent,
+            is_active=True,
+        )
+
+        self.usecase = GetRoomMessagesHistoryUseCase()
+
+    def test_returns_only_messages_from_the_given_room(self):
+        msg_in_room = Message.objects.create(
+            room=self.room, contact=self.contact, text="Hello room"
+        )
+        Message.objects.create(
+            room=self.other_room,
+            contact=self.other_room.contact,
+            text="From another room",
+        )
+
+        result = list(self.usecase.execute(self.room))
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].uuid, msg_in_room.uuid)
+
+    def test_excludes_messages_with_internal_note(self):
+        regular_msg = Message.objects.create(
+            room=self.room, contact=self.contact, text="Visible"
+        )
+        note_msg = Message.objects.create(room=self.room, user=self.agent, text="")
+        RoomNote.objects.create(
+            room=self.room,
+            user=self.agent,
+            text="Internal observation",
+            message=note_msg,
+        )
+
+        result_uuids = [m.uuid for m in self.usecase.execute(self.room)]
+
+        self.assertIn(regular_msg.uuid, result_uuids)
+        self.assertNotIn(note_msg.uuid, result_uuids)
+
+    def test_includes_messages_when_room_has_unanchored_notes(self):
+        msg = Message.objects.create(
+            room=self.room, contact=self.contact, text="Still visible"
+        )
+        RoomNote.objects.create(
+            room=self.room,
+            user=self.agent,
+            text="Note without anchor",
+            message=None,
+        )
+
+        result_uuids = [m.uuid for m in self.usecase.execute(self.room)]
+
+        self.assertIn(msg.uuid, result_uuids)
+
+    def test_messages_are_ordered_by_created_on_descending(self):
+        msg1 = Message.objects.create(
+            room=self.room, contact=self.contact, text="first"
+        )
+        msg2 = Message.objects.create(
+            room=self.room, contact=self.contact, text="second"
+        )
+        msg3 = Message.objects.create(
+            room=self.room, contact=self.contact, text="third"
+        )
+
+        result = list(self.usecase.execute(self.room))
+
+        self.assertEqual(
+            [m.uuid for m in result],
+            [msg3.uuid, msg2.uuid, msg1.uuid],
+        )
+
+    def test_returns_queryset_instance(self):
+        from django.db.models.query import QuerySet
+
+        result = self.usecase.execute(self.room)
+
+        self.assertIsInstance(result, QuerySet)

--- a/chats/apps/msgs/tests/test_get_room_messages_history_usecase.py
+++ b/chats/apps/msgs/tests/test_get_room_messages_history_usecase.py
@@ -139,7 +139,7 @@ class GetRoomMessagesHistoryUseCaseTests(TestCase):
 
         self.assertIn(msg.uuid, result_uuids)
 
-    def test_messages_are_ordered_by_created_on_descending(self):
+    def test_messages_are_ordered_by_created_on_ascending(self):
         msg1 = Message.objects.create(
             room=self.room, contact=self.contact, text="first"
         )
@@ -157,7 +157,7 @@ class GetRoomMessagesHistoryUseCaseTests(TestCase):
 
         self.assertEqual(
             [m.uuid for m in result],
-            [msg3.uuid, msg2.uuid, msg1.uuid],
+            [msg1.uuid, msg2.uuid, msg3.uuid],
         )
 
     def test_returns_queryset_instance(self):

--- a/chats/apps/msgs/usecases/get_room_messages_history.py
+++ b/chats/apps/msgs/usecases/get_room_messages_history.py
@@ -41,5 +41,5 @@ class GetRoomMessagesHistoryUseCase:
             Message.objects.filter(room=room, internal_note__isnull=True)
             .select_related("user", "contact")
             .prefetch_related("medias")
-            .order_by("-created_on")
+            .order_by("created_on")
         )

--- a/chats/apps/msgs/usecases/get_room_messages_history.py
+++ b/chats/apps/msgs/usecases/get_room_messages_history.py
@@ -1,0 +1,22 @@
+from django.db.models import QuerySet
+
+from chats.apps.msgs.models import Message
+from chats.apps.rooms.models import Room
+
+
+class GetRoomMessagesHistoryUseCase:
+    """
+    Builds the queryset of messages that compose the history of a room.
+
+    Internal notes are excluded at the database level (not on the application
+    side) by filtering on the reverse ``internal_note`` OneToOne relation
+    declared on ``RoomNote.message``.
+    """
+
+    def execute(self, room: Room) -> "QuerySet[Message]":
+        return (
+            Message.objects.filter(room=room, internal_note__isnull=True)
+            .select_related("user", "contact")
+            .prefetch_related("medias")
+            .order_by("-created_on")
+        )

--- a/chats/apps/msgs/usecases/get_room_messages_history.py
+++ b/chats/apps/msgs/usecases/get_room_messages_history.py
@@ -1,19 +1,42 @@
+from uuid import UUID
+
 from django.db.models import QuerySet
 
+from chats.apps.msgs.exceptions import RoomNotFoundError, RoomStillActiveError
 from chats.apps.msgs.models import Message
+from chats.apps.projects.models import Project
 from chats.apps.rooms.models import Room
 
 
 class GetRoomMessagesHistoryUseCase:
     """
-    Builds the queryset of messages that compose the history of a room.
+    Returns the message history queryset for a closed room that belongs to the
+    given project.
 
-    Internal notes are excluded at the database level (not on the application
-    side) by filtering on the reverse ``internal_note`` OneToOne relation
-    declared on ``RoomNote.message``.
+    Raises ``RoomNotFoundError`` when the room does not exist or does not
+    belong to the project.  Raises ``RoomStillActiveError`` when the room
+    has not been closed yet.
+
+    Internal notes are excluded at the database level by filtering on the
+    reverse ``internal_note`` OneToOne relation declared on
+    ``RoomNote.message``.
     """
 
-    def execute(self, room: Room) -> "QuerySet[Message]":
+    def execute(self, room_uuid: UUID, project: Project) -> "QuerySet[Message]":
+        room = (
+            Room.objects.filter(
+                uuid=room_uuid,
+                queue__sector__project=project,
+            )
+            .only("uuid", "is_active")
+            .first()
+        )
+        if room is None:
+            raise RoomNotFoundError()
+
+        if room.is_active:
+            raise RoomStillActiveError()
+
         return (
             Message.objects.filter(room=room, internal_note__isnull=True)
             .select_related("user", "contact")

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -273,6 +273,15 @@ REST_FRAMEWORK = {
         "external_hour": env.str("EXTERNAL_HOUR_LIMIT", default="30000/hour"),
         "external_anon": env.str("EXTERNAL_ANON_LIMIT", default="100/hour"),
         "external_critical": env.str("EXTERNAL_CRITICAL_LIMIT", default="1000/minute"),
+        "external_room_history_second": env.str(
+            "EXTERNAL_ROOM_HISTORY_SECOND_LIMIT", default="5/second"
+        ),
+        "external_room_history_minute": env.str(
+            "EXTERNAL_ROOM_HISTORY_MINUTE_LIMIT", default="100/minute"
+        ),
+        "external_room_history_hour": env.str(
+            "EXTERNAL_ROOM_HISTORY_HOUR_LIMIT", default="4000/hour"
+        ),
         "ai_text_improvement": env.str(
             "AI_TEXT_IMPROVEMENT_LIMIT", default="20/minute"
         ),
@@ -287,6 +296,17 @@ EXTERNAL_MINUTE_LIMIT = env.str("EXTERNAL_MINUTE_LIMIT", default="600/minute")
 EXTERNAL_HOUR_LIMIT = env.str("EXTERNAL_HOUR_LIMIT", default="30000/hour")
 EXTERNAL_ANON_LIMIT = env.str("EXTERNAL_ANON_LIMIT", default="100/hour")
 EXTERNAL_CRITICAL_LIMIT = env.str("EXTERNAL_CRITICAL_LIMIT", default="1000/minute")
+EXTERNAL_ROOM_HISTORY_SECOND_LIMIT = env.str(
+    "EXTERNAL_ROOM_HISTORY_SECOND_LIMIT", default="5/second"
+)
+EXTERNAL_ROOM_HISTORY_MINUTE_LIMIT = env.str(
+    "EXTERNAL_ROOM_HISTORY_MINUTE_LIMIT", default="100/minute"
+)
+EXTERNAL_ROOM_HISTORY_HOUR_LIMIT = env.str(
+    "EXTERNAL_ROOM_HISTORY_HOUR_LIMIT", default="4000/hour"
+)
+
+ROOM_HISTORY_CACHE_TTL = env.int("ROOM_HISTORY_CACHE_TTL", default=300)
 
 # Logging
 


### PR DESCRIPTION
### What
- Added a new external REST endpoint (`GET /api/v1/external/room_messages/`) that returns the full message history of a **closed** room, authenticated via project admin Bearer tokens.
- Created `GetRoomMessagesHistoryUseCase` to encapsulate the business logic: validates that the room exists within the project, ensures it is closed, and returns messages excluding internal notes.
- Added dedicated serializers (`RoomHistoryMessageSerializer`, `RoomHistoryQuerySerializer`, and supporting nested serializers) to shape the response payload with user, contact, media, and replied-message data.
- Introduced custom domain exceptions (`RoomNotFoundError`, `RoomStillActiveError`) for explicit error handling in the use case layer.
- Implemented cursor-based pagination (max 100 per page) and per-`(room, cursor)` response caching with a configurable TTL (`ROOM_HISTORY_CACHE_TTL`, default 300s).
- Added three dedicated throttle classes (`external_room_history_second`, `_minute`, `_hour`) with configurable rates (default 5/s, 100/min, 4000/h).
- Comprehensive test coverage: use case unit tests, viewset integration tests covering auth, query validation, closed-room enforcement, payload shape, internal-note filtering, replied messages, pagination, caching, and throttle wiring.

### Why
- External integrations need programmatic access to conversation history after a room is closed.
- Restricting access to closed rooms only prevents data leakage from in-progress conversations and keeps the endpoint behavior deterministic (the message set is immutable once the room is closed).
- Dedicated throttle rates and response caching protect the database from high-frequency polling by external consumers without impacting other external API rate limits.