### PR TITLE
chore: update schedule for start-archive-rooms-messages task in Celery beat settings

### DIFF
--- a/chats/settings.py
+++ b/chats/settings.py
@@ -510,7 +510,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "start-archive-rooms-messages": {
         "task": "start_archive_rooms_messages",
-        "schedule": crontab(hour="0-4", minute=0),
+        "schedule": crontab(hour="22-23,0-5", minute=0),
     },
 }
 


### PR DESCRIPTION
- Changed the schedule to run the task at 10 PM to 11 PM and 12 AM to 5 AM instead of 12 AM to 4 AM.