### PR TITLE
refactor: update permission check for internal communication

### DIFF
--- a/chats/apps/api/v1/internal/permissions.py
+++ b/chats/apps/api/v1/internal/permissions.py
@@ -22,7 +22,10 @@ class ModuleHasPermission(permissions.BasePermission):
             if cached_value == "true":
                 return True
 
-        has_perm = request.user.has_perm("accounts.can_communicate_internally")
+        has_perm = request.user.user_permissions.filter(
+            codename="can_communicate_internally",
+            content_type__app_label="accounts",
+        ).exists()
 
         if has_perm:
             redis_connection.set(cache_key, "true", self.cache_ttl)

--- a/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
+++ b/chats/apps/api/v1/internal/projects/tests/test_viewsets.py
@@ -62,6 +62,27 @@ class TestProjectViewSetAsAnonymousUser(BaseTestProjectViewSet):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
+class TestProjectViewSetAsSuperuser(BaseTestProjectViewSet):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.user = User.objects.create(
+            email="superuser@test.com", is_superuser=True
+        )
+        self.client.force_authenticate(self.user)
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_superuser_without_explicit_permission_is_denied(self):
+        response = self.retrieve(self.project.uuid)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_internal_auth
+    def test_superuser_with_explicit_permission_is_allowed(self):
+        response = self.retrieve(self.project.uuid)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
 class TestProjectViewSetAsAuthenticatedUser(BaseTestProjectViewSet):
     def setUp(self):
         self.project = Project.objects.create(name="Test Project")


### PR DESCRIPTION
### What

- Replaced `request.user.has_perm("accounts.can_communicate_internally")` with a direct `user_permissions.filter().exists()` query in `ModuleHasPermission`, bypassing Django's built-in superuser shortcut.
- Added tests verifying that a superuser without the explicit permission is denied (403), and that a superuser with the explicit permission is allowed (200).

### Why

Django's `PermissionsMixin.has_perm()` unconditionally returns `True` for any user with `is_superuser=True`, regardless of whether the permission is actually assigned. `ModuleHasPermission` is intended to restrict access exclusively to users that hold the `can_communicate_internally` permission — superuser status alone should not grant access to internal communication endpoints.