### PR TITLE
feat: optimize inactivity feature

### DIFF
--- a/chats/apps/rooms/migrations/0034_rooms_inactivity_warn_idx.py
+++ b/chats/apps/rooms/migrations/0034_rooms_inactivity_warn_idx.py
@@ -1,0 +1,27 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("rooms", "0033_room_automatic_closed"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="room",
+            index=models.Index(
+                fields=["last_interaction"],
+                name="rooms_inactivity_warn_idx",
+                condition=models.Q(
+                    is_active=True,
+                    is_inactive=False,
+                    is_waiting=False,
+                    user__isnull=False,
+                    last_message_user__isnull=False,
+                ),
+            ),
+        ),
+    ]

--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -293,6 +293,22 @@ class Room(BaseModel, BaseConfigurableModel):
                 fields=["is_active", "is_inactive", "is_waiting", "last_interaction"],
                 name="rooms_inactivity_idx",
             ),
+            # Partial index used by `InactivityService.warn_inactive_rooms`.
+            # Pre-filters rows that match every `rooms_room`-local predicate
+            # of the warn queryset so the planner picks this index directly
+            # instead of doing a BitmapAnd with `rooms_room_last_message_user_id_*`,
+            # which scans hundreds of thousands of historical rows.
+            models.Index(
+                fields=["last_interaction"],
+                name="rooms_inactivity_warn_idx",
+                condition=models.Q(
+                    is_active=True,
+                    is_inactive=False,
+                    is_waiting=False,
+                    user__isnull=False,
+                    last_message_user__isnull=False,
+                ),
+            ),
         ]
 
     def save(self, *args, **kwargs) -> None:

--- a/chats/apps/rooms/tasks.py
+++ b/chats/apps/rooms/tasks.py
@@ -95,24 +95,63 @@ def check_inactivity_rooms():
     Runs `warn_inactive_rooms` and `close_inactive_rooms` every tick. Each
     step is wrapped in its own try/except so that a failure in the warning
     pass does not prevent the closure pass from executing on this tick.
+
+    Guarded by a Redis lock so two beats can never process the same eligible
+    rooms in parallel — if a previous tick still holds the lock, the new
+    tick exits early and waits for the next schedule slot. The lock has a
+    safety TTL so a crashed worker cannot keep the lock forever.
     """
+    from django_redis import get_redis_connection
+
     from chats.apps.rooms.usecases.inactivity import InactivityService
 
-    service = InactivityService()
+    redis_conn = get_redis_connection("default")
+    lock = redis_conn.lock(
+        settings.INACTIVITY_TASK_LOCK_NAME,
+        timeout=settings.INACTIVITY_TASK_LOCK_TIMEOUT,
+    )
+
+    acquired = lock.acquire(blocking=False)
+    if not acquired:
+        logger.info(
+            "[INACTIVITY TASK] another execution is in progress (lock %s held), "
+            "skipping this tick",
+            settings.INACTIVITY_TASK_LOCK_NAME,
+        )
+        return
 
     try:
-        warned = service.warn_inactive_rooms()
-        logger.info("[INACTIVITY TASK] warn_inactive_rooms processed %s rooms", warned)
-    except Exception as exc:
-        logger.exception("[INACTIVITY TASK] warn_inactive_rooms failed: %s", exc)
-        capture_exception(exc)
+        service = InactivityService()
 
-    try:
-        closed = service.close_inactive_rooms()
-        logger.info("[INACTIVITY TASK] close_inactive_rooms processed %s rooms", closed)
-    except Exception as exc:
-        logger.exception("[INACTIVITY TASK] close_inactive_rooms failed: %s", exc)
-        capture_exception(exc)
+        try:
+            warned = service.warn_inactive_rooms()
+            logger.info(
+                "[INACTIVITY TASK] warn_inactive_rooms processed %s rooms", warned
+            )
+        except Exception as exc:
+            logger.exception("[INACTIVITY TASK] warn_inactive_rooms failed: %s", exc)
+            capture_exception(exc)
+
+        try:
+            closed = service.close_inactive_rooms()
+            logger.info(
+                "[INACTIVITY TASK] close_inactive_rooms processed %s rooms", closed
+            )
+        except Exception as exc:
+            logger.exception("[INACTIVITY TASK] close_inactive_rooms failed: %s", exc)
+            capture_exception(exc)
+    finally:
+        try:
+            lock.release()
+        except Exception as exc:
+            # Release can fail if the lock TTL already expired and another
+            # worker re-acquired it; that is a benign race we should log but
+            # not treat as fatal — the next tick will run normally.
+            logger.warning(
+                "[INACTIVITY TASK] failed to release lock %s: %s",
+                settings.INACTIVITY_TASK_LOCK_NAME,
+                exc,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/chats/apps/rooms/tests/test_inactivity_task.py
+++ b/chats/apps/rooms/tests/test_inactivity_task.py
@@ -1,9 +1,28 @@
-from unittest.mock import patch
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 from celery.schedules import crontab
 from django.test import TestCase, override_settings
 
 from chats.apps.rooms.tasks import check_inactivity_rooms
+
+
+@contextmanager
+def _mocked_redis_lock(acquire_result: bool = True):
+    """
+    Patches `django_redis.get_redis_connection` so the inactivity task can
+    interact with a lock-like object without a real Redis. Yields the lock
+    and the Redis connection mocks so tests can assert acquire/release and
+    lock-construction behaviour.
+    """
+    lock_mock = MagicMock()
+    lock_mock.acquire.return_value = acquire_result
+
+    redis_mock = MagicMock()
+    redis_mock.lock.return_value = lock_mock
+
+    with patch("django_redis.get_redis_connection", return_value=redis_mock):
+        yield lock_mock, redis_mock
 
 
 class CheckInactivityRoomsTaskTests(TestCase):
@@ -16,7 +35,7 @@ class CheckInactivityRoomsTaskTests(TestCase):
     """
 
     def test_task_calls_warn_then_close(self):
-        with patch(
+        with _mocked_redis_lock(), patch(
             "chats.apps.rooms.usecases.inactivity.InactivityService"
         ) as mocked_service_cls:
             mocked_service = mocked_service_cls.return_value
@@ -29,7 +48,7 @@ class CheckInactivityRoomsTaskTests(TestCase):
             mocked_service.close_inactive_rooms.assert_called_once_with()
 
     def test_task_runs_close_even_when_warn_raises(self):
-        with patch(
+        with _mocked_redis_lock(), patch(
             "chats.apps.rooms.usecases.inactivity.InactivityService"
         ) as mocked_service_cls, patch(
             "chats.apps.rooms.tasks.capture_exception"
@@ -45,7 +64,7 @@ class CheckInactivityRoomsTaskTests(TestCase):
             mocked_capture.assert_called_once()
 
     def test_task_does_not_propagate_close_exception(self):
-        with patch(
+        with _mocked_redis_lock(), patch(
             "chats.apps.rooms.usecases.inactivity.InactivityService"
         ) as mocked_service_cls, patch(
             "chats.apps.rooms.tasks.capture_exception"
@@ -60,6 +79,77 @@ class CheckInactivityRoomsTaskTests(TestCase):
                 self.fail(f"Task must swallow close exceptions, got: {exc}")
 
             mocked_capture.assert_called_once()
+
+
+class CheckInactivityRoomsLockTests(TestCase):
+    """
+    Tests for the Redis-backed distributed lock that prevents two task
+    executions from processing the same eligible rooms concurrently.
+    """
+
+    def test_task_skips_when_lock_is_already_held(self):
+        with _mocked_redis_lock(acquire_result=False), patch(
+            "chats.apps.rooms.usecases.inactivity.InactivityService"
+        ) as mocked_service_cls:
+            check_inactivity_rooms()
+
+            mocked_service_cls.assert_not_called()
+
+    def test_lock_is_released_after_successful_run(self):
+        with _mocked_redis_lock() as (lock_mock, _), patch(
+            "chats.apps.rooms.usecases.inactivity.InactivityService"
+        ) as mocked_service_cls:
+            mocked_service = mocked_service_cls.return_value
+            mocked_service.warn_inactive_rooms.return_value = 0
+            mocked_service.close_inactive_rooms.return_value = 0
+
+            check_inactivity_rooms()
+
+            lock_mock.release.assert_called_once()
+
+    def test_lock_is_released_even_when_warn_and_close_raise(self):
+        with _mocked_redis_lock() as (lock_mock, _), patch(
+            "chats.apps.rooms.usecases.inactivity.InactivityService"
+        ) as mocked_service_cls, patch(
+            "chats.apps.rooms.tasks.capture_exception"
+        ):
+            mocked_service = mocked_service_cls.return_value
+            mocked_service.warn_inactive_rooms.side_effect = RuntimeError("warn")
+            mocked_service.close_inactive_rooms.side_effect = RuntimeError("close")
+
+            check_inactivity_rooms()
+
+            lock_mock.release.assert_called_once()
+
+    def test_release_failure_is_logged_but_not_raised(self):
+        with _mocked_redis_lock() as (lock_mock, _), patch(
+            "chats.apps.rooms.usecases.inactivity.InactivityService"
+        ) as mocked_service_cls:
+            mocked_service_cls.return_value.warn_inactive_rooms.return_value = 0
+            mocked_service_cls.return_value.close_inactive_rooms.return_value = 0
+            lock_mock.release.side_effect = RuntimeError("lock expired")
+
+            try:
+                check_inactivity_rooms()
+            except Exception as exc:
+                self.fail(
+                    f"Task must swallow lock release errors, got: {exc}"
+                )
+
+    @override_settings(
+        INACTIVITY_TASK_LOCK_NAME="custom_lock",
+        INACTIVITY_TASK_LOCK_TIMEOUT=42,
+    )
+    def test_lock_is_acquired_with_configured_name_and_timeout(self):
+        with _mocked_redis_lock() as (_, redis_mock), patch(
+            "chats.apps.rooms.usecases.inactivity.InactivityService"
+        ) as mocked_service_cls:
+            mocked_service_cls.return_value.warn_inactive_rooms.return_value = 0
+            mocked_service_cls.return_value.close_inactive_rooms.return_value = 0
+
+            check_inactivity_rooms()
+
+            redis_mock.lock.assert_called_once_with("custom_lock", timeout=42)
 
 
 class CheckInactivityRoomsScheduleTests(TestCase):

--- a/chats/apps/rooms/tests/test_inactivity_usecase.py
+++ b/chats/apps/rooms/tests/test_inactivity_usecase.py
@@ -570,3 +570,190 @@ class RoomNotifyInactivityTests(TestCase):
             self.room.notify_inactivity()
 
         mock_send.assert_not_called()
+
+
+class InactivityBatchLimitTests(TestCase):
+    """
+    Tests for the per-execution caps that bound how many rooms the inactivity
+    service warns or closes in a single run. Above the cap, remaining rooms
+    must be left untouched for the next periodic execution to pick up.
+    """
+
+    def setUp(self):
+        _enable_inactivity_feature_flag(self)
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start="09:00",
+            work_end="18:00",
+            inactivity_timeout=_enabled_inactivity_config(),
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.user = User.objects.create(email="agent@example.com")
+        # Counter feeds unique contact ids; the rooms_room unique constraint
+        # `(contact_id, queue_id, is_active=True)` forbids two active rooms
+        # with the same contact in the same queue, so each room must use a
+        # fresh contact.
+        self._contact_seq = 0
+
+    def _new_contact(self) -> Contact:
+        self._contact_seq += 1
+        return Contact.objects.create(
+            name=f"Contact {self._contact_seq}",
+            external_id=f"c-batch-{self._contact_seq}",
+        )
+
+    def _create_warn_eligible_room(self) -> Room:
+        room = Room.objects.create(queue=self.queue, contact=self._new_contact())
+        room.user = self.user
+        room.last_message_user = self.user
+        room.last_interaction = timezone.now() - timedelta(seconds=900)
+        room.save()
+        return room
+
+    def _create_close_eligible_room(self) -> Room:
+        room = self._create_warn_eligible_room()
+        room.is_inactive = True
+        room.save()
+        return room
+
+    def test_warn_stops_at_configured_batch_limit(self):
+        rooms = [self._create_warn_eligible_room() for _ in range(3)]
+
+        with self.settings(INACTIVITY_MAX_WARNINGS_PER_RUN=2), patch.object(
+            Room, "notify_inactivity"
+        ):
+            warned = InactivityService().warn_inactive_rooms()
+
+        self.assertEqual(warned, 2)
+
+        inactive_count = Room.objects.filter(
+            pk__in=[r.pk for r in rooms], is_inactive=True
+        ).count()
+        self.assertEqual(inactive_count, 2)
+
+    def test_warn_processes_everything_when_under_limit(self):
+        rooms = [self._create_warn_eligible_room() for _ in range(3)]
+
+        with self.settings(INACTIVITY_MAX_WARNINGS_PER_RUN=10), patch.object(
+            Room, "notify_inactivity"
+        ):
+            warned = InactivityService().warn_inactive_rooms()
+
+        self.assertEqual(warned, 3)
+        inactive_count = Room.objects.filter(
+            pk__in=[r.pk for r in rooms], is_inactive=True
+        ).count()
+        self.assertEqual(inactive_count, 3)
+
+    def test_close_stops_at_configured_batch_limit(self):
+        rooms = [self._create_close_eligible_room() for _ in range(3)]
+
+        with self.settings(
+            INACTIVITY_MAX_CLOSURES_PER_RUN=2, ACTIVATE_CALC_METRICS=False
+        ), patch.object(Room, "notify_user"), patch.object(
+            Room, "notify_queue"
+        ), patch.object(
+            Message, "notify_room"
+        ):
+            closed = InactivityService().close_inactive_rooms()
+
+        self.assertEqual(closed, 2)
+
+        closed_count = Room.objects.filter(
+            pk__in=[r.pk for r in rooms], is_active=False
+        ).count()
+        self.assertEqual(closed_count, 2)
+
+
+class InactivityMetricsEnqueueTests(TestCase):
+    """
+    Tests that the inactivity usecase enqueues the metrics work to the
+    `close_metrics` Celery task instead of running `close_room` (which does
+    DB-bound work synchronously) inline in the per-room loop.
+
+    The contract verified here is local to the inactivity flow: the manual
+    close path in `viewsets.py` continues to use `close_room` directly and
+    is intentionally not affected.
+    """
+
+    def setUp(self):
+        _enable_inactivity_feature_flag(self)
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=5,
+            work_start="09:00",
+            work_end="18:00",
+            inactivity_timeout=_enabled_inactivity_config(),
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.user = User.objects.create(email="agent@example.com")
+        self.contact = Contact.objects.create(name="Contact", external_id="c-1")
+
+    def _create_already_warned_room(self) -> Room:
+        room = Room.objects.create(queue=self.queue, contact=self.contact)
+        room.user = self.user
+        room.last_message_user = self.user
+        room.last_interaction = timezone.now() - timedelta(seconds=700)
+        room.is_inactive = True
+        room.save()
+        return room
+
+    def test_metrics_are_enqueued_to_celery_when_activated(self):
+        room = self._create_already_warned_room()
+
+        with self.settings(
+            ACTIVATE_CALC_METRICS=True, METRICS_CUSTOM_QUEUE="metrics-queue"
+        ), patch.object(Room, "notify_user"), patch.object(
+            Room, "notify_queue"
+        ), patch.object(
+            Message, "notify_room"
+        ), patch(
+            "chats.apps.dashboard.tasks.close_metrics.apply_async"
+        ) as mock_apply_async, patch(
+            "chats.apps.rooms.views.close_room"
+        ) as mock_inline_close_room:
+            closed = InactivityService().close_inactive_rooms()
+
+        self.assertEqual(closed, 1)
+        mock_apply_async.assert_called_once_with(
+            args=[str(room.pk)], queue="metrics-queue"
+        )
+        mock_inline_close_room.assert_not_called()
+
+    def test_metrics_are_not_enqueued_when_deactivated(self):
+        self._create_already_warned_room()
+
+        with self.settings(ACTIVATE_CALC_METRICS=False), patch.object(
+            Room, "notify_user"
+        ), patch.object(Room, "notify_queue"), patch.object(
+            Message, "notify_room"
+        ), patch(
+            "chats.apps.dashboard.tasks.close_metrics.apply_async"
+        ) as mock_apply_async:
+            closed = InactivityService().close_inactive_rooms()
+
+        self.assertEqual(closed, 1)
+        mock_apply_async.assert_not_called()
+
+    def test_metrics_enqueue_failure_does_not_block_close(self):
+        room = self._create_already_warned_room()
+
+        with self.settings(ACTIVATE_CALC_METRICS=True), patch.object(
+            Room, "notify_user"
+        ), patch.object(Room, "notify_queue"), patch.object(
+            Message, "notify_room"
+        ), patch(
+            "chats.apps.dashboard.tasks.close_metrics.apply_async",
+            side_effect=RuntimeError("broker down"),
+        ):
+            closed = InactivityService().close_inactive_rooms()
+
+        room.refresh_from_db()
+        self.assertEqual(closed, 1)
+        self.assertFalse(room.is_active)
+        self.assertTrue(room.automatic_closed)

--- a/chats/apps/rooms/usecases/inactivity.py
+++ b/chats/apps/rooms/usecases/inactivity.py
@@ -195,11 +195,26 @@ class InactivityService:
         Sends inactivity warnings to all eligible rooms.
 
         Returns the number of rooms that were warned.
+
+        Hard-capped by `settings.INACTIVITY_MAX_WARNINGS_PER_RUN`. Anything
+        above the cap is left for the next run (the periodic task runs every
+        minute), guaranteeing the execution window stays bounded even on
+        spikes.
         """
         now = timezone.now()
         warned = 0
+        max_per_run = settings.INACTIVITY_MAX_WARNINGS_PER_RUN
+        chunk_size = settings.INACTIVITY_QUERYSET_CHUNK_SIZE
 
-        for room in _eligible_warn_queryset().iterator():
+        for room in _eligible_warn_queryset().iterator(chunk_size=chunk_size):
+            if warned >= max_per_run:
+                logger.info(
+                    "[INACTIVITY] reached warn batch limit (%s); "
+                    "remaining rooms will be processed on the next run",
+                    max_per_run,
+                )
+                break
+
             if not self._is_feature_active_for_room(room):
                 continue
 
@@ -227,11 +242,26 @@ class InactivityService:
         Closes all rooms that exceeded the closure timeout after the warning.
 
         Returns the number of rooms that were closed.
+
+        Hard-capped by `settings.INACTIVITY_MAX_CLOSURES_PER_RUN`. Anything
+        above the cap is left for the next run (the periodic task runs every
+        minute), so per-room work — including metrics enqueueing — never
+        outgrows the schedule window.
         """
         now = timezone.now()
         closed = 0
+        max_per_run = settings.INACTIVITY_MAX_CLOSURES_PER_RUN
+        chunk_size = settings.INACTIVITY_QUERYSET_CHUNK_SIZE
 
-        for room in _eligible_close_queryset().iterator():
+        for room in _eligible_close_queryset().iterator(chunk_size=chunk_size):
+            if closed >= max_per_run:
+                logger.info(
+                    "[INACTIVITY] reached close batch limit (%s); "
+                    "remaining rooms will be processed on the next run",
+                    max_per_run,
+                )
+                break
+
             if not self._is_feature_active_for_room(room):
                 continue
 
@@ -372,16 +402,23 @@ class InactivityService:
 
         # The manual close endpoint computes service metrics
         # (interaction_time, message_response_time, etc.) in the view via
-        # `close_room`. The automatic close must replicate it, otherwise
-        # inactivity-closed rooms are left without those metrics.
+        # `close_room`. The automatic close enqueues the same work to the
+        # `close_metrics` Celery task instead of running it inline, so the
+        # per-room loop is not paid for the database round-trips that
+        # `generate_metrics` performs. Behaviour is identical: `close_metrics`
+        # is the canonical async metrics task already used by the manual
+        # close path.
         if settings.ACTIVATE_CALC_METRICS:
             try:
-                from chats.apps.rooms.views import close_room
+                from chats.apps.dashboard.tasks import close_metrics
 
-                close_room(str(room.pk))
+                close_metrics.apply_async(
+                    args=[str(room.pk)],
+                    queue=settings.METRICS_CUSTOM_QUEUE,
+                )
             except Exception as exc:
                 logger.warning(
-                    "[INACTIVITY] Failed to generate metrics for room %s: %s",
+                    "[INACTIVITY] Failed to enqueue metrics for room %s: %s",
                     room.pk,
                     exc,
                 )

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -512,6 +512,30 @@ DISCUSSION_AGENTS_LIMIT = env.int("DISCUSSION_AGENTS_LIMIT", default=5)
 DEFAULT_MESSAGE_TIMEOUT_TIME = env.int("DEFAULT_MESSAGE_TIMEOUT_TIME", default=600)
 DEFAULT_CLOSE_ROOM_TIMEOUT_TIME = env.int("DEFAULT_CLOSE_ROOM_TIMEOUT_TIME", default=60)
 
+# Inactivity task safety caps: hard ceiling on how many rooms each periodic
+# execution may warn or close. Anything above the cap is processed by the
+# next run (the task runs every minute). Prevents one execution from
+# overflowing past the schedule window even in worst-case spikes.
+INACTIVITY_MAX_WARNINGS_PER_RUN = env.int(
+    "INACTIVITY_MAX_WARNINGS_PER_RUN", default=1000
+)
+INACTIVITY_MAX_CLOSURES_PER_RUN = env.int(
+    "INACTIVITY_MAX_CLOSURES_PER_RUN", default=500
+)
+INACTIVITY_QUERYSET_CHUNK_SIZE = env.int(
+    "INACTIVITY_QUERYSET_CHUNK_SIZE", default=200
+)
+
+# Distributed lock used by `check_inactivity_rooms` to guarantee only one
+# instance of the task runs at a time, even if a previous run overlaps the
+# 1-minute schedule.
+INACTIVITY_TASK_LOCK_NAME = env.str(
+    "INACTIVITY_TASK_LOCK_NAME", default="inactivity_task_lock"
+)
+INACTIVITY_TASK_LOCK_TIMEOUT = env.int(
+    "INACTIVITY_TASK_LOCK_TIMEOUT", default=120
+)
+
 # Celery
 
 METRICS_CUSTOM_QUEUE = env("METRICS_CUSTOM_QUEUE", default="celery")


### PR DESCRIPTION
### What

Adds four safety/performance optimizations to the inactivity feature, all scoped to the inactivity flow (no behavioural change to manual close, bulk close or any other system path):

1. **Per-run batch caps** in `InactivityService`: `warn_inactive_rooms` and `close_inactive_rooms` now stop after `INACTIVITY_MAX_WARNINGS_PER_RUN` / `INACTIVITY_MAX_CLOSURES_PER_RUN` rooms. Anything above the cap is picked up on the next tick (the task runs every minute). Defaults: 1000 warnings, 500 closures.
2. **Distributed Redis lock** around `check_inactivity_rooms`: prevents two beat ticks from processing the same eligible rooms in parallel if a run ever overruns the 1-minute schedule. Lock has a TTL so a crashed worker can't hold it forever.
3. **Async metrics enqueue** in `_close_room`: replaces the inline `close_room(...)` call with `close_metrics.apply_async(...)` (canonical task already used by the manual close path). The per-room loop no longer pays the synchronous DB round-trips that `generate_metrics` performs.
4. **Partial index `rooms_inactivity_warn_idx`** on `rooms_room`: pre-filters rows that match every `rooms_room`-local predicate of the warn queryset (`is_active`, `is_inactive=false`, `is_waiting=false`, `user_id IS NOT NULL`, `last_message_user_id IS NOT NULL`). Created with `AddIndexConcurrently` so it does not block writes during deploy.

New settings (all with sensible defaults and env vars): `INACTIVITY_MAX_WARNINGS_PER_RUN`, `INACTIVITY_MAX_CLOSURES_PER_RUN`, `INACTIVITY_QUERYSET_CHUNK_SIZE`, `INACTIVITY_TASK_LOCK_NAME`, `INACTIVITY_TASK_LOCK_TIMEOUT`.

Adds 11 new unit tests (40 total in the suite) covering: batch cap reached, batch cap not reached, lock skip when already held, lock release on success and on failure, release error logged but not raised, lock name/timeout configurable, metrics enqueued with the right queue, metrics not enqueued when `ACTIVATE_CALC_METRICS=False`, metrics enqueue failure does not block the close.

### Why

The inactivity feature is currently behind the `weniChatsInactivityTimeout` flag and enabled on a single test project. Before rolling it out to more projects, we identified four risks that need to be mitigated:

- **Unbounded run time.** The periodic task runs every minute. With more projects enabled, a single run could exceed the 60-second window and overlap with the next tick. Hard caps give a predictable upper bound on per-run work; leftover rooms are processed by the next tick.
- **Concurrent executions.** Without a lock, an overrun causes two task instances to walk the same eligible rooms simultaneously, doubling DB load and risking duplicate effects on edge cases. A short-TTL Redis lock blocks the overlap.
- **Synchronous DB-bound work per room.** `close_room(...)` runs `generate_metrics` inline (and also schedules `close_metrics` via `on_commit`, effectively doing the work twice on the automatic path). Switching the inactivity path to enqueue `close_metrics` directly keeps metrics behaviour identical while taking the synchronous cost off the loop.
- **Slow warn elegibility query.** `EXPLAIN ANALYZE` in production showed the planner combining `rooms_inactivity_idx` with `rooms_room_last_message_user_id_*` via BitmapAnd, scanning ~944k historical rows for a 1.2s execution returning zero rooms. The new partial index lets the planner pick a single, much smaller index path — expected to drop the warn query from ~1.2s to tens of ms.

Scope is intentionally narrow: only the inactivity code path changes. Manual close (`viewsets.py`), bulk close (`bulk_close_service.py`) and every other consumer of `close_room` / `notify_queue` continue to behave exactly as before. The feature flag is preserved as the instant rollback lever.