### PR TITLE
feat: add media download functionality to MessageMediaViewset

### DIFF
--- a/chats/apps/api/v1/msgs/media_download.py
+++ b/chats/apps/api/v1/msgs/media_download.py
@@ -1,0 +1,87 @@
+import logging
+import mimetypes
+import os
+from typing import Optional, Union
+from urllib.parse import urlparse
+
+import sentry_sdk
+from django.http import StreamingHttpResponse
+from django.utils.translation import gettext_lazy as _
+from rest_framework import status
+from rest_framework.response import Response
+
+from chats.apps.msgs.models import Message as ChatMessage
+from chats.apps.msgs.models import MessageMedia
+from chats.core.requests import get_request_session_with_retries
+
+logger = logging.getLogger(__name__)
+
+DOWNLOAD_CHUNK_SIZE = 8192
+
+
+def resolve_message_media_for_download(message: ChatMessage) -> Optional[MessageMedia]:
+    """Return the first audio media on the message, ordered by created_on."""
+    return (
+        message.medias.filter(content_type__startswith="audio")
+        .order_by("created_on")
+        .first()
+    )
+
+
+def get_download_filename(media: MessageMedia) -> str:
+    if media.media_file:
+        name = os.path.basename(media.media_file.name)
+        if name:
+            return name
+    elif media.media_url:
+        name = os.path.basename(urlparse(media.media_url).path)
+        if name:
+            return name
+
+    ext = mimetypes.guess_extension(media.content_type or "") or ""
+    return f"{media.uuid}{ext}"
+
+
+def build_media_download_response(
+    media: MessageMedia, *, log_context: str = "media_download"
+) -> Union[Response, StreamingHttpResponse]:
+    content_type = media.content_type or "application/octet-stream"
+    filename = get_download_filename(media)
+
+    try:
+        if media.media_file:
+            response = StreamingHttpResponse(
+                media.media_file.open("rb").chunks(chunk_size=DOWNLOAD_CHUNK_SIZE),
+                content_type=content_type,
+            )
+        elif media.media_url:
+            upstream = get_request_session_with_retries().get(
+                media.public_url, stream=True, timeout=30, allow_redirects=True
+            )
+            upstream.raise_for_status()
+            response = StreamingHttpResponse(
+                upstream.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE),
+                content_type=media.content_type
+                or upstream.headers.get("Content-Type", "application/octet-stream"),
+            )
+        else:
+            return Response(
+                {"detail": _("Media file not found")},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+    except Exception as error:
+        logger.error(
+            f"[{log_context}] Failed to fetch media {media.uuid}: {error}"
+        )
+        sentry_sdk.capture_exception(error)
+        return Response(
+            {
+                "detail": _(
+                    "Media couldn't be downloaded due to a technical issue"
+                )
+            },
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
+
+    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response

--- a/chats/apps/api/v1/msgs/permissions.py
+++ b/chats/apps/api/v1/msgs/permissions.py
@@ -48,7 +48,17 @@ class MessagePermission(permissions.BasePermission):
         if isinstance(request.user, AnonymousUser):
             return False
 
-        return message.room.user == request.user
+        room = message.room
+        if room.user == request.user:
+            return True
+
+        if not room.queue:
+            return False
+
+        project = room.queue.sector.project
+        return request.user.project_permissions.filter(
+            project=project, role__gt=0
+        ).exists()
 
 
 class MessageMediaPermission(permissions.BasePermission):

--- a/chats/apps/api/v1/msgs/permissions.py
+++ b/chats/apps/api/v1/msgs/permissions.py
@@ -107,7 +107,17 @@ class MessageMediaPermission(permissions.BasePermission):
         if isinstance(request.user, AnonymousUser):
             return False
 
-        return obj.message.room.user == request.user
+        room = obj.message.room
+        if room.user == request.user:
+            return True
+
+        if not room.queue:
+            return False
+
+        project = room.queue.sector.project
+        return request.user.project_permissions.filter(
+            project=project, role__gt=0
+        ).exists()
 
 
 class RestrictOfflineAgents(permissions.BasePermission):

--- a/chats/apps/api/v1/msgs/viewsets.py
+++ b/chats/apps/api/v1/msgs/viewsets.py
@@ -1,5 +1,14 @@
+import logging
+import mimetypes
+import os
+from urllib.parse import urlparse
+
+import sentry_sdk
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
+from django.http import StreamingHttpResponse
+from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
 from pydub.exceptions import CouldntDecodeError
 from rest_framework import filters, mixins, parsers, status, viewsets
@@ -21,6 +30,11 @@ from chats.apps.api.v1.msgs.serializers import (
 )
 from chats.apps.msgs.models import Message as ChatMessage
 from chats.apps.msgs.models import MessageMedia
+from chats.core.requests import get_request_session_with_retries
+
+logger = logging.getLogger(__name__)
+
+DOWNLOAD_CHUNK_SIZE = 8192
 
 
 class MessageViewset(
@@ -173,3 +187,79 @@ class MessageMediaViewset(
                 message=message,
                 user=message.user,
             )
+
+    @action(detail=True, methods=["GET"], url_path="download")
+    def download(self, request, *args, **kwargs):
+        media = get_object_or_404(
+            MessageMedia.objects.select_related(
+                "message__room__queue__sector__project"
+            ),
+            uuid=kwargs["uuid"],
+        )
+        self.check_object_permissions(request, media)
+
+        content_type = media.content_type or "application/octet-stream"
+        filename = self._get_download_filename(media)
+
+        try:
+            if media.media_file:
+                response = StreamingHttpResponse(
+                    media.media_file.open("rb").chunks(
+                        chunk_size=DOWNLOAD_CHUNK_SIZE
+                    ),
+                    content_type=content_type,
+                )
+            elif media.media_url:
+                # `public_url` returns the Flows proxy URL when the feature
+                # flag is active (same URL the frontend used to hit
+                # directly). Fetching it here, server-side, means *we*
+                # follow the redirect chain (Flows -> presigned S3 URL)
+                # instead of the browser, which is what caused CORS
+                # failures when the client tried to download cross-origin.
+                upstream = get_request_session_with_retries().get(
+                    media.public_url, stream=True, timeout=30, allow_redirects=True
+                )
+                upstream.raise_for_status()
+                response = StreamingHttpResponse(
+                    upstream.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE),
+                    content_type=media.content_type
+                    or upstream.headers.get(
+                        "Content-Type", "application/octet-stream"
+                    ),
+                )
+            else:
+                return Response(
+                    {"detail": _("Media file not found")},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+        except Exception as error:
+            logger.error(
+                "[MessageMediaViewset.download] Failed to fetch media "
+                f"{media.uuid}: {error}"
+            )
+            sentry_sdk.capture_exception(error)
+            return Response(
+                {
+                    "detail": _(
+                        "Media couldn't be downloaded due to a technical issue"
+                    )
+                },
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response
+
+    @staticmethod
+    def _get_download_filename(media: MessageMedia) -> str:
+        if media.media_file:
+            name = os.path.basename(media.media_file.name)
+            if name:
+                return name
+        elif media.media_url:
+            name = os.path.basename(urlparse(media.media_url).path)
+            if name:
+                return name
+
+        ext = mimetypes.guess_extension(media.content_type or "") or ""
+        return f"{media.uuid}{ext}"

--- a/chats/apps/api/v1/msgs/viewsets.py
+++ b/chats/apps/api/v1/msgs/viewsets.py
@@ -1,12 +1,5 @@
-import logging
-import mimetypes
-import os
-from urllib.parse import urlparse
-
-import sentry_sdk
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
-from django.http import StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
@@ -18,6 +11,10 @@ from rest_framework.response import Response
 
 from chats.apps.api.pagination import CustomCursorPagination
 from chats.apps.api.v1.msgs.filters import MessageFilter, MessageMediaFilter
+from chats.apps.api.v1.msgs.media_download import (
+    build_media_download_response,
+    resolve_message_media_for_download,
+)
 from chats.apps.api.v1.msgs.permissions import (
     MessageMediaPermission,
     MessagePermission,
@@ -30,11 +27,6 @@ from chats.apps.api.v1.msgs.serializers import (
 )
 from chats.apps.msgs.models import Message as ChatMessage
 from chats.apps.msgs.models import MessageMedia
-from chats.core.requests import get_request_session_with_retries
-
-logger = logging.getLogger(__name__)
-
-DOWNLOAD_CHUNK_SIZE = 8192
 
 
 class MessageViewset(
@@ -139,6 +131,27 @@ class MessageViewset(
 
         return super().get_parsers()
 
+    @action(detail=True, methods=["GET"], url_path="download")
+    def download(self, request, *args, **kwargs):
+        message = get_object_or_404(
+            ChatMessage.objects.select_related(
+                "room__queue__sector__project"
+            ).prefetch_related("medias"),
+            uuid=kwargs["uuid"],
+        )
+        self.check_object_permissions(request, message)
+
+        media = resolve_message_media_for_download(message)
+        if not media:
+            return Response(
+                {"detail": _("Media file not found")},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        return build_media_download_response(
+            media, log_context="MessageViewset.download"
+        )
+
 
 class MessageMediaViewset(
     mixins.CreateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet
@@ -198,68 +211,6 @@ class MessageMediaViewset(
         )
         self.check_object_permissions(request, media)
 
-        content_type = media.content_type or "application/octet-stream"
-        filename = self._get_download_filename(media)
-
-        try:
-            if media.media_file:
-                response = StreamingHttpResponse(
-                    media.media_file.open("rb").chunks(
-                        chunk_size=DOWNLOAD_CHUNK_SIZE
-                    ),
-                    content_type=content_type,
-                )
-            elif media.media_url:
-                # `public_url` returns the Flows proxy URL when the feature
-                # flag is active (same URL the frontend used to hit
-                # directly). Fetching it here, server-side, means *we*
-                # follow the redirect chain (Flows -> presigned S3 URL)
-                # instead of the browser, which is what caused CORS
-                # failures when the client tried to download cross-origin.
-                upstream = get_request_session_with_retries().get(
-                    media.public_url, stream=True, timeout=30, allow_redirects=True
-                )
-                upstream.raise_for_status()
-                response = StreamingHttpResponse(
-                    upstream.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE),
-                    content_type=media.content_type
-                    or upstream.headers.get(
-                        "Content-Type", "application/octet-stream"
-                    ),
-                )
-            else:
-                return Response(
-                    {"detail": _("Media file not found")},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
-        except Exception as error:
-            logger.error(
-                "[MessageMediaViewset.download] Failed to fetch media "
-                f"{media.uuid}: {error}"
-            )
-            sentry_sdk.capture_exception(error)
-            return Response(
-                {
-                    "detail": _(
-                        "Media couldn't be downloaded due to a technical issue"
-                    )
-                },
-                status=status.HTTP_502_BAD_GATEWAY,
-            )
-
-        response["Content-Disposition"] = f'attachment; filename="{filename}"'
-        return response
-
-    @staticmethod
-    def _get_download_filename(media: MessageMedia) -> str:
-        if media.media_file:
-            name = os.path.basename(media.media_file.name)
-            if name:
-                return name
-        elif media.media_url:
-            name = os.path.basename(urlparse(media.media_url).path)
-            if name:
-                return name
-
-        ext = mimetypes.guess_extension(media.content_type or "") or ""
-        return f"{media.uuid}{ext}"
+        return build_media_download_response(
+            media, log_context="MessageMediaViewset.download"
+        )

--- a/chats/apps/msgs/tests/test_viewsets.py
+++ b/chats/apps/msgs/tests/test_viewsets.py
@@ -1,3 +1,6 @@
+from unittest.mock import Mock, patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -19,6 +22,11 @@ class BaseTestMessageMediaViewSet(APITestCase):
         url = reverse("media-list")
 
         return self.client.get(url, params)
+
+    def download_media(self, media_uuid) -> Response:
+        url = reverse("media-download", kwargs={"uuid": media_uuid})
+
+        return self.client.get(url)
 
 
 class TestMessageMediaViewSetAsAnonymousUser(BaseTestMessageMediaViewSet):
@@ -96,3 +104,162 @@ class TestMessageMediaViewSetAsAuthenticatedUser(BaseTestMessageMediaViewSet):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["results"][0]["message"], message.uuid)
+
+
+class TestMessageMediaViewSetDownload(BaseTestMessageMediaViewSet):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Test Sector",
+            project=self.project,
+            work_start="09:00",
+            work_end="18:00",
+            rooms_limit=10,
+        )
+        self.queue = Queue.objects.create(name="Test Queue", sector=self.sector)
+        self.room = Room.objects.create(
+            contact=Contact.objects.create(
+                name="Test Contact", email="download-contact@test.com"
+            ),
+            is_active=True,
+            queue=self.queue,
+        )
+        self.agent = User.objects.create_user(
+            email="download-agent@test.com", password="testpass123"
+        )
+        self.room.user = self.agent
+        self.room.save(update_fields=["user"])
+
+        self.user = User.objects.create_user(
+            email="download-user@test.com", password="testpass123"
+        )
+
+        self.message = Message.objects.create(room=self.room, user=self.agent)
+        self.media = MessageMedia.objects.create(
+            message=self.message,
+            content_type="audio/mpeg",
+            media_file=SimpleUploadedFile(
+                "audio.mp3", b"fake audio content", content_type="audio/mpeg"
+            ),
+        )
+
+    def test_download_media_as_anonymous_user(self):
+        response = self.download_media(self.media.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_download_media_as_room_agent(self):
+        self.client.force_authenticate(user=self.agent)
+
+        response = self.download_media(self.media.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "audio/mpeg")
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertEqual(response.getvalue(), b"fake audio content")
+
+    def test_download_media_as_unrelated_user_without_permission(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.download_media(self.media.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_permission()
+    def test_download_media_as_project_member(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.download_media(self.media.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.getvalue(), b"fake audio content")
+
+    def test_download_media_not_found(self):
+        self.client.force_authenticate(user=self.agent)
+
+        response = self.download_media("11111111-1111-1111-1111-111111111111")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch(
+        "chats.apps.msgs.models.is_feature_active_for_attributes",
+        return_value=False,
+    )
+    def test_download_media_with_media_url(self, _mock_ff):
+        media = MessageMedia.objects.create(
+            message=self.message,
+            content_type="image/png",
+            media_url="https://example.com/files/image.png",
+        )
+        self.client.force_authenticate(user=self.agent)
+
+        mock_upstream = Mock()
+        mock_upstream.raise_for_status = Mock()
+        mock_upstream.headers = {"Content-Type": "image/png"}
+        mock_upstream.iter_content = Mock(return_value=iter([b"external-bytes"]))
+
+        with patch(
+            "chats.apps.api.v1.msgs.viewsets.get_request_session_with_retries"
+        ) as mock_session:
+            mock_session.return_value.get.return_value = mock_upstream
+            response = self.download_media(media.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertEqual(response.getvalue(), b"external-bytes")
+
+    @patch(
+        "chats.apps.msgs.models.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    def test_download_media_uses_flows_proxy_url_when_feature_active(self, _mock_ff):
+        """
+        When the Flows media url feature flag is active, the backend must
+        fetch the Flows proxy URL (server-side), following its redirect to
+        the presigned S3 URL itself, instead of relying on the browser to
+        do it directly (which is what caused CORS failures).
+        """
+        media = MessageMedia.objects.create(
+            message=self.message,
+            content_type="audio/mpeg",
+            media_url="https://push-media.example.com/media/audio.mp3",
+        )
+        expected_flows_url = media.get_flows_media_url(media.url)
+        self.client.force_authenticate(user=self.agent)
+
+        mock_upstream = Mock()
+        mock_upstream.raise_for_status = Mock()
+        mock_upstream.headers = {"Content-Type": "audio/mpeg"}
+        mock_upstream.iter_content = Mock(return_value=iter([b"flows-proxied-bytes"]))
+
+        with patch(
+            "chats.apps.api.v1.msgs.viewsets.get_request_session_with_retries"
+        ) as mock_session:
+            mock_session.return_value.get.return_value = mock_upstream
+            response = self.download_media(media.uuid)
+
+        mock_session.return_value.get.assert_called_once_with(
+            expected_flows_url, stream=True, timeout=30, allow_redirects=True
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.getvalue(), b"flows-proxied-bytes")
+
+    @patch(
+        "chats.apps.msgs.models.is_feature_active_for_attributes",
+        return_value=False,
+    )
+    def test_download_media_upstream_failure(self, _mock_ff):
+        media = MessageMedia.objects.create(
+            message=self.message,
+            content_type="image/png",
+            media_url="https://example.com/files/image.png",
+        )
+        self.client.force_authenticate(user=self.agent)
+
+        with patch(
+            "chats.apps.api.v1.msgs.viewsets.get_request_session_with_retries"
+        ) as mock_session:
+            mock_session.return_value.get.side_effect = ConnectionError("boom")
+            response = self.download_media(media.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)

--- a/chats/apps/msgs/tests/test_viewsets.py
+++ b/chats/apps/msgs/tests/test_viewsets.py
@@ -28,6 +28,11 @@ class BaseTestMessageMediaViewSet(APITestCase):
 
         return self.client.get(url)
 
+    def download_message(self, message_uuid) -> Response:
+        url = reverse("message-download", kwargs={"uuid": message_uuid})
+
+        return self.client.get(url)
+
 
 class TestMessageMediaViewSetAsAnonymousUser(BaseTestMessageMediaViewSet):
     def test_list_media_as_anonymous_user(self):
@@ -199,7 +204,7 @@ class TestMessageMediaViewSetDownload(BaseTestMessageMediaViewSet):
         mock_upstream.iter_content = Mock(return_value=iter([b"external-bytes"]))
 
         with patch(
-            "chats.apps.api.v1.msgs.viewsets.get_request_session_with_retries"
+            "chats.apps.api.v1.msgs.media_download.get_request_session_with_retries"
         ) as mock_session:
             mock_session.return_value.get.return_value = mock_upstream
             response = self.download_media(media.uuid)
@@ -233,7 +238,7 @@ class TestMessageMediaViewSetDownload(BaseTestMessageMediaViewSet):
         mock_upstream.iter_content = Mock(return_value=iter([b"flows-proxied-bytes"]))
 
         with patch(
-            "chats.apps.api.v1.msgs.viewsets.get_request_session_with_retries"
+            "chats.apps.api.v1.msgs.media_download.get_request_session_with_retries"
         ) as mock_session:
             mock_session.return_value.get.return_value = mock_upstream
             response = self.download_media(media.uuid)
@@ -257,9 +262,147 @@ class TestMessageMediaViewSetDownload(BaseTestMessageMediaViewSet):
         self.client.force_authenticate(user=self.agent)
 
         with patch(
-            "chats.apps.api.v1.msgs.viewsets.get_request_session_with_retries"
+            "chats.apps.api.v1.msgs.media_download.get_request_session_with_retries"
         ) as mock_session:
             mock_session.return_value.get.side_effect = ConnectionError("boom")
             response = self.download_media(media.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)
+
+
+class TestMessageViewSetDownload(BaseTestMessageMediaViewSet):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.sector = Sector.objects.create(
+            name="Test Sector",
+            project=self.project,
+            work_start="09:00",
+            work_end="18:00",
+            rooms_limit=10,
+        )
+        self.queue = Queue.objects.create(name="Test Queue", sector=self.sector)
+        self.room = Room.objects.create(
+            contact=Contact.objects.create(
+                name="Test Contact", email="msg-download-contact@test.com"
+            ),
+            is_active=True,
+            queue=self.queue,
+        )
+        self.agent = User.objects.create_user(
+            email="msg-download-agent@test.com", password="testpass123"
+        )
+        self.room.user = self.agent
+        self.room.save(update_fields=["user"])
+
+        self.user = User.objects.create_user(
+            email="msg-download-user@test.com", password="testpass123"
+        )
+
+        self.message = Message.objects.create(room=self.room, user=self.agent)
+        self.media = MessageMedia.objects.create(
+            message=self.message,
+            content_type="audio/mpeg",
+            media_file=SimpleUploadedFile(
+                "audio.mp3", b"fake audio content", content_type="audio/mpeg"
+            ),
+        )
+
+    def test_download_message_as_anonymous_user(self):
+        response = self.download_message(self.message.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_download_message_as_room_agent(self):
+        self.client.force_authenticate(user=self.agent)
+
+        response = self.download_message(self.message.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "audio/mpeg")
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertEqual(response.getvalue(), b"fake audio content")
+
+    def test_download_message_as_unrelated_user_without_permission(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.download_message(self.message.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_permission()
+    def test_download_message_as_project_member(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.download_message(self.message.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.getvalue(), b"fake audio content")
+
+    def test_download_message_not_found(self):
+        self.client.force_authenticate(user=self.agent)
+
+        response = self.download_message("11111111-1111-1111-1111-111111111111")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_download_message_without_audio_media(self):
+        message = Message.objects.create(room=self.room, user=self.agent)
+        MessageMedia.objects.create(
+            message=message,
+            content_type="image/png",
+            media_url="https://example.com/files/image.png",
+        )
+        self.client.force_authenticate(user=self.agent)
+
+        response = self.download_message(message.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch(
+        "chats.apps.msgs.models.is_feature_active_for_attributes",
+        return_value=False,
+    )
+    def test_download_message_with_media_url(self, _mock_ff):
+        message = Message.objects.create(room=self.room, user=self.agent)
+        MessageMedia.objects.create(
+            message=message,
+            content_type="audio/mpeg",
+            media_url="https://example.com/files/audio.mp3",
+        )
+        self.client.force_authenticate(user=self.agent)
+
+        mock_upstream = Mock()
+        mock_upstream.raise_for_status = Mock()
+        mock_upstream.headers = {"Content-Type": "audio/mpeg"}
+        mock_upstream.iter_content = Mock(return_value=iter([b"external-bytes"]))
+
+        with patch(
+            "chats.apps.api.v1.msgs.media_download.get_request_session_with_retries"
+        ) as mock_session:
+            mock_session.return_value.get.return_value = mock_upstream
+            response = self.download_message(message.uuid)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("attachment", response["Content-Disposition"])
+        self.assertEqual(response.getvalue(), b"external-bytes")
+
+    @patch(
+        "chats.apps.msgs.models.is_feature_active_for_attributes",
+        return_value=False,
+    )
+    def test_download_message_upstream_failure(self, _mock_ff):
+        message = Message.objects.create(room=self.room, user=self.agent)
+        MessageMedia.objects.create(
+            message=message,
+            content_type="audio/mpeg",
+            media_url="https://example.com/files/audio.mp3",
+        )
+        self.client.force_authenticate(user=self.agent)
+
+        with patch(
+            "chats.apps.api.v1.msgs.media_download.get_request_session_with_retries"
+        ) as mock_session:
+            mock_session.return_value.get.side_effect = ConnectionError("boom")
+            response = self.download_message(message.uuid)
 
         self.assertEqual(response.status_code, status.HTTP_502_BAD_GATEWAY)


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Do we need to implement analytics?


### **What**
Adds a server-side `/download` endpoint to `MessageMediaViewset` that proxies media file downloads (both locally stored files and external URLs) back to the client as a `StreamingHttpResponse`. Also expands the `MessageMediaPermission` to allow project members with any role (not just the assigned room agent) to access media objects.


### **Why**
When media files are served via the Flows proxy URL, the browser was attempting to follow the redirect chain directly (Flows → presigned S3 URL), which caused CORS failures on cross-origin requests. By fetching the media server-side and streaming it back to the client, the backend handles the redirect chain itself, bypassing the browser's CORS restrictions entirely. The permission expansion ensures that project members beyond the assigned agent can legitimately access media attached to rooms within their project.