### PR TITLE
feat: adding apm tracers to requests

### DIFF
--- a/chats/core/tests/test_apm.py
+++ b/chats/core/tests/test_apm.py
@@ -1,0 +1,76 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from django.conf import settings
+from django.test import TestCase
+
+APM_MIDDLEWARE = "elasticapm.contrib.django.middleware.TracingMiddleware"
+APM_APP = "elasticapm.contrib.django"
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+class ApmConfigurationTestCase(TestCase):
+    def test_apm_disabled_by_default(self):
+        self.assertFalse(settings.USE_APM)
+
+    def test_tracing_middleware_not_registered_when_apm_disabled(self):
+        self.assertNotIn(APM_MIDDLEWARE, settings.MIDDLEWARE)
+
+    def test_elasticapm_app_not_registered_when_apm_disabled(self):
+        self.assertNotIn(APM_APP, settings.INSTALLED_APPS)
+
+    def _build_subprocess_env(self, **overrides):
+        env = os.environ.copy()
+        env.update(
+            {
+                "DJANGO_SETTINGS_MODULE": "chats.settings",
+                "SECRET_KEY": settings.SECRET_KEY,
+                "PROMETHEUS_AUTH_TOKEN": settings.PROMETHEUS_AUTH_TOKEN,
+            }
+        )
+        if "DATABASE_URL" not in env:
+            database = settings.DATABASES["default"]
+            if database["ENGINE"] == "django.db.backends.sqlite3":
+                env["DATABASE_URL"] = f"sqlite:///{database['NAME']}"
+            else:
+                env["DATABASE_URL"] = (
+                    f"postgres://{database['USER']}:{database['PASSWORD']}"
+                    f"@{database['HOST']}:{database['PORT']}/{database['NAME']}"
+                )
+        env.update(overrides)
+        return env
+
+    def test_settings_registers_apm_when_enabled(self):
+        env = self._build_subprocess_env(
+            USE_APM="true",
+            APM_SECRET_TOKEN="test-token",
+            APM_SERVER_URL="http://localhost:8200",
+        )
+        script = """
+import django
+
+django.setup()
+
+from django.conf import settings
+
+assert settings.USE_APM is True
+assert settings.MIDDLEWARE[0] == "elasticapm.contrib.django.middleware.TracingMiddleware"
+assert "elasticapm.contrib.django" in settings.INSTALLED_APPS
+assert settings.ELASTIC_APM["SERVICE_NAME"] == "chats-production"
+assert settings.ELASTIC_APM["SERVER_URL"] == "http://localhost:8200"
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=result.stderr or result.stdout,
+        )

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -317,6 +317,7 @@ USE_APM = env.bool("USE_APM", default=False)
 
 if USE_APM:
     INSTALLED_APPS.append("elasticapm.contrib.django")
+    MIDDLEWARE.insert(0, "elasticapm.contrib.django.middleware.TracingMiddleware")
 
     ELASTIC_APM = {
         "SERVICE_NAME": env("APM_SERVICE_NAME", default="chats-production"),


### PR DESCRIPTION
### **What**
Enable Elastic APM HTTP request tracing by registering elasticapm.contrib.django.middleware.TracingMiddleware when USE_APM=true.

Add unit tests to validate APM configuration behavior:

APM remains disabled by default in test/CI environments
When USE_APM=true, the tracing middleware is registered first, the Elastic APM Django app is added to INSTALLED_APPS, and ELASTIC_APM settings are loaded correctly

### **Why**
The project already had the Elastic APM agent dependency and base configuration, but requests were not being traced because the tracing middleware was missing. Without it, the APM agent does not create a transaction per HTTP request, so traces do not appear in Kibana for API debugging.

This change is the minimum required to start capturing request-level traces in Elastic APM when APM is enabled in staging/production.