### PR TITLE
fix: handle missing replied messages in MessageSerializerV2

### DIFF
--- a/chats/apps/api/v2/msgs/serializers.py
+++ b/chats/apps/api/v2/msgs/serializers.py
@@ -127,7 +127,12 @@ class MessageSerializerV2(serializers.ModelSerializer):
 
         try:
             replied_id = context.get("id")
-            replied_msg = ChatMessageReplyIndex.objects.get(external_id=replied_id)
+            replied_msg = ChatMessageReplyIndex.objects.filter(
+                external_id=replied_id
+            ).first()
+
+            if not replied_msg:
+                return None
 
             result = {
                 "uuid": str(replied_msg.message.uuid),


### PR DESCRIPTION
### **What**

Replaces the `get()` query with `filter().first()` in `get_replied_message` and adds a `None` return when no matching `ChatMessageReplyIndex` is found for the given `external_id`.

### **Why**

The previous implementation using `get()` would raise a `DoesNotExist` exception if no matching record was found, causing unhandled errors. Using `filter().first()` allows the method to gracefully handle cases where the replied message does not exist by returning `None` instead of throwing an exception.