### PR TITLE
refactor: streamline flow template retrieval process

### DIFF
--- a/chats/apps/api/v1/projects/viewsets.py
+++ b/chats/apps/api/v1/projects/viewsets.py
@@ -49,10 +49,6 @@ from chats.apps.projects.models import (
     Project,
     ProjectPermission,
 )
-from chats.apps.projects.usecases.exceptions import (
-    FlowTemplateChannelsNotFound,
-    FlowTemplateNotFound,
-)
 from chats.apps.projects.usecases.flow_templates import GetFlowTemplatesDataUseCase
 from chats.apps.projects.usecases.integrate_ticketers import IntegratedTicketers
 from chats.apps.projects.usecases.status_service import InServiceStatusService
@@ -309,20 +305,7 @@ class ProjectViewset(
 
         project = self.get_object()
         usecase = GetFlowTemplatesDataUseCase(project.uuid)
-
-        try:
-            result = usecase.execute(flow_uuid)
-        except (FlowTemplateNotFound, FlowTemplateChannelsNotFound) as exc:
-            logger.warning(
-                "Flow templates retrieval failed: project=%s flow=%s error=%s",
-                project.uuid,
-                flow_uuid,
-                exc,
-            )
-            return Response(
-                {"detail": str(exc)},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+        result = usecase.execute(flow_uuid)
 
         templates = [
             {

--- a/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
+++ b/chats/apps/projects/tests/test_get_flow_templates_data_usecase.py
@@ -6,10 +6,6 @@ from django.test import TestCase
 
 from chats.apps.projects.models import Project
 from chats.apps.projects.dataclass import FlowTemplatesData
-from chats.apps.projects.usecases.exceptions import (
-    FlowTemplateChannelsNotFound,
-    FlowTemplateNotFound,
-)
 from chats.apps.projects.usecases.flow_templates import GetFlowTemplatesDataUseCase
 
 
@@ -260,10 +256,12 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
             name=self.template_name, uuid=self.template_uuid
         )
 
-    def test_execute_returns_only_first_valid_template(self):
+    def test_execute_returns_all_valid_templates(self):
         channel_uuid_1 = str(uuid.uuid4())
+        channel_uuid_2 = str(uuid.uuid4())
         template_uuid_1 = str(uuid.uuid4())
         template_uuid_2 = str(uuid.uuid4())
+        other_template_name = "other_template"
 
         definition = {
             "flows": [
@@ -301,7 +299,7 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
                                         "uuid": str(uuid.uuid4()),
                                         "template": {
                                             "uuid": template_uuid_2,
-                                            "name": "other_template",
+                                            "name": other_template_name,
                                         },
                                         "variables": [
                                             "@trigger.params.url",
@@ -316,17 +314,168 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         }
         self.mock_flows_client.retrieve_flow_definitions.return_value = definition
 
-        self.mock_flows_templates_usecase.execute.return_value = {
-            "uuid": template_uuid_1,
-            "name": self.template_name,
-            "translations": [
-                {
-                    "language": "por",
-                    "status": "approved",
-                    "channel": {"uuid": channel_uuid_1, "name": "Channel 1"},
+        def flows_templates_side_effect(name, uuid):
+            if uuid == template_uuid_1:
+                return {
+                    "uuid": template_uuid_1,
+                    "name": self.template_name,
+                    "translations": [
+                        {
+                            "language": "por",
+                            "status": "approved",
+                            "channel": {
+                                "uuid": channel_uuid_1,
+                                "name": "Channel 1",
+                            },
+                        }
+                    ],
                 }
-            ],
+            if uuid == template_uuid_2:
+                return {
+                    "uuid": template_uuid_2,
+                    "name": other_template_name,
+                    "translations": [
+                        {
+                            "language": "por",
+                            "status": "approved",
+                            "channel": {
+                                "uuid": channel_uuid_2,
+                                "name": "Channel 2",
+                            },
+                        }
+                    ],
+                }
+            return None
+
+        self.mock_flows_templates_usecase.execute.side_effect = (
+            flows_templates_side_effect
+        )
+
+        self.mock_channels_usecase.execute.return_value = [
+            self._make_project_channel(channel_uuid_1, self.waba_id),
+            self._make_project_channel(channel_uuid_2, self.waba_id),
+        ]
+
+        meta_template_1 = self._make_meta_template(
+            template_id="111", name=self.template_name
+        )
+        meta_template_2 = self._make_meta_template(
+            template_id="222", name=other_template_name
+        )
+        self.mock_meta_client.get_templates_list.side_effect = [
+            {"data": [meta_template_1]},
+            {"data": [meta_template_2]},
+        ]
+
+        result = self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.assertEqual(len(result.templates), 2)
+        self.assertEqual(result.templates[0].id, meta_template_1["id"])
+        self.assertEqual(result.templates[1].id, meta_template_2["id"])
+        self.assertEqual(self.mock_meta_client.get_templates_list.call_count, 2)
+        self.assertEqual(self.mock_flows_templates_usecase.execute.call_count, 2)
+
+    @patch("chats.apps.projects.usecases.flow_templates.logger")
+    def test_execute_skips_template_not_found_in_meta(self, mock_logger):
+        definition = self._make_definition_with_template(
+            self.template_uuid, self.template_name
+        )
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        self.mock_flows_templates_usecase.execute.return_value = (
+            self._make_flows_template_response(self.channel_uuid)
+        )
+
+        self.mock_channels_usecase.execute.return_value = [
+            self._make_project_channel(self.channel_uuid, self.waba_id)
+        ]
+
+        self.mock_meta_client.get_templates_list.return_value = {"data": []}
+
+        result = self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.assertEqual(result, FlowTemplatesData(uuid=self.flow_uuid, templates=[]))
+        mock_logger.warning.assert_called_once()
+
+    @patch("chats.apps.projects.usecases.flow_templates.logger")
+    def test_execute_skips_stale_template_and_returns_valid_ones(self, mock_logger):
+        channel_uuid_1 = str(uuid.uuid4())
+        template_uuid_1 = str(uuid.uuid4())
+        template_uuid_2 = str(uuid.uuid4())
+        stale_template_name = "lembrete_de_agendamento_06_2024"
+
+        definition = {
+            "flows": [
+                {
+                    "uuid": self.flow_uuid,
+                    "nodes": [
+                        {
+                            "uuid": str(uuid.uuid4()),
+                            "actions": [
+                                {
+                                    "type": "send_msg",
+                                    "uuid": str(uuid.uuid4()),
+                                    "text": "",
+                                    "templating": {
+                                        "uuid": str(uuid.uuid4()),
+                                        "template": {
+                                            "uuid": template_uuid_1,
+                                            "name": self.template_name,
+                                        },
+                                        "variables": [
+                                            "@trigger.params.contactname",
+                                        ],
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            "uuid": str(uuid.uuid4()),
+                            "actions": [
+                                {
+                                    "type": "send_msg",
+                                    "uuid": str(uuid.uuid4()),
+                                    "text": "",
+                                    "templating": {
+                                        "uuid": str(uuid.uuid4()),
+                                        "template": {
+                                            "uuid": template_uuid_2,
+                                            "name": stale_template_name,
+                                        },
+                                        "variables": [
+                                            "@trigger.params.url",
+                                        ],
+                                    },
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ]
         }
+        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
+
+        def flows_templates_side_effect(name, uuid):
+            if uuid == template_uuid_1:
+                return {
+                    "uuid": template_uuid_1,
+                    "name": self.template_name,
+                    "translations": [
+                        {
+                            "language": "por",
+                            "status": "approved",
+                            "channel": {
+                                "uuid": channel_uuid_1,
+                                "name": "Channel 1",
+                            },
+                        }
+                    ],
+                }
+            return None
+
+        self.mock_flows_templates_usecase.execute.side_effect = (
+            flows_templates_side_effect
+        )
 
         self.mock_channels_usecase.execute.return_value = [
             self._make_project_channel(channel_uuid_1, self.waba_id),
@@ -341,57 +490,9 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
 
         self.assertEqual(len(result.templates), 1)
         self.assertEqual(result.templates[0].id, meta_template["id"])
-        self.mock_meta_client.get_templates_list.assert_called_once_with(
-            waba_id=self.waba_id, name=self.template_name
-        )
-        self.mock_flows_templates_usecase.execute.assert_called_once()
-
-    def test_template_not_found_in_meta_raises_exception(self):
-        definition = self._make_definition_with_template(
-            self.template_uuid, self.template_name
-        )
-        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
-
-        self.mock_flows_templates_usecase.execute.return_value = (
-            self._make_flows_template_response(self.channel_uuid)
-        )
-
-        self.mock_channels_usecase.execute.return_value = [
-            self._make_project_channel(self.channel_uuid, self.waba_id)
-        ]
-
-        self.mock_meta_client.get_templates_list.return_value = {"data": []}
-
-        with self.assertRaises(FlowTemplateNotFound):
-            self.use_case.execute(flow_uuid=self.flow_uuid)
-
-    @patch("chats.apps.projects.usecases.flow_templates.sentry_sdk.capture_exception")
-    @patch("chats.apps.projects.usecases.flow_templates.logger")
-    def test_template_not_found_logs_and_captures_sentry(
-        self, mock_logger, mock_capture
-    ):
-        definition = self._make_definition_with_template(
-            self.template_uuid, self.template_name
-        )
-        self.mock_flows_client.retrieve_flow_definitions.return_value = definition
-
-        self.mock_flows_templates_usecase.execute.return_value = (
-            self._make_flows_template_response(self.channel_uuid)
-        )
-
-        self.mock_channels_usecase.execute.return_value = [
-            self._make_project_channel(self.channel_uuid, self.waba_id)
-        ]
-
-        self.mock_meta_client.get_templates_list.return_value = {"data": []}
-
-        with self.assertRaises(FlowTemplateNotFound):
-            self.use_case.execute(flow_uuid=self.flow_uuid)
-
-        mock_capture.assert_called_once()
-        mock_logger.error.assert_called_once()
-        call_kwargs = mock_logger.error.call_args
-        self.assertIn("exc_info", call_kwargs.kwargs)
+        mock_logger.warning.assert_called_once()
+        warning_message = mock_logger.warning.call_args[0][0]
+        self.assertIn("not found in flows templates", warning_message)
 
     def test_extract_templates_from_definition_finds_templating_in_actions(self):
         flow = self._make_flow_with_template(
@@ -431,7 +532,8 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["variables"], ["contactname", "url"])
 
-    def test_no_template_channels_found_raises_exception(self):
+    @patch("chats.apps.projects.usecases.flow_templates.logger")
+    def test_execute_skips_template_not_found_in_flows(self, mock_logger):
         definition = self._make_definition_with_template(
             self.template_uuid, self.template_name
         )
@@ -440,8 +542,10 @@ class TestGetFlowTemplatesDataUseCase(TestCase):
         self.mock_flows_templates_usecase.execute.return_value = None
         self.mock_channels_usecase.execute.return_value = []
 
-        with self.assertRaises(FlowTemplateChannelsNotFound):
-            self.use_case.execute(flow_uuid=self.flow_uuid)
+        result = self.use_case.execute(flow_uuid=self.flow_uuid)
+
+        self.assertEqual(result, FlowTemplatesData(uuid=self.flow_uuid, templates=[]))
+        mock_logger.warning.assert_called_once()
 
     def test_get_flow_definition_filters_response_by_flow_uuid(self):
         other_flow_uuid = str(uuid.uuid4())

--- a/chats/apps/projects/usecases/flow_templates.py
+++ b/chats/apps/projects/usecases/flow_templates.py
@@ -1,7 +1,5 @@
 import logging
 
-import sentry_sdk
-
 from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
 from chats.apps.api.v1.internal.rest_clients.meta import MetaGraphAPIClient
 from chats.apps.projects.dataclass import (
@@ -10,10 +8,6 @@ from chats.apps.projects.dataclass import (
     FlowTemplatesData,
 )
 from chats.apps.projects.models import Project
-from chats.apps.projects.usecases.exceptions import (
-    FlowTemplateChannelsNotFound,
-    FlowTemplateNotFound,
-)
 from chats.apps.projects.usecases.flows_templates import FlowsTemplatesUseCase
 from chats.apps.projects.usecases.get_project_channels_info import (
     GetProjectChannelsInfoUseCase,
@@ -122,17 +116,13 @@ class GetFlowTemplatesDataUseCase:
         data = response.get("data", [])
 
         if not data:
-            exc = FlowTemplateNotFound(
-                f"Template '{template_name}' not found in WABA '{waba_id}'"
-            )
-            logger.error(
-                "Template not found in Meta Graph API: waba_id=%s, name=%s",
+            logger.warning(
+                "Flow template skipped: not found in Meta Graph API. "
+                "waba_id=%s name=%s",
                 waba_id,
                 template_name,
-                exc_info=exc,
             )
-            sentry_sdk.capture_exception(exc)
-            raise exc
+            return None
 
         return data[0]
 
@@ -149,26 +139,37 @@ class GetFlowTemplatesDataUseCase:
             for ch in project_channels
         }
 
+        collected: list[FlowTemplate] = []
+
         for template_info in templates_info:
             template_channels = self._get_template_channels(template_info)
 
             if not template_channels:
-                raise FlowTemplateChannelsNotFound(
-                    f"No channels found for template '{template_info['name']}' "
-                    f"in flow '{flow_uuid}'"
+                logger.warning(
+                    "Flow template skipped: not found in flows templates or has no channels. "
+                    "project=%s flow=%s template=%s uuid=%s",
+                    self.project_uuid,
+                    flow_uuid,
+                    template_info["name"],
+                    template_info["uuid"],
                 )
+                continue
 
             waba_id = self._resolve_waba_id(template_channels, project_channels_map)
             if not waba_id:
                 continue
 
             meta_template = self._fetch_meta_template(waba_id, template_info["name"])
-            flow_template = FlowTemplate(
-                id=meta_template["id"],
-                name=meta_template["name"],
-                data=meta_template,
-                variables=template_info.get("variables", []),
-            )
-            return FlowTemplatesData(uuid=flow_uuid, templates=[flow_template])
+            if meta_template is None:
+                continue
 
-        return FlowTemplatesData(uuid=flow_uuid, templates=[])
+            collected.append(
+                FlowTemplate(
+                    id=meta_template["id"],
+                    name=meta_template["name"],
+                    data=meta_template,
+                    variables=template_info.get("variables", []),
+                )
+            )
+
+        return FlowTemplatesData(uuid=flow_uuid, templates=collected)


### PR DESCRIPTION
### What

- Updated `GetFlowTemplatesDataUseCase` to return **all valid templates** referenced in a flow definition, instead of stopping at the first match.
- Changed error handling from fail-fast exceptions to **skip-and-continue**: templates missing in flows templates, without channels, or not found in Meta are logged as warnings and skipped.
- Removed `FlowTemplateNotFound` / `FlowTemplateChannelsNotFound` handling from the `flow_templates` API endpoint; it now always returns `200` with `flow_uuid`, `total_template_qty`, and the collected `templates` list (which may be empty or partial).
- Removed Sentry reporting for templates not found in Meta.
- Updated unit tests to cover multi-template retrieval, partial results when stale templates exist, and the new skip behavior for missing templates/channels.

### Why

Flows can reference multiple WhatsApp templates (each with its own variables). The previous implementation only returned the first valid template and failed the entire request when any template was missing or stale in Meta/flows. This blocked clients from loading usable templates when a flow contained outdated references alongside valid ones. The new behavior returns all resolvable templates and gracefully skips invalid entries, improving resilience for multi-template flows.