### PR TITLE
refactor: optimize room queryset filtering by user projects

### DIFF
--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -1530,7 +1530,7 @@ class RoomNoteViewSet(
         if not room_uuid:
             raise ValidationError({"detail": "Room UUID is required"})
 
-        if not Room.objects.filter(uuid=room_uuid).exists():
+        if not self.queryset.filter(uuid=room_uuid).exists():
             raise ValidationError({"detail": "Room not found"})
 
         return super().list(request, *args, **kwargs)

--- a/chats/apps/api/v1/rooms/viewsets.py
+++ b/chats/apps/api/v1/rooms/viewsets.py
@@ -159,11 +159,12 @@ class RoomViewset(
     ):  # TODO: sparate list and retrieve queries from update and close
         if self.action != "list":
             self.filterset_class = None
-        qs = (
-            super()
-            .get_queryset()
-            .filter(queue__sector__project__permissions__user=self.request.user)
-        )
+
+        user_projects = ProjectPermission.objects.filter(
+            user=self.request.user
+        ).values_list("project", flat=True)
+
+        qs = super().get_queryset().filter(queue__sector__project__in=user_projects)
 
         qs = qs.select_related(
             "user", "contact", "queue", "queue__sector", "queue__sector__project"


### PR DESCRIPTION
### **What**

Optimizes the room queryset filtering by pre-fetching user project permissions into a separate query and using `__in` lookup instead of traversing the full relation chain. Also fixes the room existence check in the `list` action to use the scoped `self.queryset` instead of the global `Room.objects`.

### **Why**

The previous approach of filtering rooms via `queue__sector__project__permissions__user` could produce duplicate results when a user has multiple permissions associated with the same project. By resolving the user's projects upfront with `ProjectPermission.objects.filter(user=...).values_list("project", flat=True)` and then filtering with `__in`, we avoid potential duplicates and improve query clarity. Additionally, using `self.queryset` for the room existence check ensures the lookup respects the same queryset scope and permissions context as the rest of the viewset.