### PR TITLE
refactor: update RoomPin creation to include project association

### DIFF
--- a/chats/apps/api/v1/rooms/tests/test_filters_serializers_viewsets.py
+++ b/chats/apps/api/v1/rooms/tests/test_filters_serializers_viewsets.py
@@ -191,8 +191,8 @@ class RoomViewsetListTests(TestCase):
         pinned_room = self._create_room("PINNED", user=self.other_user)
         regular_room = self._create_room("REGULAR", user=self.other_user)
 
-        RoomPin.objects.create(room=pinned_room, user=self.other_user)
-        RoomPin.objects.create(room=regular_room, user=self.request_user)
+        RoomPin.objects.create(room=pinned_room, user=self.other_user, project=self.project)
+        RoomPin.objects.create(room=regular_room, user=self.request_user, project=self.project)
 
         response = self._list({"email": self.other_user.email, "limit": 10})
 
@@ -210,7 +210,7 @@ class RoomViewsetListTests(TestCase):
             if i < 3:
                 pinned_rooms.append(room)
         RoomPin.objects.bulk_create(
-            [RoomPin(room=room, user=self.request_user) for room in pinned_rooms]
+            [RoomPin(room=room, user=self.request_user, project=self.project) for room in pinned_rooms]
         )
 
         params = {"project": str(self.project.pk), "limit": 50}
@@ -260,8 +260,8 @@ class RoomViewsetListTests(TestCase):
         inactive_pinned = self._create_room("INACTIVE-PINNED", is_active=False)
 
         # Pin both pinned rooms
-        RoomPin.objects.create(room=active_pinned, user=self.request_user)
-        RoomPin.objects.create(room=inactive_pinned, user=self.request_user)
+        RoomPin.objects.create(room=active_pinned, user=self.request_user, project=self.project)
+        RoomPin.objects.create(room=inactive_pinned, user=self.request_user, project=self.project)
 
         # Request only active rooms
         params = {

--- a/chats/apps/api/v1/rooms/tests/test_services.py
+++ b/chats/apps/api/v1/rooms/tests/test_services.py
@@ -384,8 +384,8 @@ class BulkCloseServiceTest(TestCase):
         room1 = Room.objects.create(queue=self.queue, user=self.user, is_active=True)
         room2 = Room.objects.create(queue=self.queue, user=self.user, is_active=True)
 
-        RoomPin.objects.create(room=room1, user=self.user)
-        RoomPin.objects.create(room=room2, user=self.user)
+        RoomPin.objects.create(room=room1, user=self.user, project=self.project)
+        RoomPin.objects.create(room=room2, user=self.user, project=self.project)
 
         rooms = Room.objects.filter(pk__in=[room1.pk, room2.pk])
         self.assertEqual(RoomPin.objects.filter(room__in=rooms).count(), 2)

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -244,7 +244,7 @@ class RoomViewset(
 
     def _list_with_legacy_pin_order(self, qs, request, project):
         pins_query = {
-            "room__queue__sector__project": project,
+            "project": project,
         }
 
         if user_email := request.query_params.get("email"):
@@ -269,7 +269,7 @@ class RoomViewset(
             RoomPin.objects.filter(
                 user=request.user,
                 room=OuterRef("pk"),
-                room__queue__sector__project=project,
+                project=project,
             )
             .order_by("-created_on")
             .values("created_on")[:1]
@@ -300,7 +300,7 @@ class RoomViewset(
         # pinned rooms form a tiny, bounded set. We resolve them with a single
         # small query and reuse the resulting ids as constant literals, avoiding
         # the correlated subqueries / full-PK materialization of the other paths.
-        pins_query = {"room__queue__sector__project": project, "room__is_active": True}
+        pins_query = {"project": project, "room__is_active": True}
 
         if user_email := request.query_params.get("email"):
             pins_query["user__email"] = user_email

--- a/chats/apps/rooms/models.py
+++ b/chats/apps/rooms/models.py
@@ -750,8 +750,7 @@ class Room(BaseModel, BaseConfigurableModel):
         if (
             RoomPin.objects.filter(
                 user=user,
-                # TODO: Change to project once we have the project field populated
-                room__queue__sector__project=project,
+                project=project,
                 room__is_active=True,
             ).count()
             >= settings.MAX_ROOM_PINS_LIMIT

--- a/chats/apps/rooms/tests/test_viewsets.py
+++ b/chats/apps/rooms/tests/test_viewsets.py
@@ -428,8 +428,8 @@ class TestRoomsViewSet(APITestCase):
         room_3 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
         room_4 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
 
-        RoomPin.objects.create(room=room_3, user=self.user)
-        RoomPin.objects.create(room=room_2, user=self.user)
+        RoomPin.objects.create(room=room_3, user=self.user, project=self.project)
+        RoomPin.objects.create(room=room_2, user=self.user, project=self.project)
 
         queue = Queue.objects.create(
             name="Test Queue",
@@ -453,7 +453,7 @@ class TestRoomsViewSet(APITestCase):
 
         # Room from a different project, should be excluded
         room_5 = Room.objects.create(queue=queue, contact=Contact.objects.create())
-        RoomPin.objects.create(room=room_5, user=self.user)
+        RoomPin.objects.create(room=room_5, user=self.user, project=queue.sector.project)
 
         response = self.list_rooms(
             filters={
@@ -507,7 +507,7 @@ class TestRoomsViewSet(APITestCase):
             )
             rooms.append(room)
 
-        RoomPin.objects.create(room=rooms[1], user=another_user)
+        RoomPin.objects.create(room=rooms[1], user=another_user, project=self.project)
 
         response = self.list_rooms(
             filters={
@@ -536,8 +536,8 @@ class TestRoomsViewSet(APITestCase):
         room_3 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
         room_4 = Room.objects.create(queue=self.queue, contact=Contact.objects.create())
 
-        RoomPin.objects.create(room=room_3, user=self.user)
-        RoomPin.objects.create(room=room_2, user=self.user)
+        RoomPin.objects.create(room=room_3, user=self.user, project=self.project)
+        RoomPin.objects.create(room=room_2, user=self.user, project=self.project)
 
         queue = Queue.objects.create(
             name="Test Queue",
@@ -561,7 +561,7 @@ class TestRoomsViewSet(APITestCase):
 
         # Room from a different project, should be excluded even when pinned
         room_5 = Room.objects.create(queue=queue, contact=Contact.objects.create())
-        RoomPin.objects.create(room=room_5, user=self.user)
+        RoomPin.objects.create(room=room_5, user=self.user, project=queue.sector.project)
 
         response = self.list_rooms(
             filters={
@@ -616,7 +616,7 @@ class TestRoomsViewSet(APITestCase):
             )
             rooms.append(room)
 
-        RoomPin.objects.create(room=rooms[1], user=another_user)
+        RoomPin.objects.create(room=rooms[1], user=another_user, project=self.project)
 
         response = self.list_rooms(
             filters={
@@ -648,7 +648,7 @@ class TestRoomsViewSet(APITestCase):
 
         # Pin the most recently created room; ascending ordering would place it
         # last, yet it must stay at the top because it is pinned.
-        RoomPin.objects.create(room=room_3, user=self.user)
+        RoomPin.objects.create(room=room_3, user=self.user, project=self.project)
 
         response = self.list_rooms(
             filters={
@@ -1725,7 +1725,7 @@ class TestRoomPinAuthenticatedUser(BaseRoomPinTestCase):
                 queue=self.queue,
                 user=self.user,
             )
-            RoomPin.objects.create(room=room, user=self.user)
+            RoomPin.objects.create(room=room, user=self.user, project=self.project)
 
         room = Room.objects.create(
             queue=self.queue,


### PR DESCRIPTION
### **What**

Replaces the traversal lookup `room__queue__sector__project` with a direct `project` field reference on `RoomPin` across filtering, annotation, and pin limit enforcement logic.

### **Why**

The `RoomPin` model now has a dedicated `project` field, making the previous multi-join traversal through `room__queue__sector__project` unnecessary. Using the direct field improves query efficiency and removes the temporary workaround that was noted with a `TODO` comment. Tests have been updated to populate the new `project` field when creating `RoomPin` instances to reflect this change.