### PR TITLE
refactor: optimize pinned room retrieval in RoomViewset

### DIFF
--- a/chats/apps/api/v1/rooms/serializers.py
+++ b/chats/apps/api/v1/rooms/serializers.py
@@ -388,6 +388,13 @@ class ListRoomSerializer(serializers.ModelSerializer):
         }
 
     def get_is_pinned(self, room: Room) -> bool:
+        # The list queryset annotates ``is_pinned`` (see RoomViewset), so the
+        # value is read straight from the instance and the per-room query below
+        # is skipped, avoiding an N+1 during listing.
+        annotated = getattr(room, "is_pinned", None)
+        if annotated is not None:
+            return bool(annotated)
+
         request = self.context.get("request")
 
         if not request:

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -8,10 +8,11 @@ from django.db.models import (
     Case,
     Count,
     DateTimeField,
-    Exists,
+    IntegerField,
     OuterRef,
     Q,
     Subquery,
+    Value,
     When,
 )
 from django.shortcuts import get_object_or_404
@@ -294,65 +295,55 @@ class RoomViewset(
         return self._get_paginated_response(annotated_qs)
 
     def _list_with_optimized_pin_order(self, qs, request, project):
-        target_pins_queryset = RoomPin.objects.filter(
-            room__queue__sector__project=project,
-        )
+        # The pin limit is capped at ``MAX_ROOM_PINS_LIMIT`` (3) per user, so the
+        # pinned rooms form a tiny, bounded set. We resolve them with a single
+        # small query and reuse the resulting ids as constant literals, avoiding
+        # the correlated subqueries / full-PK materialization of the other paths.
+        pins_query = {"room__queue__sector__project": project, "room__is_active": True}
 
         if user_email := request.query_params.get("email"):
-            target_pins_queryset = target_pins_queryset.filter(user__email=user_email)
+            pins_query["user__email"] = user_email
         else:
-            target_pins_queryset = target_pins_queryset.filter(user=request.user)
+            pins_query["user"] = request.user
 
-        annotation_pins_queryset = RoomPin.objects.filter(
-            room__queue__sector__project=project,
-        )
-        if user_email:
-            annotation_pins_queryset = annotation_pins_queryset.filter(
-                user__email=user_email
-            )
-        else:
-            annotation_pins_queryset = annotation_pins_queryset.filter(
-                user=request.user
-            )
-
-        pin_subquery = annotation_pins_queryset.filter(room=OuterRef("pk")).order_by(
-            "-created_on"
-        )
-        target_pin_subquery = target_pins_queryset.filter(room=OuterRef("pk")).order_by(
-            "-created_on"
+        # Ordered most-recent-first so the list index doubles as the pin rank.
+        pinned_ids = list(
+            RoomPin.objects.filter(**pins_query)
+            .order_by("-created_on")
+            .values_list("room_id", flat=True)
         )
 
-        annotated_qs = qs.annotate(
-            is_pinned=Exists(pin_subquery),
-            pin_created_on=Subquery(
-                pin_subquery.values("created_on")[:1],
-                output_field=DateTimeField(),
-            ),
-            list_is_pinned=Exists(target_pin_subquery),
-            list_pin_created_on=Subquery(
-                target_pin_subquery.values("created_on")[:1],
-                output_field=DateTimeField(),
-            ),
-        )
-
-        filtered_qs = self.filter_queryset(annotated_qs)
-        filtered_room_ids = filtered_qs.values("pk").order_by()
-
+        filtered_qs = self.filter_queryset(qs)
         secondary_sort = list(filtered_qs.query.order_by or self.ordering or [])
 
-        pinned_room_subquery = target_pins_queryset.values("room_id")
+        if not pinned_ids:
+            return self._get_paginated_response(filtered_qs)
 
-        combined_qs = annotated_qs.filter(
-            Q(pk__in=Subquery(filtered_room_ids))
-            | Q(pk__in=Subquery(pinned_room_subquery))
-        ).distinct()
+        # Pinned rooms must always appear at the top, even if other active
+        # filters (queue, sector, search) would otherwise exclude them. The
+        # filtered set is referenced as a subquery (never pulled into Python)
+        # and the pinned ids are a literal list of at most 3 elements.
+        combined_qs = qs.filter(
+            Q(pk__in=Subquery(filtered_qs.values("pk"))) | Q(pk__in=pinned_ids)
+        )
 
-        if secondary_sort:
-            combined_qs = combined_qs.order_by(
-                "-is_pinned", "-pin_created_on", *secondary_sort
-            )
-        else:
-            combined_qs = combined_qs.order_by("-is_pinned", "-pin_created_on")
+        pin_rank_whens = [
+            When(pk=room_id, then=Value(index))
+            for index, room_id in enumerate(pinned_ids)
+        ]
+
+        combined_qs = combined_qs.annotate(
+            is_pinned=Case(
+                When(pk__in=pinned_ids, then=Value(True)),
+                default=Value(False),
+                output_field=BooleanField(),
+            ),
+            pin_rank=Case(
+                *pin_rank_whens,
+                default=Value(len(pinned_ids)),
+                output_field=IntegerField(),
+            ),
+        ).order_by("pin_rank", *secondary_sort)
 
         return self._get_paginated_response(combined_qs)
 

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -529,6 +529,147 @@ class TestRoomsViewSet(APITestCase):
         self.assertEqual(results[2]["uuid"], str(rooms[0].uuid))
         self.assertEqual(results[2].get("is_pinned"), False)
 
+    @patch("chats.apps.api.v1.rooms.viewsets.is_feature_active", return_value=True)
+    def test_room_order_with_pin_optimized(self, mock_is_feature_active):
+        room_1 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
+        room_2 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
+        room_3 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
+        room_4 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
+
+        RoomPin.objects.create(room=room_3, user=self.user)
+        RoomPin.objects.create(room=room_2, user=self.user)
+
+        queue = Queue.objects.create(
+            name="Test Queue",
+            sector=Sector.objects.create(
+                name="Test Sector",
+                project=Project.objects.create(name="Test Project"),
+                rooms_limit=10,
+                work_start="09:00",
+                work_end="18:00",
+            ),
+        )
+        QueueAuthorization.objects.create(
+            permission=ProjectPermission.objects.create(
+                user=self.user,
+                project=queue.sector.project,
+                role=ProjectPermission.ROLE_ATTENDANT,
+            ),
+            queue=queue,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        # Room from a different project, should be excluded even when pinned
+        room_5 = Room.objects.create(queue=queue, contact=Contact.objects.create())
+        RoomPin.objects.create(room=room_5, user=self.user)
+
+        response = self.list_rooms(
+            filters={
+                "project": str(self.project.uuid),
+                "is_active": True,
+                "ordering": "-created_on",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertIn("max_pin_limit", response.data)
+        self.assertEqual(
+            response.data.get("max_pin_limit"), settings.MAX_ROOM_PINS_LIMIT
+        )
+
+        results = response.data.get("results")
+        rooms_uuids = [room["uuid"] for room in results]
+
+        self.assertNotIn(str(room_5.uuid), rooms_uuids)
+
+        self.assertEqual(rooms_uuids[0], str(room_2.uuid))
+        self.assertEqual(results[0].get("is_pinned"), True)
+
+        self.assertEqual(rooms_uuids[1], str(room_3.uuid))
+        self.assertEqual(results[1].get("is_pinned"), True)
+
+        self.assertEqual(rooms_uuids[2], str(room_4.uuid))
+        self.assertEqual(results[2].get("is_pinned"), False)
+
+        self.assertEqual(rooms_uuids[3], str(room_1.uuid))
+        self.assertEqual(results[3].get("is_pinned"), False)
+
+    @patch("chats.apps.api.v1.rooms.viewsets.is_feature_active", return_value=True)
+    def test_room_order_with_email_optimized(self, mock_is_feature_active):
+        another_user = User.objects.create(email="another_user@example.com")
+        QueueAuthorization.objects.create(
+            permission=ProjectPermission.objects.create(
+                user=another_user,
+                project=self.project,
+                role=ProjectPermission.ROLE_ADMIN,
+            ),
+            queue=self.queue,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        rooms = []
+
+        for _i in range(3):
+            room = Room.objects.create(
+                queue=self.queue, contact=Contact.objects.create(), user=another_user
+            )
+            rooms.append(room)
+
+        RoomPin.objects.create(room=rooms[1], user=another_user)
+
+        response = self.list_rooms(
+            filters={
+                "project": str(self.project.uuid),
+                "is_active": True,
+                "ordering": "-created_on",
+                "email": another_user.email,
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.data.get("results")
+
+        self.assertEqual(results[0]["uuid"], str(rooms[1].uuid))
+        self.assertEqual(results[0].get("is_pinned"), True)
+        self.assertEqual(results[1]["uuid"], str(rooms[2].uuid))
+        self.assertEqual(results[1].get("is_pinned"), False)
+        self.assertEqual(results[2]["uuid"], str(rooms[0].uuid))
+        self.assertEqual(results[2].get("is_pinned"), False)
+
+    @patch("chats.apps.api.v1.rooms.viewsets.is_feature_active", return_value=True)
+    def test_optimized_pins_stay_on_top_regardless_of_ordering(
+        self, mock_is_feature_active
+    ):
+        room_1 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
+        room_2 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
+        room_3 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
+
+        # Pin the most recently created room; ascending ordering would place it
+        # last, yet it must stay at the top because it is pinned.
+        RoomPin.objects.create(room=room_3, user=self.user)
+
+        response = self.list_rooms(
+            filters={
+                "project": str(self.project.uuid),
+                "is_active": True,
+                "ordering": "created_on",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        results = response.data.get("results")
+        rooms_uuids = [room["uuid"] for room in results]
+
+        self.assertEqual(rooms_uuids[0], str(room_3.uuid))
+        self.assertEqual(results[0].get("is_pinned"), True)
+        self.assertEqual(rooms_uuids[1], str(room_1.uuid))
+        self.assertEqual(results[1].get("is_pinned"), False)
+        self.assertEqual(rooms_uuids[2], str(room_2.uuid))
+        self.assertEqual(results[2].get("is_pinned"), False)
+
 
 class RoomPickTests(APITestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Do we need to implement analytics?

### **What**

Replaces the correlated subquery-based pin ordering logic in `_list_with_optimized_pin_order` with a lightweight approach that resolves pinned room IDs upfront using a single small query. The pinned IDs (capped at `MAX_ROOM_PINS_LIMIT`, i.e. 3) are then used as constant literals in a `Case/When` annotation (`pin_rank`) to drive ordering, and `is_pinned` is annotated directly on the queryset so the serializer can skip its per-room lookup entirely.

### **Why**

The previous implementation used correlated `Exists` subqueries and `Subquery` expressions that caused N+1 query patterns and unnecessary full primary-key materialization during room listing. Because the pin limit is bounded to 3 entries per user, resolving the pinned IDs eagerly is both safe and efficient. Annotating `is_pinned` on the queryset also eliminates the per-room database hit previously triggered inside `get_is_pinned` on the serializer during list operations.  
  


## Ongoing rooms listing — pin ordering optimization

### Request flow (after)

```mermaid
flowchart TD
    A["GET /rooms (is_active=true, ongoing)"] --> B{"Pin optimization<br/>flag active?"}
    B -->|no| C["_list_with_legacy_pin_order<br/>(fallback)"]
    B -->|yes| D["1 small query:<br/>pinned room ids (max 3, ordered by -created_on)"]
    D --> E{"Has pinned ids?"}
    E -->|no| F["Return filtered_qs as-is"]
    E -->|yes| G["Annotate with constants:<br/>is_pinned (Case/When)<br/>pin_rank (Case/When 0..n-1)"]
    G --> H["filtered_qs (Subquery) OR pk__in pinned_ids<br/>no Python PK materialization, no distinct"]
    H --> I["order_by(pin_rank, *secondary_sort)"]
    I --> J["Serializer reads is_pinned annotation<br/>(no per-row query)"]
    F --> J
    J --> K["Paginated response"]
```

### Before vs after (cost per request)

```mermaid
flowchart LR
    subgraph before [Before]
        B1["Legacy: set() of ALL ongoing PKs<br/>+ giant IN (...)"]
        B2["Optimized: 4 correlated subqueries/row<br/>+ OR of 2 pk__in subqueries + distinct<br/>+ order by per-row subquery"]
        B3["Serializer get_is_pinned:<br/>1 query per room (N+1, up to page_size)"]
    end
    subgraph after [After]
        A1["1 tiny query: <= 3 pinned ids"]
        A2["Constant Case/When literals<br/>no correlated subqueries, no distinct"]
        A3["Serializer reads annotation<br/>0 extra queries"]
    end
    before -->|"leverage 3-pin cap"| after
```