### PR TITLE
fix: fall back to default queue routing when linked agent is not in q…

### DIFF
--- a/chats/apps/rooms/tests/test_resolve_room_user.py
+++ b/chats/apps/rooms/tests/test_resolve_room_user.py
@@ -139,6 +139,11 @@ class ResolveRoomUserLinkedUserTests(TestCase):
             role=ProjectPermission.ROLE_ATTENDANT,
             status="ONLINE",
         )
+        self.queue_authorization = QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=self.permission,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
         LinkContact.objects.create(
             user=self.linked_agent,
             contact=self.contact,
@@ -168,6 +173,54 @@ class ResolveRoomUserLinkedUserTests(TestCase):
     def test_skips_linked_user_when_linked_user_offline(self):
         self.permission.status = "OFFLINE"
         self.permission.save(update_fields=["status"])
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=False,
+        )
+
+        self.assertIsNone(result)
+
+    def test_skips_linked_user_when_not_agent_of_queue(self):
+        self.queue_authorization.delete()
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=False,
+        )
+
+        self.assertIsNone(result)
+
+    def test_falls_back_to_default_routing_when_linked_user_not_in_queue(self):
+        self.queue_authorization.delete()
+
+        other_agent = User.objects.create(email="other@example.com")
+        other_permission = ProjectPermission.objects.create(
+            project=self.project,
+            user=other_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status="ONLINE",
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=other_permission,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        result = self.usecase.execute(
+            contact=self.contact,
+            user=None,
+            is_created=False,
+        )
+
+        self.assertEqual(result, other_agent)
+
+    def test_skips_linked_user_when_link_has_no_user(self):
+        LinkContact.objects.filter(contact=self.contact, project=self.project).update(
+            user=None
+        )
 
         result = self.usecase.execute(
             contact=self.contact,

--- a/chats/apps/rooms/usecases/resolve_room_user.py
+++ b/chats/apps/rooms/usecases/resolve_room_user.py
@@ -40,8 +40,17 @@ class ResolveRoomUserUseCase:
 
         if not is_created:
             linked_user = contact.get_linked_user(self.project)
-            if linked_user is not None and linked_user.is_online:
-                return linked_user.user
+            if linked_user is not None and linked_user.user is not None:
+                if not self.queue.is_agent(linked_user.user):
+                    logger.info(
+                        "Linked user %s for contact %s is not an agent of queue"
+                        " %s; falling back to default routing",
+                        linked_user.user_id,
+                        contact.pk,
+                        self.queue.uuid,
+                    )
+                elif linked_user.is_online:
+                    return linked_user.user
 
         if user and self.project.permissions.filter(
             user=user, status="ONLINE"


### PR DESCRIPTION
### **What**
Update ResolveRoomUserUseCase to check whether the contact's linked agent is authorized in the queue where the room is being opened (queue.is_agent()).
If the linked agent is not in that queue, skip direct assignment and continue with the default routing flow (queue priority or general).
Add tests covering linked agents without queue authorization, fallback to another available agent, and links with no user.

### **Why**
Contacts can have a linked agent at the project level, but that agent may not belong to the queue where the room is opened. Assigning the linked agent in that case bypasses queue rules and can route conversations to the wrong team. This change keeps linked-agent assignment only when the agent is actually part of the target queue; otherwise the room follows the standard queue routing behavior.