### PR TITLE
refactor: optimize media handling in archived chat messages

### DIFF
--- a/chats/apps/archive_chats/services.py
+++ b/chats/apps/archive_chats/services.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from datetime import timedelta
 import json
 import logging
@@ -368,6 +369,10 @@ class ArchiveChatsService(BaseArchiveChatsService):
         return self._iter_messages(room)
 
     def _iter_messages(self, room: Room) -> Iterable[dict]:
+        medias_by_message = defaultdict(list)
+        for media in MessageMedia.objects.filter(message__room=room):
+            medias_by_message[media.message_id].append(media)
+
         messages = (
             Message.objects.filter(room=room)
             .select_related("automatic_message")
@@ -376,17 +381,14 @@ class ArchiveChatsService(BaseArchiveChatsService):
 
         for message in messages.iterator():
             message_context = {"media": []}
-            if message.medias.exists():
-                for media in message.medias.all():  # noqa
-                    url = self.process_media(media)
-                    media_data = {
+            for media in medias_by_message.get(message.pk, []):
+                url = self.process_media(media)
+                if url:
+                    message_context["media"].append({
                         "url": url,
                         "content_type": media.content_type,
                         "created_on": media.created_on.isoformat(),
-                    }
-
-                    if url:
-                        message_context["media"].append(media_data)
+                    })
 
             yield ArchiveMessageSerializer(message, context=message_context).data
 


### PR DESCRIPTION
### **What**

Pre-fetches all `MessageMedia` records for a room into a `defaultdict` before iterating over messages, replacing the per-message `medias.exists()` and `medias.all()` queries. The media data is only appended to the message context when a valid URL is returned.

### **Why**

The previous implementation triggered two additional database queries (`exists()` and `all()`) for every message in the room, leading to an N+1 query problem. By loading all media records for the room upfront and grouping them by message ID, the number of database queries is reduced significantly, improving performance when archiving rooms with large numbers of messages.