### PR TITLE
chore: Update archive chats schedule

### DIFF
--- a/chats/settings.py
+++ b/chats/settings.py
@@ -510,7 +510,7 @@ CELERY_BEAT_SCHEDULE = {
     },
     "start-archive-rooms-messages": {
         "task": "start_archive_rooms_messages",
-        "schedule": crontab(hour="22-23,0-5", minute=0),
+        "schedule": crontab(hour="0-4", minute=0),
     },
 }
 


### PR DESCRIPTION
The cron schedule for `start-archive-rooms-messages` was updated from `hour="22-23,0-5"` to `hour="0-4"`, removing the late-night hours (22:00–23:00) from the execution window.