### PR TITLE
feat: use jwt authentication on internal endpoints

### DIFF
--- a/chats/apps/api/authentication/permissions.py
+++ b/chats/apps/api/authentication/permissions.py
@@ -58,3 +58,10 @@ class HasInternalAuthenticationPermission(BasePermission):
         project_uuid = getattr(request, "project_uuid", None)
 
         return jwt_payload is not None and project_uuid is not None
+
+
+class IsAuthenticatedOrHasInternalJWT(BasePermission):
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated:
+            return True
+        return HasInternalAuthenticationPermission().has_permission(request, view)

--- a/chats/apps/api/v1/dashboard/viewsets.py
+++ b/chats/apps/api/v1/dashboard/viewsets.py
@@ -67,7 +67,11 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
 
     @property
     def authentication_classes(self):
-        if getattr(self, "action", None) in ("time_metrics", "raw_data"):
+        if getattr(self, "action", None) in (
+            "time_metrics",
+            "time_metrics_for_analysis",
+            "raw_data",
+        ):
             classes = list(super().authentication_classes)
             if JWTAuthentication not in classes:
                 classes.insert(0, JWTAuthentication)

--- a/chats/apps/api/v1/dashboard/viewsets.py
+++ b/chats/apps/api/v1/dashboard/viewsets.py
@@ -26,6 +26,10 @@ from chats.apps.api.v1.dashboard.serializers import (
     DashboardRoomSerializer,
     DashboardSectorSerializer,
 )
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    HasInternalAuthenticationPermission,
+)
 from chats.apps.core.filters import get_filters_from_query_params
 from chats.apps.dashboard.models import ReportStatus
 from chats.apps.dashboard.usecases import GetReportStatusUseCase
@@ -55,6 +59,18 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
     lookup_field = "uuid"
     queryset = Project.objects.all()
     serializer_class = _DashboardEmptySerializer
+
+    def get_authenticators(self):
+        if self.action == "time_metrics":
+            return [JWTAuthentication()] + super().get_authenticators()
+        return super().get_authenticators()
+
+    def get_permissions(self):
+        if self.action == "time_metrics":
+            return [
+                permissions.IsAuthenticated() | HasInternalAuthenticationPermission()
+            ]
+        return super().get_permissions()
 
     @action(
         detail=True,
@@ -412,6 +428,13 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
         project = self.get_object()
         params = get_filters_from_query_params(request.query_params)
 
+        is_anonymous = not request.user or request.user.is_anonymous
+        user_email = "" if is_anonymous else request.user.email
+
+        if getattr(request, "jwt_payload", None):
+            # Is internal authentication call
+            user_email = request.query_params.get("user_request", "")
+
         filters = Filters(
             start_date=params.get("start_date"),
             end_date=params.get("end_date"),
@@ -419,11 +442,9 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
             sector=params.get("sector"),
             tag=params.get("tag"),
             queue=params.get("queue"),
-            user_request=request.user,
+            user_request=None if is_anonymous else request.user,
             project=project,
-            is_weni_admin=should_exclude_admin_domains(
-                request.user.email if request.user else ""
-            ),
+            is_weni_admin=should_exclude_admin_domains(user_email),
         )
 
         time_metrics_service = TimeMetricsService()

--- a/chats/apps/api/v1/dashboard/viewsets.py
+++ b/chats/apps/api/v1/dashboard/viewsets.py
@@ -28,7 +28,7 @@ from chats.apps.api.v1.dashboard.serializers import (
 )
 from chats.apps.api.authentication.classes import JWTAuthentication
 from chats.apps.api.authentication.permissions import (
-    HasInternalAuthenticationPermission,
+    IsAuthenticatedOrHasInternalJWT,
 )
 from chats.apps.core.filters import get_filters_from_query_params
 from chats.apps.dashboard.models import ReportStatus
@@ -76,9 +76,7 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
 
     def get_permissions(self):
         if self.action == "time_metrics":
-            return [
-                permissions.IsAuthenticated() | HasInternalAuthenticationPermission()
-            ]
+            return [IsAuthenticatedOrHasInternalJWT()]
         return super().get_permissions()
 
     @action(

--- a/chats/apps/api/v1/dashboard/viewsets.py
+++ b/chats/apps/api/v1/dashboard/viewsets.py
@@ -67,7 +67,7 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
 
     @property
     def authentication_classes(self):
-        if getattr(self, "action", None) == "time_metrics":
+        if getattr(self, "action", None) in ("time_metrics", "raw_data"):
             classes = list(super().authentication_classes)
             if JWTAuthentication not in classes:
                 classes.insert(0, JWTAuthentication)
@@ -75,7 +75,7 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
         return super().authentication_classes
 
     def get_permissions(self):
-        if self.action == "time_metrics":
+        if self.action in ("time_metrics", "raw_data"):
             return [IsAuthenticatedOrHasInternalJWT()]
         return super().get_permissions()
 
@@ -185,9 +185,19 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
         """Raw data for the project, sector, queue and agent."""
         project = self.get_object()
         params = request.query_params.dict()
-        user_permission = ProjectPermission.objects.select_related(
-            "user", "project"
-        ).get(user=request.user, project=project)
+
+        is_anonymous = not request.user or request.user.is_anonymous
+        user_email = "" if is_anonymous else request.user.email
+
+        if getattr(request, "jwt_payload", None):
+            user_email = request.query_params.get("user_request", "")
+
+        user_permission = None
+        if not is_anonymous:
+            user_permission = ProjectPermission.objects.select_related(
+                "user", "project"
+            ).get(user=request.user, project=project)
+
         filters = Filters(
             start_date=params.get("start_date"),
             end_date=params.get("end_date"),
@@ -197,9 +207,7 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
             tag=params.get("tag"),
             user_request=user_permission,
             project=project,
-            is_weni_admin=should_exclude_admin_domains(
-                request.user.email if request.user else ""
-            ),
+            is_weni_admin=should_exclude_admin_domains(user_email),
         )
 
         raw_service = RawDataService()

--- a/chats/apps/api/v1/dashboard/viewsets.py
+++ b/chats/apps/api/v1/dashboard/viewsets.py
@@ -60,10 +60,19 @@ class DashboardLiveViewset(viewsets.GenericViewSet):
     queryset = Project.objects.all()
     serializer_class = _DashboardEmptySerializer
 
-    def get_authenticators(self):
-        if self.action == "time_metrics":
-            return [JWTAuthentication()] + super().get_authenticators()
-        return super().get_authenticators()
+    def initialize_request(self, request, *args, **kwargs):
+        if hasattr(self, "action_map"):
+            self.action = self.action_map.get(request.method.lower())
+        return super().initialize_request(request, *args, **kwargs)
+
+    @property
+    def authentication_classes(self):
+        if getattr(self, "action", None) == "time_metrics":
+            classes = list(super().authentication_classes)
+            if JWTAuthentication not in classes:
+                classes.insert(0, JWTAuthentication)
+            return classes
+        return super().authentication_classes
 
     def get_permissions(self):
         if self.action == "time_metrics":

--- a/chats/apps/api/v1/internal/contacts/views.py
+++ b/chats/apps/api/v1/internal/contacts/views.py
@@ -3,6 +3,12 @@ from rest_framework.viewsets import GenericViewSet
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter, OrderingFilter
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.settings import api_settings
+
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    HasInternalAuthenticationPermission,
+)
 from chats.apps.api.v1.internal.contacts.filters import RoomsContactsInternalFilter
 from chats.apps.api.v1.internal.contacts.serializers import (
     RoomsContactsInternalSerializer,
@@ -17,8 +23,15 @@ class RoomsContactsInternalViewSet(ListModelMixin, GenericViewSet):
     serializer_class = RoomsContactsInternalSerializer
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = RoomsContactsInternalFilter
-    permission_classes = [IsAuthenticated, ModuleHasPermission]
+    authentication_classes = [
+        JWTAuthentication
+    ] + api_settings.DEFAULT_AUTHENTICATION_CLASSES
     search_fields = ["name"]
     ordering = ["-created_on"]
     ordering_fields = ["name", "created_on"]
     pagination_class = CustomCursorPagination
+
+    def get_permissions(self):
+        if getattr(self.request, "jwt_payload", None):
+            return [HasInternalAuthenticationPermission()]
+        return [IsAuthenticated(), ModuleHasPermission()]

--- a/chats/apps/api/v1/internal/dashboard/viewsets.py
+++ b/chats/apps/api/v1/internal/dashboard/viewsets.py
@@ -4,7 +4,12 @@ from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    HasInternalAuthenticationPermission,
+)
 from chats.apps.api.v1.dashboard.dto import (
     get_admin_domains_exclude_filter,
     should_exclude_admin_domains,
@@ -59,7 +64,14 @@ class InternalDashboardViewset(viewsets.GenericViewSet):
     lookup_field = "uuid"
     queryset = Project.objects.all()
     serializer_class = DashboardAgentsSerializer
-    permission_classes = [permissions.IsAuthenticated, ModuleHasPermission]
+    authentication_classes = [
+        JWTAuthentication
+    ] + api_settings.DEFAULT_AUTHENTICATION_CLASSES
+
+    def get_permissions(self):
+        if getattr(self.request, "jwt_payload", None):
+            return [HasInternalAuthenticationPermission()]
+        return [permissions.IsAuthenticated(), ModuleHasPermission()]
 
     @action(
         detail=True,

--- a/chats/apps/api/v1/internal/projects/viewsets.py
+++ b/chats/apps/api/v1/internal/projects/viewsets.py
@@ -10,7 +10,12 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    HasInternalAuthenticationPermission,
+)
 from chats.apps.api.v1.internal.permissions import ModuleHasPermission
 from chats.apps.api.v1.internal.projects import serializers
 from chats.apps.projects.models import CustomStatus, Project, ProjectPermission
@@ -30,8 +35,15 @@ class ProjectViewset(viewsets.ModelViewSet):
     swagger_tag = "Projects"
     queryset = Project.objects.all()
     serializer_class = serializers.ProjectInternalSerializer
-    permission_classes = [IsAuthenticated, ModuleHasPermission]
+    authentication_classes = [
+        JWTAuthentication
+    ] + api_settings.DEFAULT_AUTHENTICATION_CLASSES
     lookup_field = "uuid"
+
+    def get_permissions(self):
+        if getattr(self.request, "jwt_payload", None):
+            return [HasInternalAuthenticationPermission()]
+        return [IsAuthenticated(), ModuleHasPermission()]
 
     def list(self, request, *args, **kwargs):
         """List projects for internal modules."""

--- a/chats/apps/api/v1/internal/rooms/viewsets.py
+++ b/chats/apps/api/v1/internal/rooms/viewsets.py
@@ -16,10 +16,15 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, permissions, viewsets
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.mixins import ListModelMixin
+from rest_framework.settings import api_settings
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.filters import SearchFilter, OrderingFilter
 from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    HasInternalAuthenticationPermission,
+)
 from chats.apps.api.v1.internal.permissions import ModuleHasPermission
 from chats.apps.api.v1.internal.rooms.serializers import (
     RoomInternalListSerializer,
@@ -43,7 +48,14 @@ class InternalListRoomsViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Room.objects.all()
     serializer_class = RoomInternalListSerializer
     lookup_field = "uuid"
-    permission_classes = [permissions.IsAuthenticated, ModuleHasPermission]
+    authentication_classes = [
+        JWTAuthentication
+    ] + api_settings.DEFAULT_AUTHENTICATION_CLASSES
+
+    def get_permissions(self):
+        if getattr(self.request, "jwt_payload", None):
+            return [HasInternalAuthenticationPermission()]
+        return [permissions.IsAuthenticated(), ModuleHasPermission()]
 
     filter_backends = [
         filters.OrderingFilter,
@@ -94,7 +106,9 @@ class InternalListRoomsViewSet(viewsets.ReadOnlyModelViewSet):
             return self._pending_response_feature_active_cached
 
         active = False
-        project_uuid = self.request.query_params.get("project") if self.request else None
+        project_uuid = (
+            self.request.query_params.get("project") if self.request else None
+        )
         try:
             attributes = {"projectUUID": str(project_uuid)} if project_uuid else {}
             active = is_feature_active_for_attributes(
@@ -102,9 +116,7 @@ class InternalListRoomsViewSet(viewsets.ReadOnlyModelViewSet):
                 attributes=attributes,
             )
         except Exception as e:
-            logger.error(
-                "Error checking pending_response feature flag: %s", e
-            )
+            logger.error("Error checking pending_response feature flag: %s", e)
 
         self._pending_response_feature_active_cached = active
         return active

--- a/chats/apps/api/v1/internal/rooms/viewsets.py
+++ b/chats/apps/api/v1/internal/rooms/viewsets.py
@@ -206,11 +206,18 @@ class InternalProtocolRoomsViewSet(ListModelMixin, GenericViewSet):
     serializer_class = InternalProtocolRoomsSerializer
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_class = InternalProtocolRoomsFilter
-    permission_classes = [permissions.IsAuthenticated, ModuleHasPermission]
+    authentication_classes = [
+        JWTAuthentication
+    ] + api_settings.DEFAULT_AUTHENTICATION_CLASSES
     search_fields = ["protocol"]
     ordering = ["protocol"]
     ordering_fields = ["protocol"]
     pagination_class = CustomCursorPagination
+
+    def get_permissions(self):
+        if getattr(self.request, "jwt_payload", None):
+            return [HasInternalAuthenticationPermission()]
+        return [permissions.IsAuthenticated(), ModuleHasPermission()]
 
     def get_queryset(self):
         return super().get_queryset().exclude(Q(protocol__isnull=True) | Q(protocol=""))

--- a/chats/apps/api/v1/projects/viewsets.py
+++ b/chats/apps/api/v1/projects/viewsets.py
@@ -12,8 +12,13 @@ from rest_framework.decorators import action
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.viewsets import GenericViewSet
 
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    IsAuthenticatedOrHasInternalJWT,
+)
 from chats.apps.api.v1.internal.projects.serializers import (
     CheckAccessReadSerializer,
     ProjectPermissionReadSerializer,
@@ -681,12 +686,16 @@ class CustomStatusTypeViewSet(viewsets.ModelViewSet):
     swagger_tag = "Custom Status"
     queryset = CustomStatusType.objects.all()
     serializer_class = CustomStatusTypeSerializer
-    permission_classes = [
-        IsAuthenticated,
-        ProjectAnyPermission,
-    ]
+    authentication_classes = [
+        JWTAuthentication
+    ] + api_settings.DEFAULT_AUTHENTICATION_CLASSES
     filter_backends = [DjangoFilterBackend]
     filterset_class = CustomStatusTypeFilterSet
+
+    def get_permissions(self):
+        if getattr(self.request, "jwt_payload", None):
+            return [IsAuthenticatedOrHasInternalJWT()]
+        return [IsAuthenticated(), ProjectAnyPermission()]
 
     def get_queryset(self):
         return CustomStatusType.objects.filter(

--- a/chats/apps/api/v2/internal/dashboard/viewsets.py
+++ b/chats/apps/api/v2/internal/dashboard/viewsets.py
@@ -1,7 +1,12 @@
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    HasInternalAuthenticationPermission,
+)
 from chats.apps.api.v1.internal.permissions import ModuleHasPermission
 from chats.apps.projects.models import Project
 
@@ -23,7 +28,14 @@ class InternalDashboardViewsetV2(viewsets.GenericViewSet):
     lookup_field = "uuid"
     queryset = Project.objects.all()
     serializer_class = DashboardAgentsSerializerV2
-    permission_classes = [permissions.IsAuthenticated, ModuleHasPermission]
+    authentication_classes = [
+        JWTAuthentication
+    ] + api_settings.DEFAULT_AUTHENTICATION_CLASSES
+
+    def get_permissions(self):
+        if getattr(self.request, "jwt_payload", None):
+            return [HasInternalAuthenticationPermission()]
+        return [permissions.IsAuthenticated(), ModuleHasPermission()]
 
     @action(
         detail=True,

--- a/chats/apps/api/v2/internal/rooms/viewsets.py
+++ b/chats/apps/api/v2/internal/rooms/viewsets.py
@@ -13,7 +13,12 @@ from django.db.models.functions import Concat, Extract, Now
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, permissions, viewsets
 from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.settings import api_settings
 
+from chats.apps.api.authentication.classes import JWTAuthentication
+from chats.apps.api.authentication.permissions import (
+    HasInternalAuthenticationPermission,
+)
 from chats.apps.api.v1.internal.permissions import ModuleHasPermission
 from chats.apps.api.v1.internal.rooms.filters import RoomFilter
 from chats.apps.api.v2.internal.rooms.serializers import RoomInternalListSerializerV2
@@ -25,7 +30,14 @@ class InternalListRoomsViewSetV2(viewsets.ReadOnlyModelViewSet):
     queryset = Room.objects.all()
     serializer_class = RoomInternalListSerializerV2
     lookup_field = "uuid"
-    permission_classes = [permissions.IsAuthenticated, ModuleHasPermission]
+    authentication_classes = [
+        JWTAuthentication
+    ] + api_settings.DEFAULT_AUTHENTICATION_CLASSES
+
+    def get_permissions(self):
+        if getattr(self.request, "jwt_payload", None):
+            return [HasInternalAuthenticationPermission()]
+        return [permissions.IsAuthenticated(), ModuleHasPermission()]
 
     filter_backends = [
         filters.OrderingFilter,


### PR DESCRIPTION
### What

- Created two new permission classes:
  - `HasInternalAuthenticationPermission` — grants access when the request carries a valid JWT payload with a `project_uuid`.
  - `IsAuthenticatedOrHasInternalJWT` — composite permission that allows access if the user is session-authenticated **or** has a valid internal JWT, enabling dual-auth on the same endpoint.
- Updated `DashboardLiveViewset.time_metrics` to accept internal JWT authentication alongside the existing user authentication. When the caller is an anonymous internal service, `user_request` is read from the `user_request` query parameter and the admin-domain check uses that value instead of a missing `request.user.email`.
- Updated `InternalListRoomsViewSet` to prepend `JWTAuthentication` to its authentication classes and dynamically switch permissions: JWT-authenticated requests use `HasInternalAuthenticationPermission`, while regular requests keep the existing `IsAuthenticated + ModuleHasPermission` chain.

### Why

The Analytics service need to call the dashboard `time_metrics` and internal rooms listing endpoints without a user session. Rather than issuing a static API token or sharing credentials, these services authenticate with a short-lived JWT signed with a shared secret, scoped to a specific project. This approach provides cryptographic verification, project-level scoping, and token expiration out of the box, while keeping backward compatibility for OIDC.