### PR TITLE
fix: exclude currently active custom statuses from historical date fi…

### DIFF
--- a/chats/apps/api/v1/internal/dashboard/repository.py
+++ b/chats/apps/api/v1/internal/dashboard/repository.py
@@ -157,19 +157,17 @@ class AgentRepository:
         #     output_field=FloatField(),
         # )
 
+        date_filter = Q(
+            created_on__range=[custom_status_start_date, custom_status_end_date]
+        )
+        if not filters.start_date and not filters.end_date:
+            date_filter |= Q(is_active=True)
+
         custom_status_subquery = Subquery(
             CustomStatus.objects.filter(
                 Q(user=OuterRef("email"))
                 & Q(status_type__project=project)
-                & (
-                    Q(
-                        created_on__range=[
-                            custom_status_start_date,
-                            custom_status_end_date,
-                        ]
-                    )
-                    | Q(is_active=True)
-                )
+                & date_filter
             )
             .values("user")
             .annotate(


### PR DESCRIPTION
### **What**
in get_agents_data(), the custom_status_subquery used an OR condition — Q(created_on__range=[...]) | Q(is_active=True) — to fetch agent status records. The Q(is_active=True) clause had no date boundary, causing today's active "In-Service" status to be included even when querying a past date range.

### **Why**
When a date filter is provided, only historical records within that range should be considered. The Q(is_active=True) clause is only needed in real-time mode (no date filter) to capture overnight sessions that started before midnight. Made the clause conditional: it is added only when both start_date and end_date are absent, preserving the real-time behavior while fixing the historical query leak.