### PR TITLE
feat: JWT authentication

### DIFF
--- a/chats/apps/api/authentication/classes.py
+++ b/chats/apps/api/authentication/classes.py
@@ -1,8 +1,12 @@
 from django.conf import settings
 
+from chats.apps.api.authentication.exceptions import InvalidTokenError
+from chats.apps.api.authentication.services.jwt_service import JWTService
 from chats.apps.api.authentication.token import JWTTokenGenerator
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
+
+from chats.apps.projects.models.models import Project
 
 
 class GenericJWTAuthentication(BaseAuthentication):
@@ -74,6 +78,49 @@ class InternalAPITokenAuthentication(BaseAuthentication):
             raise AuthenticationFailed("Invalid authentication token.")
 
         return (None, "INTERNAL")
+
+    def authenticate_header(self, request):
+        return "Bearer"
+
+
+class JWTAuthentication(BaseAuthentication):
+    def authenticate(self, request):
+        header = request.headers.get("Authorization")
+
+        if not header:
+            return None
+
+        try:
+            header_parts = header.split(" ")
+            if len(header_parts) != 2 or header_parts[0] != "Bearer":
+                return None
+        except Exception:
+            return None
+
+        token = header_parts[1]
+
+        try:
+            decoded_token = JWTService().decode_jwt_token(token)
+        except InvalidTokenError:
+            # Not a valid JWT (e.g. OIDC token); let other authenticators try
+            return None
+
+        project_uuid = decoded_token.get("project_uuid")
+
+        if not project_uuid:
+            raise AuthenticationFailed("Invalid token")
+
+        request.project_uuid = project_uuid
+        request.jwt_payload = decoded_token
+
+        project = Project.objects.filter(uuid=project_uuid).first()
+
+        if not project:
+            raise AuthenticationFailed("Project not found")
+
+        request.project = project
+
+        return None, None
 
     def authenticate_header(self, request):
         return "Bearer"

--- a/chats/apps/api/authentication/classes.py
+++ b/chats/apps/api/authentication/classes.py
@@ -5,7 +5,7 @@ from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
 
-class JWTAuthentication(BaseAuthentication):
+class GenericJWTAuthentication(BaseAuthentication):
     """
     Authentication class for the JWT token.
     """

--- a/chats/apps/api/authentication/exceptions.py
+++ b/chats/apps/api/authentication/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidTokenError(Exception):
+    pass

--- a/chats/apps/api/authentication/permissions.py
+++ b/chats/apps/api/authentication/permissions.py
@@ -1,5 +1,7 @@
 from rest_framework.permissions import BasePermission
 from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 from chats.apps.projects.models.models import Project
 
@@ -48,3 +50,11 @@ class ProjectUUIDRequestBodyPermission(BasePermission):
 
         request.project = project
         return True
+
+
+class HasInternalAuthenticationPermission(BasePermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        jwt_payload = getattr(request, "jwt_payload", None)
+        project_uuid = getattr(request, "project_uuid", None)
+
+        return jwt_payload is not None and project_uuid is not None

--- a/chats/apps/api/authentication/services/jwt_service.py
+++ b/chats/apps/api/authentication/services/jwt_service.py
@@ -1,0 +1,48 @@
+from typing import Optional, Union
+from uuid import UUID
+
+import jwt
+from datetime import datetime, timedelta, timezone
+from django.conf import settings
+
+from chats.apps.api.authentication.exceptions import InvalidTokenError
+
+
+class JWTService:
+    """
+    Service to generate JWT tokens for the project
+    """
+
+    def generate_jwt_token(
+        self,
+        project_uuid: Optional[Union[str, UUID]] = None,
+        key: Optional[str] = None,
+        vtex_account: Optional[str] = None,
+    ) -> str:
+        if key is None:
+            key = settings.JWT_SECRET_KEY
+        payload = {
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+            "iat": datetime.now(timezone.utc),
+        }
+
+        if vtex_account is not None:
+            payload["vtex_account"] = vtex_account
+
+        if project_uuid is not None:
+            payload["project_uuid"] = str(project_uuid)
+
+        if not key:
+            key = settings.JWT_SECRET_KEY
+
+        token = jwt.encode(payload, key, algorithm="RS256")
+
+        return token
+
+    def decode_jwt_token(self, token: str, key: Optional[str] = None) -> dict:
+        if key is None:
+            key = settings.JWT_PUBLIC_KEY
+        try:
+            return jwt.decode(token, key, algorithms=["RS256"])
+        except Exception as e:
+            raise InvalidTokenError("Error decoding token") from e

--- a/chats/apps/api/authentication/tests/test_classes.py
+++ b/chats/apps/api/authentication/tests/test_classes.py
@@ -13,7 +13,7 @@ from rest_framework import status
 
 from chats.apps.api.authentication.classes import (
     InternalAPITokenAuthentication,
-    JWTAuthentication,
+    GenericJWTAuthentication,
 )
 from chats.apps.api.authentication.token import JWTTokenGenerator
 
@@ -24,7 +24,7 @@ from chats.apps.api.authentication.permissions import (
 )
 
 
-class JWTAuthenticationTests(TestCase):
+class GenericJWTAuthenticationTests(TestCase):
     def setUp(self):
         self.token_generator = JWTTokenGenerator()
         self.valid_token = self.token_generator.generate_token(
@@ -32,7 +32,7 @@ class JWTAuthenticationTests(TestCase):
         )
 
     def test_authenticate(self):
-        authentication = JWTAuthentication()
+        authentication = GenericJWTAuthentication()
         request = HttpRequest()
         request.META["HTTP_AUTHORIZATION"] = f"Token {self.valid_token}"
         result = authentication.authenticate(request)
@@ -42,7 +42,7 @@ class JWTAuthenticationTests(TestCase):
         self.assertIsNotNone(result[1])
 
     def test_authenticate_credentials(self):
-        authentication = JWTAuthentication()
+        authentication = GenericJWTAuthentication()
         result = authentication.authenticate_credentials(self.valid_token)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 2)
@@ -50,8 +50,8 @@ class JWTAuthenticationTests(TestCase):
         self.assertIsNotNone(result[1])
 
 
-class JWTAuthenticationView(APIView):
-    authentication_classes = [JWTAuthentication]
+class GenericJWTAuthenticationView(APIView):
+    authentication_classes = [GenericJWTAuthentication]
     permission_classes = [JWTRequiredPermission]
 
     def get(self, request):
@@ -66,8 +66,8 @@ class JWTAuthenticationView(APIView):
 
 
 @override_settings(ROOT_URLCONF="chats.apps.api.authentication.tests.test_urls")
-class JWTAuthenticationViewAPITestCase(APITestCase):
-    """Test cases for JWTAuthenticationView using JWTAuthentication."""
+class GenericJWTAuthenticationViewAPITestCase(APITestCase):
+    """Test cases for GenericJWTAuthenticationView using GenericJWTAuthentication."""
 
     def setUp(self):
         self.client = APIClient()

--- a/chats/apps/api/authentication/tests/test_jwt_authentication.py
+++ b/chats/apps/api/authentication/tests/test_jwt_authentication.py
@@ -1,0 +1,74 @@
+import uuid
+from rest_framework.test import APITestCase
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    HasInternalAuthenticationPermission,
+)
+from django.test import override_settings
+from django.urls import reverse
+
+from chats.apps.api.authentication.services.jwt_service import JWTService
+from chats.apps.api.authentication.tests.test_jwt_service import (
+    generate_private_key,
+    generate_private_key_pem,
+    generate_public_key,
+    generate_public_key_pem,
+)
+from chats.apps.projects.models.models import Project
+
+
+TEST_PRIVATE_KEY = generate_private_key()
+TEST_PRIVATE_KEY_PEM = generate_private_key_pem(TEST_PRIVATE_KEY)
+
+TEST_PUBLIC_KEY = generate_public_key(TEST_PRIVATE_KEY)
+TEST_PUBLIC_KEY_PEM = generate_public_key_pem(TEST_PUBLIC_KEY)
+
+
+class MockJWTAuthenticationView(APIView):
+    authentication_classes = [JWTAuthentication]
+    # Same as internal VTEX/conversations views: allow when JWT set request.jwt_payload/project_uuid
+    permission_classes = [HasInternalAuthenticationPermission]
+
+    def get(self, request):
+        return Response({"status": "ok"}, status=status.HTTP_200_OK)
+
+
+class TestJWTAuthentication(APITestCase):
+    def setUp(self):
+        self.jwt_service = JWTService()
+
+    @override_settings(ROOT_URLCONF="chats.apps.api.authentication.tests.test_urls")
+    @override_settings(JWT_SECRET_KEY=TEST_PRIVATE_KEY_PEM)
+    @override_settings(JWT_PUBLIC_KEY=TEST_PUBLIC_KEY_PEM)
+    def test_jwt_authentication(self):
+        project = Project.objects.create(name="Test Project")
+        token = self.jwt_service.generate_jwt_token(project_uuid=project.uuid)
+        url = reverse("mock-jwt-authentication-view")
+        response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"status": "ok"})
+
+    @override_settings(ROOT_URLCONF="chats.apps.api.authentication.tests.test_urls")
+    @override_settings(JWT_SECRET_KEY=TEST_PRIVATE_KEY_PEM)
+    @override_settings(JWT_PUBLIC_KEY=TEST_PUBLIC_KEY_PEM)
+    def test_jwt_authentication_project_not_found(self):
+        token = self.jwt_service.generate_jwt_token(project_uuid=uuid.uuid4())
+        url = reverse("mock-jwt-authentication-view")
+        response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data, {"detail": "Project not found"})
+
+    @override_settings(ROOT_URLCONF="chats.apps.api.authentication.tests.test_urls")
+    def test_jwt_authentication_missing_header(self):
+        url = reverse("mock-jwt-authentication-view")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @override_settings(ROOT_URLCONF="chats.apps.api.authentication.tests.test_urls")
+    def test_jwt_authentication_invalid_header(self):
+        url = reverse("mock-jwt-authentication-view")
+        response = self.client.get(url, HTTP_AUTHORIZATION="Bearer invalid-token")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/chats/apps/api/authentication/tests/test_jwt_service.py
+++ b/chats/apps/api/authentication/tests/test_jwt_service.py
@@ -1,0 +1,43 @@
+import uuid
+
+from django.test import TestCase
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+
+from chats.apps.api.authentication.services.jwt_service import JWTService
+
+
+def generate_private_key():
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+
+def generate_private_key_pem(private_key: rsa.RSAPrivateKey):
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+def generate_public_key(private_key):
+    return private_key.public_key()
+
+
+def generate_public_key_pem(public_key: rsa.RSAPublicKey):
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+
+
+class JWTServiceTests(TestCase):
+    def test_generate_jwt_token(self):
+        jwt_service = JWTService()
+        token = jwt_service.generate_jwt_token(
+            project_uuid=uuid.uuid4(),
+            key=generate_private_key_pem(generate_private_key()),
+        )
+        self.assertIsNotNone(token)

--- a/chats/apps/api/authentication/tests/test_urls.py
+++ b/chats/apps/api/authentication/tests/test_urls.py
@@ -3,6 +3,9 @@ from chats.apps.api.authentication.tests.test_classes import (
     InternalAPITokenAuthenticationView,
     GenericJWTAuthenticationView,
 )
+from chats.apps.api.authentication.tests.test_jwt_authentication import (
+    MockJWTAuthenticationView,
+)
 
 urlpatterns = [
     path(
@@ -14,5 +17,10 @@ urlpatterns = [
         "internal-api-token-authentication/",
         InternalAPITokenAuthenticationView.as_view(),
         name="internal-api-token-authentication-view",
+    ),
+    path(
+        "mock-jwt-authentication/",
+        MockJWTAuthenticationView.as_view(),
+        name="mock-jwt-authentication-view",
     ),
 ]

--- a/chats/apps/api/authentication/tests/test_urls.py
+++ b/chats/apps/api/authentication/tests/test_urls.py
@@ -1,13 +1,13 @@
 from django.urls import path
 from chats.apps.api.authentication.tests.test_classes import (
     InternalAPITokenAuthenticationView,
-    JWTAuthenticationView,
+    GenericJWTAuthenticationView,
 )
 
 urlpatterns = [
     path(
         "jwt-authentication/",
-        JWTAuthenticationView.as_view(),
+        GenericJWTAuthenticationView.as_view(),
         name="jwt-authentication-view",
     ),
     path(

--- a/chats/apps/api/v1/internal/csat/views.py
+++ b/chats/apps/api/v1/internal/csat/views.py
@@ -2,7 +2,7 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework.response import Response
 from rest_framework import status
 
-from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.classes import GenericJWTAuthentication
 from chats.apps.api.v1.internal.csat.permissions import CSATWebhookPermission
 from chats.apps.api.v1.internal.csat.serializers import (
     CreateCSATWebhookSerializer,
@@ -14,7 +14,7 @@ from chats.apps.csat.models import CSATSurvey
 class CSATWebhookView(GenericViewSet):
     serializer_class = CreateCSATWebhookSerializer
     permission_classes = [CSATWebhookPermission]
-    authentication_classes = [JWTAuthentication]
+    authentication_classes = [GenericJWTAuthentication]
 
     def create(self, request, *args, **kwargs):
         room_uuid = request.data.get("room")

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -451,6 +451,9 @@ if USE_SENTRY:
         environment=env.str("ENVIRONMENT", default="develop"),
     )
 
+# JWT
+JWT_SECRET_KEY = env.str("JWT_SECRET_KEY", default="").replace("\\n", "\n")
+JWT_PUBLIC_KEY = env.str("JWT_PUBLIC_KEY", default="").replace("\\n", "\n")
 
 # Query Limiters
 


### PR DESCRIPTION
### What
- Renamed the existing `JWTAuthentication` class to `GenericJWTAuthentication` to avoid naming conflicts and clarify its purpose as the generic/legacy authenticator (more details about this in the notes section below)
- Introduced a new `JWTAuthentication` class that validates RS256-signed JWT tokens, extracts the `project_uuid` claim, resolves the corresponding `Project`, and attaches both the decoded payload and the project instance to the request.
- Created `JWTService` for generating and decoding RS256 JWT tokens using configurable RSA key pairs (`JWT_SECRET_KEY` / `JWT_PUBLIC_KEY`).
- Added `InvalidTokenError` custom exception for token decoding failures.
- Added `HasInternalAuthenticationPermission` permission class that grants access when the request carries a valid JWT payload and project UUID.
- Registered the new `JWT_SECRET_KEY` and `JWT_PUBLIC_KEY` settings sourced from environment variables.
- Added unit tests covering token generation, successful authentication, missing/invalid tokens, and project-not-found scenarios.

### Why
The system needed a dedicated internal JWT authentication mechanism based on RSA (RS256) key pairs to securely authenticate service-to-service requests scoped to a specific project. The previous `JWTAuthentication` was a generic token-based authenticator that didn't support asymmetric signing or project-level authorization. By introducing the new `JWTAuthentication` and `JWTService`, internal services can issue and verify short-lived, project-scoped tokens while keeping the legacy authenticator intact under its new name (`GenericJWTAuthentication`).

### Notes
The old JWTAuthentication will be removed in the future in a separate task, as it will require a changes in the CSAT webhook viewset and its tests to support it, which is out of scope here.

### Sequence diagram
```mermaid
sequenceDiagram
    participant Client
    participant API as Django API
    participant JWTAuth as JWTAuthentication
    participant JWTSvc as JWTService
    participant DB as Database

    Client->>API: GET /endpoint (Authorization: Bearer <token>)
    API->>JWTAuth: authenticate(request)
    JWTAuth->>JWTAuth: Extract token from Authorization header

    alt Missing or malformed header
        JWTAuth-->>API: return None (skip to next authenticator)
    end

    JWTAuth->>JWTSvc: decode_jwt_token(token)

    alt Invalid or expired token
        JWTSvc-->>JWTAuth: raise InvalidTokenError
        JWTAuth-->>API: return None (skip to next authenticator)
    end

    JWTSvc-->>JWTAuth: decoded payload (project_uuid, vtex_account, ...)

    alt Missing project_uuid claim
        JWTAuth-->>API: raise AuthenticationFailed("Invalid token")
        API-->>Client: 401 Unauthorized
    end

    JWTAuth->>DB: Project.objects.filter(uuid=project_uuid)

    alt Project not found
        DB-->>JWTAuth: None
        JWTAuth-->>API: raise AuthenticationFailed("Project not found")
        API-->>Client: 401 Unauthorized
    end

    DB-->>JWTAuth: Project instance
    JWTAuth->>JWTAuth: Attach project, project_uuid, jwt_payload to request
    JWTAuth-->>API: return (None, None)
    API->>API: HasInternalAuthenticationPermission checks jwt_payload and project_uuid
    API-->>Client: 200 OK
```