### PR TITLE
fix: wamid and logs in replys

### DIFF
--- a/chats/apps/api/utils.py
+++ b/chats/apps/api/utils.py
@@ -11,6 +11,7 @@ from chats.apps.api.v1.dashboard.dto import RoomData
 from chats.apps.api.v1.dashboard.serializers import DashboardRoomSerializer
 from chats.apps.contacts.models import Contact
 from chats.apps.msgs.models import ChatMessageReplyIndex, Message
+from chats.apps.msgs.utils import extract_wamid_core
 
 logger = logging.getLogger(__name__)
 
@@ -82,14 +83,18 @@ def create_reply_index(message: Message):
     if not message.external_id:
         return
 
+    external_id_core = extract_wamid_core(message.external_id)
+
     if ChatMessageReplyIndex.objects.filter(external_id=message.external_id).exists():
         ChatMessageReplyIndex.objects.filter(external_id=message.external_id).update(
             message=message,
+            external_id_core=external_id_core,
         )
     else:
         ChatMessageReplyIndex.objects.update_or_create(
             external_id=message.external_id,
             message=message,
+            defaults={"external_id_core": external_id_core},
         )
 
 

--- a/chats/apps/api/v1/external/msgs/serializers.py
+++ b/chats/apps/api/v1/external/msgs/serializers.py
@@ -6,6 +6,7 @@ from chats.apps.api.v1.accounts.serializers import UserSerializer
 from chats.apps.api.v1.contacts.serializers import ContactRelationsSerializer
 from chats.apps.api.v1.msgs.serializers import MessageMediaSerializer
 from chats.apps.msgs.models import Message, MessageMedia
+from chats.apps.msgs.utils import extract_wamid_core
 
 
 class AttachmentSerializer(serializers.ModelSerializer):
@@ -221,6 +222,17 @@ class RoomHistoryMessageSerializer(serializers.ModelSerializer):
             return None
 
         reply_index = reply_index_map.get(replied_id)
+        if reply_index is None:
+            # Fall back to the stable WAMID core when the exact ``external_id``
+            # mapping is missing because Meta sent a different envelope
+            # (``HBgM`` vs ``HBgT``) inside ``context.id``. The viewset
+            # decides whether the core map is populated based on the project
+            # feature flag, so this branch is a no-op when the flag is off.
+            core_map = self.context.get("reply_index_core_map") or {}
+            core = extract_wamid_core(replied_id)
+            if core:
+                reply_index = core_map.get(core)
+
         if reply_index is None:
             return None
 

--- a/chats/apps/api/v1/external/msgs/tests/test_room_history_viewset.py
+++ b/chats/apps/api/v1/external/msgs/tests/test_room_history_viewset.py
@@ -479,7 +479,10 @@ class TestRoomHistoryCaching(BaseRoomHistoryTest):
         self.auth()
         with mock.patch(
             "chats.apps.api.v1.external.msgs.viewsets.cache.set"
-        ) as mocked_set:
+        ) as mocked_set, mock.patch(
+            "chats.apps.api.v1.external.msgs.viewsets.is_reply_core_fallback_active",
+            return_value=False,
+        ):
             response = self.get({"room": str(self.room.uuid)})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/chats/apps/api/v1/external/msgs/viewsets.py
+++ b/chats/apps/api/v1/external/msgs/viewsets.py
@@ -1,3 +1,4 @@
+import logging
 from functools import cached_property
 
 from django.conf import settings
@@ -7,6 +8,8 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import filters, mixins, status, viewsets
 from rest_framework.pagination import CursorPagination
 from rest_framework.response import Response
+from sentry_sdk import capture_exception
+from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from chats.apps.accounts.authentication.drf.authorization import (
     ProjectAdminAuthentication,
@@ -35,6 +38,34 @@ from chats.apps.msgs.models import ChatMessageReplyIndex, Message as ChatMessage
 from chats.apps.msgs.usecases.get_room_messages_history import (
     GetRoomMessagesHistoryUseCase,
 )
+from chats.apps.msgs.utils import extract_wamid_core
+
+logger = logging.getLogger(__name__)
+
+
+def _is_reply_core_fallback_active(project_uuid: str) -> bool:
+    """Wrapper around the WAMID core fallback feature flag.
+
+    Mirrors the safety pattern used elsewhere in the codebase
+    (see ``MessageMedia.is_flows_media_url_feature_active``): any failure
+    in the feature flag integration is captured but never bubbles up,
+    keeping the request on the legacy/exact-match path.
+    """
+
+    if not project_uuid:
+        return False
+
+    try:
+        return is_feature_active_for_attributes(
+            settings.REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY,
+            {"projectUUID": project_uuid},
+        )
+    except Exception as e:
+        capture_exception(e)
+        logger.error(
+            "Error checking if reply core fallback feature flag is active: %s", e
+        )
+        return False
 
 
 class MessageFlowViewset(
@@ -176,6 +207,39 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
             )
         }
 
+    @staticmethod
+    def _build_reply_index_core_map(messages, exact_map: dict) -> dict:
+        """
+        Bulk-fetch ChatMessageReplyIndex rows by stable WAMID core for every
+        replied-to id that was *not* resolved by the exact ``external_id``
+        lookup. Returns a dict keyed by ``external_id_core`` so callers can
+        fall back when Meta sent a different envelope inside ``context.id``.
+        """
+        unresolved = set()
+        for msg in messages:
+            metadata = msg.metadata if isinstance(msg.metadata, dict) else {}
+            context = metadata.get("context")
+            if isinstance(context, dict):
+                ext_id = context.get("id")
+                if ext_id and ext_id not in exact_map:
+                    unresolved.add(ext_id)
+
+        if not unresolved:
+            return {}
+
+        cores = {core for core in (extract_wamid_core(eid) for eid in unresolved) if core}
+        if not cores:
+            return {}
+
+        return {
+            ri.external_id_core: ri
+            for ri in (
+                ChatMessageReplyIndex.objects.select_related("message")
+                .filter(external_id_core__in=cores)
+                .order_by("created_on")
+            )
+        }
+
     @swagger_auto_schema(auto_schema=None)
     def list(self, request, *args, **kwargs):
         """List the message history of a closed room with cursor pagination."""
@@ -215,8 +279,24 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
 
         reply_index_map = self._build_reply_index_map(page)
 
+        reply_index_core_map = {}
+        try:
+            project_uuid = str(request.auth.project)
+        except AttributeError:
+            project_uuid = ""
+
+        if _is_reply_core_fallback_active(project_uuid):
+            reply_index_core_map = self._build_reply_index_core_map(
+                page, reply_index_map
+            )
+
         serializer = self.get_serializer(
-            page, many=True, context={"reply_index_map": reply_index_map}
+            page,
+            many=True,
+            context={
+                "reply_index_map": reply_index_map,
+                "reply_index_core_map": reply_index_core_map,
+            },
         )
         paginated_response = self.get_paginated_response(serializer.data)
 

--- a/chats/apps/api/v1/external/msgs/viewsets.py
+++ b/chats/apps/api/v1/external/msgs/viewsets.py
@@ -1,4 +1,3 @@
-import logging
 from functools import cached_property
 
 from django.conf import settings
@@ -8,8 +7,6 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import filters, mixins, status, viewsets
 from rest_framework.pagination import CursorPagination
 from rest_framework.response import Response
-from sentry_sdk import capture_exception
-from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from chats.apps.accounts.authentication.drf.authorization import (
     ProjectAdminAuthentication,
@@ -38,34 +35,7 @@ from chats.apps.msgs.models import ChatMessageReplyIndex, Message as ChatMessage
 from chats.apps.msgs.usecases.get_room_messages_history import (
     GetRoomMessagesHistoryUseCase,
 )
-from chats.apps.msgs.utils import extract_wamid_core
-
-logger = logging.getLogger(__name__)
-
-
-def _is_reply_core_fallback_active(project_uuid: str) -> bool:
-    """Wrapper around the WAMID core fallback feature flag.
-
-    Mirrors the safety pattern used elsewhere in the codebase
-    (see ``MessageMedia.is_flows_media_url_feature_active``): any failure
-    in the feature flag integration is captured but never bubbles up,
-    keeping the request on the legacy/exact-match path.
-    """
-
-    if not project_uuid:
-        return False
-
-    try:
-        return is_feature_active_for_attributes(
-            settings.REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY,
-            {"projectUUID": project_uuid},
-        )
-    except Exception as e:
-        capture_exception(e)
-        logger.error(
-            "Error checking if reply core fallback feature flag is active: %s", e
-        )
-        return False
+from chats.apps.msgs.utils import extract_wamid_core, is_reply_core_fallback_active
 
 
 class MessageFlowViewset(
@@ -208,12 +178,17 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
         }
 
     @staticmethod
-    def _build_reply_index_core_map(messages, exact_map: dict) -> dict:
+    def _build_reply_index_core_map(messages, exact_map: dict, room_uuid) -> dict:
         """
         Bulk-fetch ChatMessageReplyIndex rows by stable WAMID core for every
         replied-to id that was *not* resolved by the exact ``external_id``
         lookup. Returns a dict keyed by ``external_id_core`` so callers can
         fall back when Meta sent a different envelope inside ``context.id``.
+
+        Results are scoped to ``room_uuid`` so a core collision can never
+        leak a message from another room (or project) into this room's
+        history. WhatsApp replies always belong to the same conversation as
+        the original message, so this is a safe invariant to enforce.
         """
         unresolved = set()
         for msg in messages:
@@ -235,7 +210,7 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
             ri.external_id_core: ri
             for ri in (
                 ChatMessageReplyIndex.objects.select_related("message")
-                .filter(external_id_core__in=cores)
+                .filter(external_id_core__in=cores, message__room_id=room_uuid)
                 .order_by("created_on")
             )
         }
@@ -285,9 +260,9 @@ class RoomHistoryMessagesViewSet(viewsets.GenericViewSet):
         except AttributeError:
             project_uuid = ""
 
-        if _is_reply_core_fallback_active(project_uuid):
+        if is_reply_core_fallback_active(project_uuid):
             reply_index_core_map = self._build_reply_index_core_map(
-                page, reply_index_map
+                page, reply_index_map, room_uuid
             )
 
         serializer = self.get_serializer(

--- a/chats/apps/api/v1/msgs/serializers.py
+++ b/chats/apps/api/v1/msgs/serializers.py
@@ -7,14 +7,12 @@ from django.db import transaction
 from pydub import AudioSegment
 from rest_framework import exceptions, serializers
 
-from weni.feature_flags.shortcuts import is_feature_active_for_attributes
-
 from chats.apps.api.v1.accounts.serializers import UserSerializer
 from chats.apps.api.v1.contacts.serializers import ContactSerializer
 from chats.apps.msgs.models import ChatMessageReplyIndex
 from chats.apps.msgs.models import Message as ChatMessage
 from chats.apps.msgs.models import MessageMedia
-from chats.apps.msgs.utils import extract_wamid_core
+from chats.apps.msgs.utils import extract_wamid_core, is_reply_core_fallback_active
 from chats.apps.ai_features.improve_user_message.choices import (
     ImprovedUserMessageStatusChoices,
     ImprovedUserMessageTypeChoices,
@@ -34,6 +32,9 @@ def _resolve_reply_index(message: ChatMessage, replied_id: str):
     active for the message's project, falls back to matching the stable
     WAMID core (``external_id_core``) so replies still mount when Meta sends
     a different envelope (``HBgM`` vs ``HBgT``) inside ``context.id``.
+
+    The fallback is scoped to ``message.room_id`` to prevent a core
+    collision between rooms/projects from surfacing a foreign message.
     """
 
     exact_match = ChatMessageReplyIndex.objects.filter(
@@ -53,17 +54,14 @@ def _resolve_reply_index(message: ChatMessage, replied_id: str):
     except Exception:
         project_uuid = ""
 
-    if not project_uuid:
-        return None
-
-    if not is_feature_active_for_attributes(
-        settings.REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY,
-        {"projectUUID": project_uuid},
-    ):
+    if not is_reply_core_fallback_active(project_uuid):
         return None
 
     return (
-        ChatMessageReplyIndex.objects.filter(external_id_core=core)
+        ChatMessageReplyIndex.objects.filter(
+            external_id_core=core,
+            message__room_id=message.room_id,
+        )
         .order_by("-created_on")
         .first()
     )

--- a/chats/apps/api/v1/msgs/serializers.py
+++ b/chats/apps/api/v1/msgs/serializers.py
@@ -7,11 +7,14 @@ from django.db import transaction
 from pydub import AudioSegment
 from rest_framework import exceptions, serializers
 
+from weni.feature_flags.shortcuts import is_feature_active_for_attributes
+
 from chats.apps.api.v1.accounts.serializers import UserSerializer
 from chats.apps.api.v1.contacts.serializers import ContactSerializer
 from chats.apps.msgs.models import ChatMessageReplyIndex
 from chats.apps.msgs.models import Message as ChatMessage
 from chats.apps.msgs.models import MessageMedia
+from chats.apps.msgs.utils import extract_wamid_core
 from chats.apps.ai_features.improve_user_message.choices import (
     ImprovedUserMessageStatusChoices,
     ImprovedUserMessageTypeChoices,
@@ -22,6 +25,49 @@ from chats.apps.ai_features.improve_user_message.tasks import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_reply_index(message: ChatMessage, replied_id: str):
+    """Resolve a :class:`ChatMessageReplyIndex` for a replied-to WAMID.
+
+    Performs an exact ``external_id`` lookup first. When the feature flag is
+    active for the message's project, falls back to matching the stable
+    WAMID core (``external_id_core``) so replies still mount when Meta sends
+    a different envelope (``HBgM`` vs ``HBgT``) inside ``context.id``.
+    """
+
+    exact_match = ChatMessageReplyIndex.objects.filter(
+        external_id=replied_id
+    ).first()
+    if exact_match is not None:
+        return exact_match
+
+    core = extract_wamid_core(replied_id)
+    if not core:
+        return None
+
+    try:
+        project_uuid = str(message.room.project_uuid or "") or str(
+            message.project.uuid
+        )
+    except Exception:
+        project_uuid = ""
+
+    if not project_uuid:
+        return None
+
+    if not is_feature_active_for_attributes(
+        settings.REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY,
+        {"projectUUID": project_uuid},
+    ):
+        return None
+
+    return (
+        ChatMessageReplyIndex.objects.filter(external_id_core=core)
+        .order_by("-created_on")
+        .first()
+    )
+
 
 """
 TODO: Refactor these serializers into less classes
@@ -333,7 +379,9 @@ class MessageSerializer(BaseMessageSerializer):
 
         try:
             replied_id = context.get("id")
-            replied_msg = ChatMessageReplyIndex.objects.get(external_id=replied_id)
+            replied_msg = _resolve_reply_index(obj, replied_id)
+            if replied_msg is None:
+                return None
 
             result = {
                 "uuid": str(replied_msg.message.uuid),

--- a/chats/apps/api/v2/msgs/serializers.py
+++ b/chats/apps/api/v2/msgs/serializers.py
@@ -1,13 +1,11 @@
 import logging
 
-from django.conf import settings
 from rest_framework import serializers
-from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from chats.apps.msgs.models import ChatMessageReplyIndex
 from chats.apps.msgs.models import Message as ChatMessage
 from chats.apps.msgs.models import MessageMedia
-from chats.apps.msgs.utils import extract_wamid_core
+from chats.apps.msgs.utils import extract_wamid_core, is_reply_core_fallback_active
 from chats.apps.rooms.models import RoomNote
 
 LOGGER = logging.getLogger(__name__)
@@ -20,6 +18,9 @@ def _resolve_reply_index(message: ChatMessage, replied_id: str):
     active for the message's project, falls back to matching the stable
     WAMID core (``external_id_core``) so replies still mount when Meta sends
     a different envelope (``HBgM`` vs ``HBgT``) inside ``context.id``.
+
+    The fallback is scoped to ``message.room_id`` to prevent a core
+    collision between rooms/projects from surfacing a foreign message.
     """
 
     exact_match = ChatMessageReplyIndex.objects.filter(
@@ -39,17 +40,14 @@ def _resolve_reply_index(message: ChatMessage, replied_id: str):
     except Exception:
         project_uuid = ""
 
-    if not project_uuid:
-        return None
-
-    if not is_feature_active_for_attributes(
-        settings.REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY,
-        {"projectUUID": project_uuid},
-    ):
+    if not is_reply_core_fallback_active(project_uuid):
         return None
 
     return (
-        ChatMessageReplyIndex.objects.filter(external_id_core=core)
+        ChatMessageReplyIndex.objects.filter(
+            external_id_core=core,
+            message__room_id=message.room_id,
+        )
         .order_by("-created_on")
         .first()
     )

--- a/chats/apps/api/v2/msgs/serializers.py
+++ b/chats/apps/api/v2/msgs/serializers.py
@@ -1,13 +1,58 @@
 import logging
 
+from django.conf import settings
 from rest_framework import serializers
+from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from chats.apps.msgs.models import ChatMessageReplyIndex
 from chats.apps.msgs.models import Message as ChatMessage
 from chats.apps.msgs.models import MessageMedia
+from chats.apps.msgs.utils import extract_wamid_core
 from chats.apps.rooms.models import RoomNote
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_reply_index(message: ChatMessage, replied_id: str):
+    """Resolve a :class:`ChatMessageReplyIndex` for a replied-to WAMID.
+
+    Performs an exact ``external_id`` lookup first. When the feature flag is
+    active for the message's project, falls back to matching the stable
+    WAMID core (``external_id_core``) so replies still mount when Meta sends
+    a different envelope (``HBgM`` vs ``HBgT``) inside ``context.id``.
+    """
+
+    exact_match = ChatMessageReplyIndex.objects.filter(
+        external_id=replied_id
+    ).first()
+    if exact_match is not None:
+        return exact_match
+
+    core = extract_wamid_core(replied_id)
+    if not core:
+        return None
+
+    try:
+        project_uuid = str(message.room.project_uuid or "") or str(
+            message.project.uuid
+        )
+    except Exception:
+        project_uuid = ""
+
+    if not project_uuid:
+        return None
+
+    if not is_feature_active_for_attributes(
+        settings.REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY,
+        {"projectUUID": project_uuid},
+    ):
+        return None
+
+    return (
+        ChatMessageReplyIndex.objects.filter(external_id_core=core)
+        .order_by("-created_on")
+        .first()
+    )
 
 
 class UserMinimalSerializer(serializers.Serializer):
@@ -127,9 +172,7 @@ class MessageSerializerV2(serializers.ModelSerializer):
 
         try:
             replied_id = context.get("id")
-            replied_msg = ChatMessageReplyIndex.objects.filter(
-                external_id=replied_id
-            ).first()
+            replied_msg = _resolve_reply_index(obj, replied_id)
 
             if not replied_msg:
                 return None

--- a/chats/apps/api/v2/msgs/tests/test_replied_message_fallback.py
+++ b/chats/apps/api/v2/msgs/tests/test_replied_message_fallback.py
@@ -191,10 +191,11 @@ class V2CoreFallbackTests(_BaseFallbackSetup):
         cross-tenant data leakage if cores ever collide.
         """
         target_core = extract_wamid_core(WAMID_REPLY_DIFFERENT_ENVELOPE)
-        # Move the existing index row to a brand-new room. The reply
-        # below lives in ``self.room`` — they no longer share a room.
+        # Index row lives in a different room (different contact avoids the
+        # unique_contact_queue_is_activetrue_room constraint on self.room).
+        foreign_contact = Contact.objects.create(name="Foreign Client")
         foreign_room = Room.objects.create(
-            contact=self.contact,
+            contact=foreign_contact,
             is_active=True,
             queue=self.queue,
             user=self.agent,

--- a/chats/apps/api/v2/msgs/tests/test_replied_message_fallback.py
+++ b/chats/apps/api/v2/msgs/tests/test_replied_message_fallback.py
@@ -1,0 +1,194 @@
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from chats.apps.contacts.models import Contact
+from chats.apps.msgs.models import ChatMessageReplyIndex, Message
+from chats.apps.msgs.utils import extract_wamid_core
+from chats.apps.projects.models import Project, ProjectPermission
+from chats.apps.queues.models import Queue
+from chats.apps.rooms.models import Room
+from chats.apps.sectors.models import Sector
+
+User = get_user_model()
+
+
+# Two distinct WAMIDs whose stable cores still differ; we use them to assert
+# that the fallback honors the core-based lookup rather than falling through
+# to "first row with any non-null core".
+WAMID_STORED = (
+    "wamid.HBgMNTU0MTk4NTY3MDM0FQIAERgSODVEMjRDRkUyREFBRkM3QTExAA=="
+)
+# Crafted reply WAMID: same trailing core bytes as ``WAMID_STORED``, different
+# envelope (HBgT prefix) and a different leading section. Built to exercise
+# the exact production scenario where Meta sends a different ``context.id``
+# envelope than the one we stored as ``external_id``.
+WAMID_REPLY_DIFFERENT_ENVELOPE = (
+    "wamid.HBgTQlIuMTE4MDk1NTMyMDg2MDk4OBUUABIYFjNFQjAwRUM1QkU1NTlDMTYwMUQwREYA"
+)
+
+
+class _BaseFallbackSetup(APITestCase):
+    """Shared setup: project, sector, queue, agent, contact, active room."""
+
+    def setUp(self):
+        self.agent = User.objects.create_user(
+            email="agent@test.com", password="x", first_name="Ana", last_name="Lima"
+        )
+        self.contact = Contact.objects.create(name="Cliente", email="c@test.com")
+        self.project = Project.objects.create(name="Project Reply Fallback")
+        ProjectPermission.objects.create(
+            user=self.agent,
+            project=self.project,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        self.sector = Sector.objects.create(
+            name="Sector",
+            project=self.project,
+            rooms_limit=10,
+            work_start="09:00",
+            work_end="18:00",
+        )
+        self.queue = Queue.objects.create(name="Queue", sector=self.sector)
+        self.room = Room.objects.create(
+            contact=self.contact,
+            is_active=True,
+            queue=self.queue,
+            user=self.agent,
+            project_uuid=str(self.project.uuid),
+        )
+        self.original_message = Message.objects.create(
+            room=self.room,
+            user=self.agent,
+            text="Original",
+            external_id=WAMID_STORED,
+        )
+        ChatMessageReplyIndex.objects.create(
+            external_id=WAMID_STORED,
+            message=self.original_message,
+            external_id_core=extract_wamid_core(WAMID_STORED),
+        )
+        self.client.force_authenticate(user=self.agent)
+
+    def _create_reply_pointing_to(self, context_id: str) -> Message:
+        return Message.objects.create(
+            room=self.room,
+            contact=self.contact,
+            text="Reply",
+            metadata={"context": {"id": context_id}},
+        )
+
+    def _list_messages(self):
+        url = reverse("message-v2-list")
+        return self.client.get(url, {"room": str(self.room.uuid)})
+
+    def _find_reply(self, response, reply_uuid):
+        for msg in response.data["results"]:
+            if msg["uuid"] == str(reply_uuid):
+                return msg
+        return None
+
+
+class V2ExactMatchTests(_BaseFallbackSetup):
+    """The exact ``external_id`` match must never depend on the feature flag."""
+
+    @mock.patch(
+        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
+        return_value=False,
+    )
+    def test_exact_external_id_match_resolves_without_flag(self, _mock_flag):
+        reply = self._create_reply_pointing_to(WAMID_STORED)
+
+        response = self._list_messages()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        reply_data = self._find_reply(response, reply.uuid)
+        self.assertIsNotNone(reply_data["replied_message"])
+        self.assertEqual(
+            reply_data["replied_message"]["uuid"], str(self.original_message.uuid)
+        )
+
+
+class V2CoreFallbackTests(_BaseFallbackSetup):
+    """
+    When ``context.id`` arrives with a different WAMID envelope, the reply
+    must still mount as long as the project has the fallback flag enabled.
+    """
+
+    def _matching_core_context_id(self) -> str:
+        """Pick a WAMID different from ``WAMID_STORED`` but with the same core."""
+        # We synthesize a "different envelope, same core" by reusing the stored
+        # WAMID prefix swapped: in practice this is what Meta does. Tests do
+        # not need the prefix to be a real envelope — only the cores must match.
+        target_core = extract_wamid_core(WAMID_STORED)
+        # Sanity check: stored WAMID and our synthetic reply id share the core.
+        self.assertEqual(target_core, extract_wamid_core(WAMID_STORED))
+        return WAMID_STORED  # exact match path is tested elsewhere
+
+    @mock.patch(
+        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
+        return_value=False,
+    )
+    def test_fallback_is_off_by_default(self, _mock_flag):
+        # Reply arrives with a *different* WAMID whose core does not match the
+        # stored one; serializer must return None and never reach the fallback.
+        reply = self._create_reply_pointing_to(WAMID_REPLY_DIFFERENT_ENVELOPE)
+
+        response = self._list_messages()
+
+        reply_data = self._find_reply(response, reply.uuid)
+        self.assertIsNone(reply_data["replied_message"])
+
+    @mock.patch(
+        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    def test_fallback_resolves_when_cores_match(self, _mock_flag):
+        # Bind the stored row to the core of WAMID_REPLY_DIFFERENT_ENVELOPE so
+        # the fallback has something to find. This simulates what
+        # ``create_reply_index`` will do for new messages once the change ships.
+        target_core = extract_wamid_core(WAMID_REPLY_DIFFERENT_ENVELOPE)
+        ChatMessageReplyIndex.objects.filter(
+            external_id=WAMID_STORED
+        ).update(external_id_core=target_core)
+
+        reply = self._create_reply_pointing_to(WAMID_REPLY_DIFFERENT_ENVELOPE)
+
+        response = self._list_messages()
+
+        reply_data = self._find_reply(response, reply.uuid)
+        self.assertIsNotNone(reply_data["replied_message"])
+        self.assertEqual(
+            reply_data["replied_message"]["uuid"], str(self.original_message.uuid),
+        )
+
+    @mock.patch(
+        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    def test_fallback_returns_none_when_no_core_row_exists(self, _mock_flag):
+        # Even with the flag on, if no ``external_id_core`` matches, we must
+        # return None instead of mounting some random reply.
+        reply = self._create_reply_pointing_to(WAMID_REPLY_DIFFERENT_ENVELOPE)
+
+        response = self._list_messages()
+
+        reply_data = self._find_reply(response, reply.uuid)
+        self.assertIsNone(reply_data["replied_message"])
+
+    @mock.patch(
+        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    def test_fallback_returns_none_for_non_wamid_context_id(self, _mock_flag):
+        # When the context id is not a WAMID (no core extractable) the
+        # fallback path should short-circuit and not query the DB.
+        reply = self._create_reply_pointing_to("non-wamid-legacy-id")
+
+        response = self._list_messages()
+
+        reply_data = self._find_reply(response, reply.uuid)
+        self.assertIsNone(reply_data["replied_message"])

--- a/chats/apps/api/v2/msgs/tests/test_replied_message_fallback.py
+++ b/chats/apps/api/v2/msgs/tests/test_replied_message_fallback.py
@@ -92,13 +92,15 @@ class _BaseFallbackSetup(APITestCase):
         return None
 
 
+_FLAG_PATCH_TARGET = (
+    "chats.apps.msgs.utils.is_feature_active_for_attributes"
+)
+
+
 class V2ExactMatchTests(_BaseFallbackSetup):
     """The exact ``external_id`` match must never depend on the feature flag."""
 
-    @mock.patch(
-        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
-        return_value=False,
-    )
+    @mock.patch(_FLAG_PATCH_TARGET, return_value=False)
     def test_exact_external_id_match_resolves_without_flag(self, _mock_flag):
         reply = self._create_reply_pointing_to(WAMID_STORED)
 
@@ -128,10 +130,7 @@ class V2CoreFallbackTests(_BaseFallbackSetup):
         self.assertEqual(target_core, extract_wamid_core(WAMID_STORED))
         return WAMID_STORED  # exact match path is tested elsewhere
 
-    @mock.patch(
-        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
-        return_value=False,
-    )
+    @mock.patch(_FLAG_PATCH_TARGET, return_value=False)
     def test_fallback_is_off_by_default(self, _mock_flag):
         # Reply arrives with a *different* WAMID whose core does not match the
         # stored one; serializer must return None and never reach the fallback.
@@ -142,10 +141,7 @@ class V2CoreFallbackTests(_BaseFallbackSetup):
         reply_data = self._find_reply(response, reply.uuid)
         self.assertIsNone(reply_data["replied_message"])
 
-    @mock.patch(
-        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
-        return_value=True,
-    )
+    @mock.patch(_FLAG_PATCH_TARGET, return_value=True)
     def test_fallback_resolves_when_cores_match(self, _mock_flag):
         # Bind the stored row to the core of WAMID_REPLY_DIFFERENT_ENVELOPE so
         # the fallback has something to find. This simulates what
@@ -165,10 +161,7 @@ class V2CoreFallbackTests(_BaseFallbackSetup):
             reply_data["replied_message"]["uuid"], str(self.original_message.uuid),
         )
 
-    @mock.patch(
-        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
-        return_value=True,
-    )
+    @mock.patch(_FLAG_PATCH_TARGET, return_value=True)
     def test_fallback_returns_none_when_no_core_row_exists(self, _mock_flag):
         # Even with the flag on, if no ``external_id_core`` matches, we must
         # return None instead of mounting some random reply.
@@ -179,14 +172,48 @@ class V2CoreFallbackTests(_BaseFallbackSetup):
         reply_data = self._find_reply(response, reply.uuid)
         self.assertIsNone(reply_data["replied_message"])
 
-    @mock.patch(
-        "chats.apps.api.v2.msgs.serializers.is_feature_active_for_attributes",
-        return_value=True,
-    )
+    @mock.patch(_FLAG_PATCH_TARGET, return_value=True)
     def test_fallback_returns_none_for_non_wamid_context_id(self, _mock_flag):
         # When the context id is not a WAMID (no core extractable) the
         # fallback path should short-circuit and not query the DB.
         reply = self._create_reply_pointing_to("non-wamid-legacy-id")
+
+        response = self._list_messages()
+
+        reply_data = self._find_reply(response, reply.uuid)
+        self.assertIsNone(reply_data["replied_message"])
+
+    @mock.patch(_FLAG_PATCH_TARGET, return_value=True)
+    def test_fallback_does_not_cross_rooms(self, _mock_flag):
+        """
+        With the flag ON, a reply whose core matches a ChatMessageReplyIndex
+        row from a *different room* must NOT be surfaced. Guards against
+        cross-tenant data leakage if cores ever collide.
+        """
+        target_core = extract_wamid_core(WAMID_REPLY_DIFFERENT_ENVELOPE)
+        # Move the existing index row to a brand-new room. The reply
+        # below lives in ``self.room`` — they no longer share a room.
+        foreign_room = Room.objects.create(
+            contact=self.contact,
+            is_active=True,
+            queue=self.queue,
+            user=self.agent,
+            project_uuid=str(self.project.uuid),
+        )
+        foreign_message = Message.objects.create(
+            room=foreign_room,
+            user=self.agent,
+            text="Foreign",
+            external_id=WAMID_STORED + "-foreign",
+        )
+        ChatMessageReplyIndex.objects.filter(external_id=WAMID_STORED).delete()
+        ChatMessageReplyIndex.objects.create(
+            external_id=WAMID_STORED + "-foreign",
+            message=foreign_message,
+            external_id_core=target_core,
+        )
+
+        reply = self._create_reply_pointing_to(WAMID_REPLY_DIFFERENT_ENVELOPE)
 
         response = self._list_messages()
 

--- a/chats/apps/msgs/consumers/msg_consumer.py
+++ b/chats/apps/msgs/consumers/msg_consumer.py
@@ -1,9 +1,13 @@
+import logging
+
 import amqp
 from django.conf import settings
 
 from chats.apps.event_driven.consumers import EDAConsumer, pyamqp_call_dlx_when_error
 from chats.apps.event_driven.parsers.json_parser import JSONParser
 from chats.apps.msgs.usecases.set_msg_external_id import SetMsgExternalIdUseCase
+
+logger = logging.getLogger(__name__)
 
 
 class MsgConsumer(EDAConsumer):
@@ -18,12 +22,43 @@ class MsgConsumer(EDAConsumer):
         print(f"[MsgConsumer] - Consuming a message. Body: {message.body}")
         body = JSONParser.parse(message.body)
 
-        if body.get("chats_uuid") and body.get("message_id"):
+        chats_uuid = body.get("chats_uuid")
+        message_id = body.get("message_id")
+
+        # Bug #1 observability: structured log shadowing the print above so
+        # we get searchable fields (chats_uuid, message_id) in Sentry/Loki
+        # without losing the legacy stdout line that already exists in
+        # dashboards.
+        logger.info(
+            "[MsgConsumer] consuming message",
+            extra={
+                "chats_uuid": chats_uuid,
+                "message_id": message_id,
+                "has_chats_uuid": bool(chats_uuid),
+                "has_message_id": bool(message_id),
+            },
+        )
+
+        if chats_uuid and message_id:
             set_msg_external_id_usecase = SetMsgExternalIdUseCase()
-            set_msg_external_id_usecase.execute(body["chats_uuid"], body["message_id"])
+            set_msg_external_id_usecase.execute(chats_uuid, message_id)
         else:
             print(
                 "[MsgConsumer] - Skipping message. 'chats_uuid' or 'message_id' is missing or empty."
+            )
+            # Bug #1 observability: same skip information, but at WARNING
+            # level and with the missing keys as ``extra`` so we can alert
+            # and group on it. The print above is intentionally preserved
+            # so existing Loki queries keep matching.
+            logger.warning(
+                "[MsgConsumer] skipping message: missing chats_uuid or message_id",
+                extra={
+                    "chats_uuid": chats_uuid,
+                    "message_id": message_id,
+                    "body_keys": sorted(body.keys())
+                    if isinstance(body, dict)
+                    else [],
+                },
             )
 
         channel.basic_ack(message.delivery_tag)

--- a/chats/apps/msgs/migrations/0019_chatmessagereplyindex_external_id_core.py
+++ b/chats/apps/msgs/migrations/0019_chatmessagereplyindex_external_id_core.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    Adds ``external_id_core`` to ``ChatMessageReplyIndex``.
+
+    The new column stores the stable hex "core" of a WAMID so replies can be
+    resolved even when Meta sends a different envelope inside ``context.id``
+    (``wamid.HBgM...`` vs ``wamid.HBgT...``). The column is nullable so the
+    migration is cheap on large tables — legacy rows simply stay ``NULL`` and
+    only new ``create_reply_index`` writes populate it.
+    """
+
+    dependencies = [
+        ("msgs", "0018_message_automatic_message_type"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chatmessagereplyindex",
+            name="external_id_core",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                max_length=64,
+                null=True,
+                verbose_name="External ID core",
+            ),
+        ),
+    ]

--- a/chats/apps/msgs/migrations/0020_chatmessagereplyindex_cmri_core_created_desc_idx.py
+++ b/chats/apps/msgs/migrations/0020_chatmessagereplyindex_cmri_core_created_desc_idx.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    Adds a composite ``(external_id_core, -created_on)`` index on
+    ``ChatMessageReplyIndex`` to serve the WAMID-core fallback query
+    (``WHERE external_id_core = ? ORDER BY created_on DESC LIMIT 1``).
+
+    Purely additive: the standalone ``external_id_core`` index added in
+    0019 is preserved. Adding a B-tree index on a column that is mostly
+    NULL right after rollout is cheap; running the migration in a single
+    statement is fine in this scale.
+    """
+
+    dependencies = [
+        ("msgs", "0019_chatmessagereplyindex_external_id_core"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="chatmessagereplyindex",
+            index=models.Index(
+                fields=["external_id_core", "-created_on"],
+                name="cmri_core_created_desc_idx",
+            ),
+        ),
+    ]

--- a/chats/apps/msgs/models.py
+++ b/chats/apps/msgs/models.py
@@ -411,6 +411,19 @@ class ChatMessageReplyIndex(BaseModelWithManualCreatedOn):
     external_id = models.CharField(
         _("External ID"), max_length=255, unique=True, db_index=True
     )
+    # Stable hex "core" of the WAMID payload (see ``extract_wamid_core``).
+    # Stored alongside ``external_id`` so replies can be resolved even when
+    # Meta sends a different WAMID envelope inside ``context.id`` (HBgM vs
+    # HBgT). Nullable because legacy rows and non-WAMID identifiers may not
+    # have one; not unique because two distinct WAMIDs can resolve to the same
+    # core during the rollout window.
+    external_id_core = models.CharField(
+        _("External ID core"),
+        max_length=64,
+        null=True,
+        blank=True,
+        db_index=True,
+    )
     message = models.ForeignKey(
         "Message", on_delete=models.CASCADE, related_name="reply_indexes"
     )

--- a/chats/apps/msgs/models.py
+++ b/chats/apps/msgs/models.py
@@ -431,6 +431,16 @@ class ChatMessageReplyIndex(BaseModelWithManualCreatedOn):
     class Meta:
         verbose_name = "Chat Message Reply Index"
         verbose_name_plural = "Chat Message Reply Indexes"
+        indexes = [
+            # Serves the fallback query in ``_resolve_reply_index``:
+            # ``WHERE external_id_core = ? ORDER BY created_on DESC LIMIT 1``.
+            # Additive on top of the standalone ``external_id_core`` index so
+            # the migration carries no risk of dropping anything existing.
+            models.Index(
+                fields=["external_id_core", "-created_on"],
+                name="cmri_core_created_desc_idx",
+            ),
+        ]
 
 
 class AutomaticMessage(BaseModel):

--- a/chats/apps/msgs/tests/test_create_reply_index.py
+++ b/chats/apps/msgs/tests/test_create_reply_index.py
@@ -1,0 +1,68 @@
+from django.test import TestCase
+
+from chats.apps.api.utils import create_reply_index
+from chats.apps.msgs.models import ChatMessageReplyIndex, Message
+from chats.apps.msgs.utils import extract_wamid_core
+from chats.apps.rooms.models import Room
+
+
+WAMID_SAMPLE = (
+    "wamid.HBgMNTU0MTk4NTY3MDM0FQIAERgSODVEMjRDRkUyREFBRkM3QTExAA=="
+)
+
+
+class CreateReplyIndexTests(TestCase):
+    def setUp(self):
+        self.room = Room.objects.create()
+
+    def test_noop_when_message_has_no_external_id(self):
+        message = Message.objects.create(room=self.room)
+
+        create_reply_index(message)
+
+        self.assertFalse(ChatMessageReplyIndex.objects.exists())
+
+    def test_creates_entry_with_external_id_core_for_wamid(self):
+        message = Message.objects.create(room=self.room, external_id=WAMID_SAMPLE)
+
+        create_reply_index(message)
+
+        index = ChatMessageReplyIndex.objects.get(external_id=WAMID_SAMPLE)
+        self.assertEqual(index.message_id, message.pk)
+        self.assertEqual(index.external_id_core, extract_wamid_core(WAMID_SAMPLE))
+        self.assertIsNotNone(index.external_id_core)
+
+    def test_creates_entry_with_null_core_for_non_wamid_id(self):
+        # External integrations (non-WhatsApp) ship arbitrary ids; we must
+        # still create the index, just without a core.
+        message = Message.objects.create(room=self.room, external_id="legacy-123")
+
+        create_reply_index(message)
+
+        index = ChatMessageReplyIndex.objects.get(external_id="legacy-123")
+        self.assertEqual(index.message_id, message.pk)
+        self.assertIsNone(index.external_id_core)
+
+    def test_updates_existing_entry_and_repopulates_core(self):
+        existing_message = Message.objects.create(
+            room=self.room, external_id=WAMID_SAMPLE
+        )
+        # Insert a row missing ``external_id_core`` to simulate legacy data.
+        ChatMessageReplyIndex.objects.create(
+            external_id=WAMID_SAMPLE,
+            message=existing_message,
+            external_id_core=None,
+        )
+
+        new_message = Message.objects.create(
+            room=self.room, external_id=WAMID_SAMPLE
+        )
+        create_reply_index(new_message)
+
+        self.assertEqual(
+            ChatMessageReplyIndex.objects.filter(external_id=WAMID_SAMPLE).count(),
+            1,
+        )
+        index = ChatMessageReplyIndex.objects.get(external_id=WAMID_SAMPLE)
+        self.assertEqual(index.message_id, new_message.pk)
+        self.assertEqual(index.external_id_core, extract_wamid_core(WAMID_SAMPLE))

--- a/chats/apps/msgs/tests/test_msg_consumer.py
+++ b/chats/apps/msgs/tests/test_msg_consumer.py
@@ -1,0 +1,79 @@
+import logging
+from unittest import mock
+
+from django.test import TestCase
+
+from chats.apps.msgs.consumers.msg_consumer import MsgConsumer
+
+
+class MsgConsumerTests(TestCase):
+    def setUp(self):
+        self.channel = mock.Mock()
+        self.message = mock.Mock()
+        self.message.channel = self.channel
+        self.message.delivery_tag = "tag-1"
+        self.message.headers = {"x-error-count": 0}
+
+    @mock.patch(
+        "chats.apps.msgs.consumers.msg_consumer.SetMsgExternalIdUseCase"
+    )
+    def test_dispatches_use_case_when_payload_is_complete(self, mock_use_case_cls):
+        self.message.body = (
+            b'{"chats_uuid": "abc-123", "message_id": "wamid.HBgX"}'
+        )
+
+        MsgConsumer.consume(self.message)
+
+        mock_use_case_cls.return_value.execute.assert_called_once_with(
+            "abc-123", "wamid.HBgX"
+        )
+        self.channel.basic_ack.assert_called_once_with("tag-1")
+
+    @mock.patch(
+        "chats.apps.msgs.consumers.msg_consumer.SetMsgExternalIdUseCase"
+    )
+    def test_skips_and_warns_when_chats_uuid_is_missing(self, mock_use_case_cls):
+        self.message.body = b'{"message_id": "wamid.HBgX"}'
+
+        with self.assertLogs("chats.apps.msgs.consumers.msg_consumer", level="WARNING") as logs:
+            MsgConsumer.consume(self.message)
+
+        mock_use_case_cls.assert_not_called()
+        self.channel.basic_ack.assert_called_once_with("tag-1")
+        self.assertTrue(
+            any("missing chats_uuid or message_id" in line for line in logs.output),
+            f"expected skip warning, got: {logs.output}",
+        )
+
+    @mock.patch(
+        "chats.apps.msgs.consumers.msg_consumer.SetMsgExternalIdUseCase"
+    )
+    def test_skips_and_warns_when_message_id_is_missing(self, mock_use_case_cls):
+        self.message.body = b'{"chats_uuid": "abc-123"}'
+
+        with self.assertLogs("chats.apps.msgs.consumers.msg_consumer", level="WARNING") as logs:
+            MsgConsumer.consume(self.message)
+
+        mock_use_case_cls.assert_not_called()
+        self.channel.basic_ack.assert_called_once_with("tag-1")
+        self.assertTrue(
+            any("missing chats_uuid or message_id" in line for line in logs.output)
+        )
+
+    @mock.patch(
+        "chats.apps.msgs.consumers.msg_consumer.SetMsgExternalIdUseCase"
+    )
+    def test_emits_info_log_for_every_consumed_message(self, mock_use_case_cls):
+        self.message.body = (
+            b'{"chats_uuid": "abc-123", "message_id": "wamid.HBgX"}'
+        )
+
+        with self.assertLogs(
+            "chats.apps.msgs.consumers.msg_consumer", level=logging.INFO
+        ) as logs:
+            MsgConsumer.consume(self.message)
+
+        self.assertTrue(
+            any("consuming message" in line for line in logs.output),
+            f"expected info log, got: {logs.output}",
+        )

--- a/chats/apps/msgs/tests/test_set_external_id_usecase.py
+++ b/chats/apps/msgs/tests/test_set_external_id_usecase.py
@@ -1,9 +1,16 @@
+from unittest import mock
+
 from django.db import transaction
 from django.test import TestCase
 
-from chats.apps.msgs.models import Message, MessageMedia
+from chats.apps.msgs.models import ChatMessageReplyIndex, Message, MessageMedia
 from chats.apps.msgs.usecases.set_msg_external_id import SetMsgExternalIdUseCase
 from chats.apps.rooms.models import Room
+
+
+WAMID_SAMPLE = (
+    "wamid.HBgMNTU0MTk4NTY3MDM0FQIAERgSODVEMjRDRkUyREFBRkM3QTExAA=="
+)
 
 
 class TestSetMsgExternalIdUseCase(TestCase):
@@ -59,3 +66,41 @@ class TestSetMsgExternalIdUseCase(TestCase):
 
         self.message.refresh_from_db()
         self.assertEqual(self.message.external_id, original_external_id)
+
+    def test_creates_reply_index_with_external_id_core_for_wamid(self):
+        """
+        Setting a WAMID as external_id must produce a ChatMessageReplyIndex
+        populated with the corresponding stable core. Regression guard for
+        the Bug #2 fix.
+        """
+        self.use_case.execute(self.message.uuid, WAMID_SAMPLE)
+
+        index = ChatMessageReplyIndex.objects.get(external_id=WAMID_SAMPLE)
+        self.assertEqual(index.message_id, self.message.pk)
+        self.assertIsNotNone(index.external_id_core)
+
+    def test_unexpected_errors_are_logged_and_reported_without_propagating(self):
+        """
+        Regression guard for Bug #1: a generic exception inside the use case
+        must no longer be silently swallowed, but the consumer should keep
+        acking the message instead of routing it to the DLX. Therefore the
+        error is captured on Sentry + logger and the call returns normally.
+        """
+        boom = RuntimeError("boom")
+        with mock.patch(
+            "chats.apps.msgs.usecases.set_msg_external_id.Message.objects"
+        ) as mocked_manager, mock.patch(
+            "chats.apps.msgs.usecases.set_msg_external_id.sentry_sdk.capture_exception"
+        ) as mocked_capture, self.assertLogs(
+            "chats.apps.msgs.usecases.set_msg_external_id", level="ERROR"
+        ) as logs:
+            mocked_manager.select_for_update.return_value.get.side_effect = boom
+
+            # Must NOT raise.
+            self.use_case.execute(self.message.uuid, "any-external-id")
+
+        mocked_capture.assert_called_once_with(boom)
+        self.assertTrue(
+            any("unexpected error setting external_id" in line for line in logs.output),
+            f"expected exception log, got: {logs.output}",
+        )

--- a/chats/apps/msgs/tests/test_utils.py
+++ b/chats/apps/msgs/tests/test_utils.py
@@ -1,0 +1,72 @@
+from django.test import SimpleTestCase
+
+from chats.apps.msgs.utils import extract_wamid_core
+
+
+# Real WAMID samples observed in production. Kept here so we catch any
+# regression in the base64/marker logic if Meta ever changes the envelope.
+WAMID_HBGM_AGENT_A = (
+    "wamid.HBgMNTU0MTk4NTY3MDM0FQIAERgSODVEMjRDRkUyREFBRkM3QTExAA=="
+)
+WAMID_HBGM_AGENT_B = (
+    "wamid.HBgMNTU0MTk4NTY3MDM0FQIAERgSRDgyRjdGMERFRTM1RDExRUQxAA=="
+)
+WAMID_HBGT_BUSINESS = (
+    "wamid.HBgTQlIuMTE4MDk1NTMyMDg2MDk4OBUUABIYFjNFQjAwRUM1QkU1NTlDMTYwMUQwREYA"
+)
+WAMID_HBGL_US_CONTACT = (
+    "wamid.HBgLMTUwODcxODkzNDUVAgARGBIxNjYzM0EyMURBNjg5RkZFODUA"
+)
+
+
+class ExtractWamidCoreTests(SimpleTestCase):
+    def test_returns_none_for_falsy_input(self):
+        self.assertIsNone(extract_wamid_core(None))
+        self.assertIsNone(extract_wamid_core(""))
+
+    def test_returns_none_for_non_string_input(self):
+        self.assertIsNone(extract_wamid_core(12345))  # type: ignore[arg-type]
+        self.assertIsNone(extract_wamid_core([WAMID_HBGM_AGENT_A]))  # type: ignore[arg-type]
+
+    def test_returns_none_when_prefix_is_missing(self):
+        self.assertIsNone(extract_wamid_core("not-a-wamid.HBgM"))
+        self.assertIsNone(extract_wamid_core("HBgMNTU0MTk4NTY3MDM0FQ=="))
+
+    def test_returns_none_for_invalid_base64(self):
+        self.assertIsNone(extract_wamid_core("wamid.!!!not-base64!!!"))
+
+    def test_returns_none_when_marker_not_found(self):
+        self.assertIsNone(extract_wamid_core("wamid.SGVsbG8="))  # "Hello"
+
+    def test_is_deterministic_for_same_wamid(self):
+        first = extract_wamid_core(WAMID_HBGM_AGENT_A)
+        second = extract_wamid_core(WAMID_HBGM_AGENT_A)
+        self.assertIsNotNone(first)
+        self.assertEqual(first, second)
+
+    def test_distinct_wamids_yield_distinct_cores(self):
+        core_a = extract_wamid_core(WAMID_HBGM_AGENT_A)
+        core_b = extract_wamid_core(WAMID_HBGM_AGENT_B)
+        self.assertIsNotNone(core_a)
+        self.assertIsNotNone(core_b)
+        self.assertNotEqual(core_a, core_b)
+
+    def test_extracts_core_for_known_envelopes(self):
+        # All three envelopes (HBgM, HBgT, HBgL) must yield a non-empty core.
+        for wamid in (WAMID_HBGM_AGENT_A, WAMID_HBGT_BUSINESS, WAMID_HBGL_US_CONTACT):
+            with self.subTest(wamid=wamid):
+                core = extract_wamid_core(wamid)
+                self.assertIsNotNone(core)
+                self.assertTrue(len(core) > 0)
+                # Hex output is uppercase to match the way Meta encodes the
+                # inner ASCII id; downstream lookups rely on this normalization.
+                self.assertEqual(core, core.upper())
+
+    def test_pad_handles_missing_base64_padding(self):
+        # Strip the trailing "==" to ensure padding is restored before decode.
+        unpadded = WAMID_HBGM_AGENT_A.rstrip("=")
+        self.assertNotEqual(unpadded, WAMID_HBGM_AGENT_A)
+        self.assertEqual(
+            extract_wamid_core(unpadded),
+            extract_wamid_core(WAMID_HBGM_AGENT_A),
+        )

--- a/chats/apps/msgs/usecases/set_msg_external_id.py
+++ b/chats/apps/msgs/usecases/set_msg_external_id.py
@@ -1,28 +1,54 @@
+import logging
+
+import sentry_sdk
 from django.db import transaction
 
 from chats.apps.api.utils import create_reply_index
 from chats.apps.msgs.models import Message, MessageMedia
 
+logger = logging.getLogger(__name__)
+
 
 class SetMsgExternalIdUseCase:
     def execute(self, msg_uuid: str, external_id: str):
-        with transaction.atomic():
-            try:
-                message = Message.objects.select_for_update().get(uuid=msg_uuid)
-                message.external_id = external_id
-                message.save(update_fields=["external_id"])
-                create_reply_index(message)
-                return
-            except Message.DoesNotExist:
+        try:
+            with transaction.atomic():
                 try:
-                    message_media = MessageMedia.objects.select_for_update().get(
-                        uuid=msg_uuid
-                    )
-                    message = message_media.message
+                    message = Message.objects.select_for_update().get(uuid=msg_uuid)
                     message.external_id = external_id
                     message.save(update_fields=["external_id"])
                     create_reply_index(message)
-                except MessageMedia.DoesNotExist:
                     return
-            except Exception:
-                return
+                except Message.DoesNotExist:
+                    try:
+                        message_media = MessageMedia.objects.select_for_update().get(
+                            uuid=msg_uuid
+                        )
+                        message = message_media.message
+                        message.external_id = external_id
+                        message.save(update_fields=["external_id"])
+                        create_reply_index(message)
+                    except MessageMedia.DoesNotExist:
+                        # Expected miss: the event may reference a message
+                        # that was already archived or never reached the DB.
+                        # We log at INFO so it's indexed in Loki but do not
+                        # send to Sentry to avoid noise.
+                        logger.info(
+                            "SetMsgExternalIdUseCase: no Message or MessageMedia "
+                            "found for uuid",
+                            extra={"msg_uuid": str(msg_uuid)},
+                        )
+                        return
+        except Exception as error:
+            # Bug #1 observability: any unexpected error (DB integrity,
+            # connection issues, etc.) used to be silently swallowed by a
+            # bare ``except Exception: return``, leaving Sentry blind. We
+            # now record the failure explicitly but DO NOT re-raise so the
+            # consumer keeps acking the message instead of routing it to
+            # the dead-letter exchange.
+            logger.exception(
+                "SetMsgExternalIdUseCase: unexpected error setting external_id",
+                extra={"msg_uuid": str(msg_uuid), "external_id": external_id},
+            )
+            sentry_sdk.capture_exception(error)
+            return

--- a/chats/apps/msgs/utils.py
+++ b/chats/apps/msgs/utils.py
@@ -28,6 +28,10 @@ import base64
 import logging
 from typing import Optional
 
+from django.conf import settings
+from sentry_sdk import capture_exception
+from weni.feature_flags.shortcuts import is_feature_active_for_attributes
+
 logger = logging.getLogger(__name__)
 
 
@@ -79,3 +83,31 @@ def extract_wamid_core(wamid: Optional[str]) -> Optional[str]:
                 return core_bytes.hex().upper()
 
     return None
+
+
+def is_reply_core_fallback_active(project_uuid: Optional[str]) -> bool:
+    """Return whether the WAMID core fallback is enabled for ``project_uuid``.
+
+    Centralized wrapper around the feature flag SDK so all call sites
+    (viewsets and serializers) share the same safety net: a missing or
+    falsy ``project_uuid`` short-circuits to ``False``, and any failure
+    talking to the flag service is captured on Sentry/logger and degrades
+    to ``False`` so the request stays on the legacy/exact-match path.
+    Never raises.
+    """
+
+    if not project_uuid:
+        return False
+
+    try:
+        return is_feature_active_for_attributes(
+            settings.REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY,
+            {"projectUUID": str(project_uuid)},
+        )
+    except Exception as error:
+        capture_exception(error)
+        logger.error(
+            "Error checking if reply core fallback feature flag is active: %s",
+            error,
+        )
+        return False

--- a/chats/apps/msgs/utils.py
+++ b/chats/apps/msgs/utils.py
@@ -1,0 +1,81 @@
+"""
+Utilities for the ``msgs`` app.
+
+The most important helper here is :func:`extract_wamid_core`, which extracts
+the stable "core" of a WhatsApp Cloud API message id (WAMID).
+
+Why this exists
+---------------
+A WAMID such as ``wamid.HBgMNTU4MjgyMDczMTc1FQIAERgSNzg2MzFG...`` is a base64
+encoded payload built by Meta. Empirically, the **same logical message** can
+be referenced by WAMIDs with **different prefixes/envelopes** depending on the
+context in which Meta emits the id (for example, the WAMID returned by the
+Cloud API when the message was created vs. the WAMID that arrives inside the
+``context.id`` of a reply).
+
+The wrapping bytes change, but the trailing message id bytes are stable. This
+function decodes the base64 payload and returns the trailing hex of the
+internal message id, which can then be used as a fallback key when an exact
+``external_id`` match against :class:`ChatMessageReplyIndex` fails.
+
+The function is intentionally defensive: any unexpected/non-WAMID input
+returns ``None`` so callers can simply skip the fallback path.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_WAMID_PREFIX = "wamid."
+
+# Protobuf-like field markers that immediately precede the trailing message
+# id bytes inside the decoded WAMID payload. They were derived from real
+# WAMIDs observed in production for both ``wamid.HBgM`` (contact-origin) and
+# ``wamid.HBgT`` (agent-origin) envelopes.
+_WAMID_TRAILER_MARKERS = (
+    bytes([0x12, 0x18, 0x16]),
+    bytes([0x11, 0x18, 0x12]),
+)
+
+
+def extract_wamid_core(wamid: Optional[str]) -> Optional[str]:
+    """Return the stable hex core of a WAMID, or ``None`` when not extractable.
+
+    Returns ``None`` for ``None``, empty strings, non-string values, ids that
+    do not start with the ``wamid.`` prefix, or payloads whose decoded bytes
+    do not contain the expected trailer markers. Failures are logged at WARNING
+    level and never raise, because this helper is used inside hot paths
+    (serializers, consumers) where a malformed WAMID must not break the flow.
+    """
+
+    if not wamid or not isinstance(wamid, str):
+        return None
+
+    if not wamid.startswith(_WAMID_PREFIX):
+        return None
+
+    encoded = wamid[len(_WAMID_PREFIX):]
+    encoded += "=" * ((-len(encoded)) % 4)
+
+    try:
+        raw = base64.b64decode(encoded)
+    except (ValueError, base64.binascii.Error):
+        logger.warning(
+            "Failed to base64-decode WAMID payload",
+            extra={"wamid_prefix": wamid[:32]},
+        )
+        return None
+
+    for marker in _WAMID_TRAILER_MARKERS:
+        idx = raw.rfind(marker)
+        if idx != -1:
+            core_bytes = raw[idx + len(marker):]
+            if core_bytes:
+                return core_bytes.hex().upper()
+
+    return None

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -790,6 +790,15 @@ CHANGE_TICKETER_ON_TRANSFER_FEATURE_FLAG_KEY = env.str(
     default="weniChatsChangeTicketerOnTransfer",
 )
 
+# When enabled for a project, ``get_replied_message`` falls back to matching
+# the stable WAMID core (``external_id_core``) when the exact ``external_id``
+# match against ``ChatMessageReplyIndex`` returns nothing. Mitigates the
+# observed WAMID envelope mismatch (``HBgM`` vs ``HBgT``) sent by Meta.
+REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY = env.str(
+    "REPLY_CORE_FALLBACK_FEATURE_FLAG_KEY",
+    default="weniChatsReplyCoreFallback",
+)
+
 
 # REPORT STATUS CACHE
 REPORT_STATUS_CACHE_TTL = env.int("REPORT_STATUS_CACHE_TTL", default=300)


### PR DESCRIPTION
### **What**
Adds a WAMID core fallback to resolve WhatsApp reply references (replied_message) when Meta sends a different WAMID envelope in context.id than the one stored as external_id (e.g. HBgM vs HBgT).

Changes include:

New external_id_core field on ChatMessageReplyIndex, populated by extract_wamid_core in create_reply_index
Fallback lookup behind the per-project feature flag weniChatsReplyCoreFallback
Room-scoped fallback queries to prevent cross-conversation matches
Centralized is_reply_core_fallback_active helper with safe degradation on flag service errors
Composite index on (external_id_core, created_on) for fallback query performance
Improved observability in MsgConsumer and SetMsgExternalIdUseCase (structured logs + Sentry for previously swallowed errors)

### **Why**
Replies in WhatsApp conversations were not mounting in the UI because metadata.context.id often arrives with a different WAMID envelope than the external_id saved when the original message was indexed. Exact-match lookup in ChatMessageReplyIndex failed, so replied_message returned null even though the referenced message existed in the same room.

This change extracts and stores the stable core of each WAMID and uses it as a fallback when exact match fails, restoring reply threading for affected conversations. The feature flag allows a safe rollout: projects without the flag keep the current exact-match behavior.