### PR TITLE
Fix: inactivity last message problem

### DIFF
--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -810,22 +810,29 @@ class Room(BaseModel, BaseConfigurableModel):
             unread_messages_count=0, last_unread_message_at=timezone.now()
         )
 
-    def update_last_message(self, message, user=None):
+    def update_last_message(self, message, user=None, update_last_interaction=True):
         """
         Updates last message fields. Used for agent/system messages.
+
+        When ``update_last_interaction`` is False the interaction timestamp
+        is preserved — useful for automatic messages (e.g. inactivity
+        warnings) that must not reset timers.
         """
         media_data = [
             {"content_type": media.content_type, "url": media.url}
             for media in message.medias.all()
         ]
-        Room.objects.filter(pk=self.pk).update(
-            last_interaction=message.created_on,
-            last_message=message,
-            last_message_text=message.text,
-            last_message_user=user,
-            last_message_contact=None,
-            last_message_media=media_data,
-        )
+        fields = {
+            "last_message": message,
+            "last_message_text": message.text,
+            "last_message_user": user,
+            "last_message_contact": None,
+            "last_message_media": media_data,
+        }
+        if update_last_interaction:
+            fields["last_interaction"] = message.created_on
+
+        Room.objects.filter(pk=self.pk).update(**fields)
 
     def on_new_message(self, message, contact=None, increment_unread: int = 0):
         """

--- a/chats/apps/rooms/tests/test_inactivity_usecase.py
+++ b/chats/apps/rooms/tests/test_inactivity_usecase.py
@@ -99,6 +99,24 @@ class InactivityWarnTests(TestCase):
         )
         self.assertTrue(warning_msg.is_automatic_message)
 
+    def test_warn_updates_last_message_but_not_last_interaction(self):
+        room = self._create_eligible_room()
+        original_last_interaction = room.last_interaction
+
+        with patch.object(Room, "notify_inactivity"):
+            InactivityService().warn_inactive_rooms()
+
+        room.refresh_from_db()
+        warning_msg = Message.objects.get(
+            room=room, text="Are you still there?", user=self.user
+        )
+        self.assertEqual(room.last_message, warning_msg)
+        self.assertEqual(room.last_message_text, "Are you still there?")
+        self.assertEqual(
+            int(room.last_interaction.timestamp()),
+            int(original_last_interaction.timestamp()),
+        )
+
     def test_room_within_timeout_is_not_warned(self):
         room = self._create_eligible_room(last_interaction_offset_seconds=60)
 
@@ -238,6 +256,24 @@ class InactivityCloseTests(TestCase):
         self.assertTrue(feedback_msg.seen)
         self.assertIsNone(feedback_msg.automatic_message_type)
         self.assertFalse(feedback_msg.is_automatic_message)
+
+    def test_close_updates_last_message_to_closure_text(self):
+        room = self._create_already_warned_room(last_interaction_offset_seconds=700)
+        original_last_interaction = room.last_interaction
+
+        with patch.object(Room, "notify_user"), patch.object(Message, "notify_room"):
+            InactivityService().close_inactive_rooms()
+
+        room.refresh_from_db()
+        closure_msg = Message.objects.get(
+            room=room, text="Closing due to inactivity.", user=self.user
+        )
+        self.assertEqual(room.last_message, closure_msg)
+        self.assertEqual(room.last_message_text, "Closing due to inactivity.")
+        self.assertEqual(
+            int(room.last_interaction.timestamp()),
+            int(original_last_interaction.timestamp()),
+        )
 
     def test_history_serializer_payload_after_automatic_close(self):
         """
@@ -471,7 +507,10 @@ class SilentAutomaticMessageTests(TestCase):
             int(room.last_interaction.timestamp()),
             int(original_last_interaction.timestamp()),
         )
+        self.assertEqual(room.last_message, message)
+        self.assertEqual(room.last_message_text, "warn me")
         self.assertEqual(room.last_message_user, self.user)
+        self.assertIsNone(room.last_message_contact)
 
     def test_returns_none_when_text_is_empty(self):
         room = Room.objects.create(queue=self.queue, contact=self.contact)

--- a/chats/apps/rooms/tests/test_models.py
+++ b/chats/apps/rooms/tests/test_models.py
@@ -607,6 +607,26 @@ class TestUpdateLastMessage(APITestCase):
         self.assertEqual(self.room.last_message_text, "Second message")
         self.assertEqual(self.room.last_interaction, message_2.created_on)
 
+    def test_update_last_message_without_updating_last_interaction(self):
+        message_1 = Message.objects.create(
+            room=self.room, text="Agent message", user=self.user
+        )
+        self.room.update_last_message(message=message_1, user=self.user)
+        self.room.refresh_from_db()
+        original_last_interaction = self.room.last_interaction
+
+        message_2 = Message.objects.create(
+            room=self.room, text="Automatic warning", user=self.user
+        )
+        self.room.update_last_message(
+            message=message_2, user=self.user, update_last_interaction=False
+        )
+        self.room.refresh_from_db()
+
+        self.assertEqual(self.room.last_message, message_2)
+        self.assertEqual(self.room.last_message_text, "Automatic warning")
+        self.assertEqual(self.room.last_interaction, original_last_interaction)
+
 
 class TestOnNewMessage(APITestCase):
     def setUp(self):

--- a/chats/apps/rooms/tests/test_models.py
+++ b/chats/apps/rooms/tests/test_models.py
@@ -627,6 +627,26 @@ class TestUpdateLastMessage(APITestCase):
         self.assertEqual(self.room.last_message_text, "Automatic warning")
         self.assertEqual(self.room.last_interaction, original_last_interaction)
 
+    def test_update_last_message_persists_after_refresh_and_close(self):
+        message_1 = Message.objects.create(
+            room=self.room, text="Agent message", user=self.user
+        )
+        self.room.update_last_message(message=message_1, user=self.user)
+
+        message_2 = Message.objects.create(
+            room=self.room, text="Automatic warning", user=self.user
+        )
+        self.room.update_last_message(
+            message=message_2, user=self.user, update_last_interaction=False
+        )
+
+        self.room.refresh_from_db()
+        self.room.close(end_by="inactivity", closed_by=self.user)
+        self.room.refresh_from_db()
+
+        self.assertEqual(self.room.last_message, message_2)
+        self.assertEqual(self.room.last_message_text, "Automatic warning")
+
 
 class TestOnNewMessage(APITestCase):
     def setUp(self):

--- a/chats/apps/rooms/usecases/inactivity.py
+++ b/chats/apps/rooms/usecases/inactivity.py
@@ -344,9 +344,12 @@ class InactivityService:
             )
             capture_exception(exc)
 
-        # Mark `automatic_closed=True` BEFORE `room.close()` so the flag is
-        # persisted in the same `save()` call and visible to any post-close
-        # signal/consumer.
+        # Refresh from DB so the in-memory instance picks up
+        # `last_message*` fields written by `update_last_message` via
+        # queryset `.update()`. Without this, `room.close()` → `save()`
+        # would overwrite those columns with stale in-memory values.
+        room.refresh_from_db()
+
         room.automatic_closed = True
 
         try:

--- a/chats/apps/rooms/usecases/inactivity.py
+++ b/chats/apps/rooms/usecases/inactivity.py
@@ -76,12 +76,11 @@ def _send_silent_automatic_message(
     message_type: Optional[str] = None,
 ) -> Optional[Message]:
     """
-    Creates an automatic message on the room WITHOUT updating
-    `last_interaction` / `last_message_*` fields.
-
-    The inactivity feature requires that the warning and closure messages do
-    not reset the inactivity counter, so they can't go through the regular
-    `room.update_last_message` flow.
+    Creates an automatic message on the room and updates the
+    `last_message*` fields so REST and WebSocket payloads reflect the
+    actual latest message. `last_interaction` is intentionally left
+    unchanged — it anchors the inactivity timer to the last real
+    conversation turn.
 
     `message_type` classifies the automatic message (e.g. `inactive_warning`
     or `inactive_close`) so the front can render a specific UI for each.
@@ -103,6 +102,20 @@ def _send_silent_automatic_message(
                     room=room,
                     automatic_message_type=message_type,
                 )
+
+            Room.objects.filter(pk=room.pk).update(
+                last_message=message,
+                last_message_text=text,
+                last_message_user=user,
+                last_message_contact=None,
+                last_message_media=[],
+            )
+            room.last_message = message
+            room.last_message_text = text
+            room.last_message_user = user
+            room.last_message_contact = None
+            room.last_message_media = []
+
             transaction.on_commit(lambda: message.notify_room("create", True))
             return message
     except Exception as exc:
@@ -137,7 +150,6 @@ def _eligible_warn_queryset():
         is_waiting=False,
         user__isnull=False,
         last_message_user__isnull=False,
-        last_message__automatic_message__isnull=True,
         queue__sector__inactivity_timeout__is_message_timeout_enabled=True,
     ).select_related("queue__sector", "user")
 
@@ -156,7 +168,6 @@ def _eligible_close_queryset():
         is_waiting=False,
         user__isnull=False,
         last_message_user__isnull=False,
-        last_message__automatic_message__isnull=True,
         queue__sector__inactivity_timeout__is_close_room_enabled=True,
     ).select_related("queue__sector", "user")
 

--- a/chats/apps/rooms/usecases/inactivity.py
+++ b/chats/apps/rooms/usecases/inactivity.py
@@ -77,10 +77,11 @@ def _send_silent_automatic_message(
 ) -> Optional[Message]:
     """
     Creates an automatic message on the room and updates the
-    `last_message*` fields so REST and WebSocket payloads reflect the
-    actual latest message. `last_interaction` is intentionally left
-    unchanged — it anchors the inactivity timer to the last real
-    conversation turn.
+    `last_message*` fields (via the standard ``update_last_message``)
+    so REST and WebSocket payloads reflect the actual latest message.
+
+    `last_interaction` is intentionally left unchanged — it anchors the
+    inactivity timer to the last real conversation turn.
 
     `message_type` classifies the automatic message (e.g. `inactive_warning`
     or `inactive_close`) so the front can render a specific UI for each.
@@ -103,18 +104,11 @@ def _send_silent_automatic_message(
                     automatic_message_type=message_type,
                 )
 
-            Room.objects.filter(pk=room.pk).update(
-                last_message=message,
-                last_message_text=text,
-                last_message_user=user,
-                last_message_contact=None,
-                last_message_media=[],
+            room.update_last_message(
+                message=message,
+                user=user,
+                update_last_interaction=False,
             )
-            room.last_message = message
-            room.last_message_text = text
-            room.last_message_user = user
-            room.last_message_contact = None
-            room.last_message_media = []
 
             transaction.on_commit(lambda: message.notify_room("create", True))
             return message


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Do we need to implement analytics?


### **What**
Fix the `last_message` field on rooms not reflecting inactivity automatic messages (warning and closure). Both the REST endpoint and WebSocket events were returning stale `last_message` data — still pointing to the agent's last real message instead of the warning/closure message sent by the inactivity feature.

### **Why**
The `_send_silent_automatic_message` helper was intentionally skipping the update of all `last_message*` fields to preserve the inactivity timer. However, `last_interaction` (used by the timer) and `last_message*` (used for display) serve different purposes. By not updating `last_message*`, the frontend received outdated data via both the REST API (`GET /rooms/`) and WebSocket events (`rooms.close`), causing the room list and chat view to show the wrong last message when the most recent message was an inactivity warning or closure.

The fix updates `last_message`, `last_message_text`, `last_message_user`, `last_message_contact`, and `last_message_media` while leaving `last_interaction` unchanged, so the timer keeps working correctly. The `last_message__automatic_message__isnull=True` filter was also removed from the eligibility querysets since `is_inactive` already prevents duplicate processing and the old filter would now incorrectly exclude valid rooms.
