### PR TITLE
refactor: rename JWT authentication classes and update token generator for CSAT integration

### DIFF
--- a/chats/apps/api/authentication/classes.py
+++ b/chats/apps/api/authentication/classes.py
@@ -2,16 +2,16 @@ from django.conf import settings
 
 from chats.apps.api.authentication.exceptions import InvalidTokenError
 from chats.apps.api.authentication.services.jwt_service import JWTService
-from chats.apps.api.authentication.token import JWTTokenGenerator
+from chats.apps.api.authentication.token import CSATJWTTokenGenerator
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
 from chats.apps.projects.models.models import Project
 
 
-class GenericJWTAuthentication(BaseAuthentication):
+class CSATJWTAuthentication(BaseAuthentication):
     """
-    Authentication class for the JWT token.
+    Authentication class for CSAT webhook JWT tokens.
     """
 
     def authenticate(self, request):
@@ -34,7 +34,7 @@ class GenericJWTAuthentication(BaseAuthentication):
         """
         Authenticate the credentials using the JWT token.
         """
-        token_generator = JWTTokenGenerator()
+        token_generator = CSATJWTTokenGenerator()
         try:
             payload = token_generator.verify_token(token)
             return (None, payload)

--- a/chats/apps/api/authentication/tests/test_classes.py
+++ b/chats/apps/api/authentication/tests/test_classes.py
@@ -13,9 +13,9 @@ from rest_framework import status
 
 from chats.apps.api.authentication.classes import (
     InternalAPITokenAuthentication,
-    GenericJWTAuthentication,
+    CSATJWTAuthentication,
 )
-from chats.apps.api.authentication.token import JWTTokenGenerator
+from chats.apps.api.authentication.token import CSATJWTTokenGenerator
 
 
 from chats.apps.api.authentication.permissions import (
@@ -24,15 +24,15 @@ from chats.apps.api.authentication.permissions import (
 )
 
 
-class GenericJWTAuthenticationTests(TestCase):
+class CSATJWTAuthenticationTests(TestCase):
     def setUp(self):
-        self.token_generator = JWTTokenGenerator()
+        self.token_generator = CSATJWTTokenGenerator()
         self.valid_token = self.token_generator.generate_token(
             {"user_id": 1, "username": "testuser"}
         )
 
     def test_authenticate(self):
-        authentication = GenericJWTAuthentication()
+        authentication = CSATJWTAuthentication()
         request = HttpRequest()
         request.META["HTTP_AUTHORIZATION"] = f"Token {self.valid_token}"
         result = authentication.authenticate(request)
@@ -42,7 +42,7 @@ class GenericJWTAuthenticationTests(TestCase):
         self.assertIsNotNone(result[1])
 
     def test_authenticate_credentials(self):
-        authentication = GenericJWTAuthentication()
+        authentication = CSATJWTAuthentication()
         result = authentication.authenticate_credentials(self.valid_token)
         self.assertIsNotNone(result)
         self.assertEqual(len(result), 2)
@@ -50,8 +50,8 @@ class GenericJWTAuthenticationTests(TestCase):
         self.assertIsNotNone(result[1])
 
 
-class GenericJWTAuthenticationView(APIView):
-    authentication_classes = [GenericJWTAuthentication]
+class CSATJWTAuthenticationView(APIView):
+    authentication_classes = [CSATJWTAuthentication]
     permission_classes = [JWTRequiredPermission]
 
     def get(self, request):
@@ -66,12 +66,12 @@ class GenericJWTAuthenticationView(APIView):
 
 
 @override_settings(ROOT_URLCONF="chats.apps.api.authentication.tests.test_urls")
-class GenericJWTAuthenticationViewAPITestCase(APITestCase):
-    """Test cases for GenericJWTAuthenticationView using GenericJWTAuthentication."""
+class CSATJWTAuthenticationViewAPITestCase(APITestCase):
+    """Test cases for CSATJWTAuthenticationView using CSATJWTAuthentication."""
 
     def setUp(self):
         self.client = APIClient()
-        self.token_generator = JWTTokenGenerator()
+        self.token_generator = CSATJWTTokenGenerator()
         self.test_payload = {
             "room": str(uuid.uuid4()),
         }

--- a/chats/apps/api/authentication/tests/test_token.py
+++ b/chats/apps/api/authentication/tests/test_token.py
@@ -1,16 +1,16 @@
 from django.test import TestCase
 
-from chats.apps.api.authentication.token import JWTTokenGenerator
+from chats.apps.api.authentication.token import CSATJWTTokenGenerator
 
 
-class JWTTokenGeneratorTests(TestCase):
+class CSATJWTTokenGeneratorTests(TestCase):
     def test_generate_token(self):
-        token_generator = JWTTokenGenerator()
+        token_generator = CSATJWTTokenGenerator()
         token = token_generator.generate_token(payload={"test": "test"})
         self.assertIsNotNone(token)
 
     def test_verify_token(self):
-        token_generator = JWTTokenGenerator()
+        token_generator = CSATJWTTokenGenerator()
         token = token_generator.generate_token(payload={"test": "test"})
         self.assertIsNotNone(token)
         verified_token = token_generator.verify_token(token)

--- a/chats/apps/api/authentication/tests/test_urls.py
+++ b/chats/apps/api/authentication/tests/test_urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from chats.apps.api.authentication.tests.test_classes import (
     InternalAPITokenAuthenticationView,
-    GenericJWTAuthenticationView,
+    CSATJWTAuthenticationView,
 )
 from chats.apps.api.authentication.tests.test_jwt_authentication import (
     MockJWTAuthenticationView,
@@ -10,7 +10,7 @@ from chats.apps.api.authentication.tests.test_jwt_authentication import (
 urlpatterns = [
     path(
         "jwt-authentication/",
-        GenericJWTAuthenticationView.as_view(),
+        CSATJWTAuthenticationView.as_view(),
         name="jwt-authentication-view",
     ),
     path(

--- a/chats/apps/api/authentication/token.py
+++ b/chats/apps/api/authentication/token.py
@@ -5,12 +5,12 @@ from django.conf import settings
 from django.utils import timezone
 
 
-class JWTTokenGenerator:
+class CSATJWTTokenGenerator:
     """
-    A class for generating JWT tokens with configurable options.
+    JWT token generator for CSAT flow and webhook authentication.
 
-    This class provides methods to generate JWT tokens with custom payloads,
-    expiration times, and signing algorithms.
+    Uses HS256 with Django's SECRET_KEY to sign tokens passed to the flows
+    service and validated by CSATJWTAuthentication.
     """
 
     def __init__(self, secret_key: Optional[str] = None, algorithm: str = "HS256"):
@@ -70,36 +70,6 @@ class JWTTokenGenerator:
             return token
         except Exception as e:
             raise jwt.InvalidTokenError(f"Failed to generate token: {str(e)}")
-
-    def generate_api_token(
-        self,
-        service_name: str,
-        permissions: Optional[list] = None,
-        expires_in_hours: int = 2,
-        additional_claims: Optional[Dict[str, Any]] = None,
-    ) -> str:
-        """
-        Generate a JWT token for API service authentication.
-
-        Args:
-            service_name: Name of the service using the token.
-            permissions: List of permissions granted to the service.
-            expires_in_hours: Token expiration time in hours (default: 2).
-            additional_claims: Additional claims to include in the token.
-
-        Returns:
-            str: The encoded JWT token.
-        """
-        payload = {
-            "service": service_name,
-            "type": "api_auth",
-            "permissions": permissions or [],
-        }
-
-        if additional_claims:
-            payload.update(additional_claims)
-
-        return self.generate_token(payload, expires_in_hours)
 
     def verify_token(self, token: str) -> Dict[str, Any]:
         """

--- a/chats/apps/api/v1/internal/csat/tests/decorators.py
+++ b/chats/apps/api/v1/internal/csat/tests/decorators.py
@@ -1,6 +1,6 @@
 import functools
 
-from chats.apps.api.authentication.token import JWTTokenGenerator
+from chats.apps.api.authentication.token import CSATJWTTokenGenerator
 
 
 def with_project_jwt_token(func=None, *, room_uuid=None):
@@ -26,7 +26,7 @@ def with_project_jwt_token(func=None, *, room_uuid=None):
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
-        self.jwt_generator = JWTTokenGenerator()
+        self.jwt_generator = CSATJWTTokenGenerator()
         room = room_uuid if room_uuid is not None else str(self.room.uuid)
         self.token = self.jwt_generator.generate_token(
             {"project": str(self.project.uuid), "room": room}

--- a/chats/apps/api/v1/internal/csat/tests/test_views.py
+++ b/chats/apps/api/v1/internal/csat/tests/test_views.py
@@ -16,7 +16,7 @@ from chats.apps.projects.models import Project
 from chats.apps.sectors.models import Sector
 from chats.apps.queues.models import Queue
 from chats.apps.rooms.models import Room
-from chats.apps.api.authentication.token import JWTTokenGenerator
+from chats.apps.api.authentication.token import CSATJWTTokenGenerator
 
 
 class BaseTestCSATWebhookView(APITestCase):
@@ -33,7 +33,7 @@ class BaseTestCSATWebhookView(APITestCase):
 
 class TestCSATWebhookView(BaseTestCSATWebhookView):
     def setUp(self):
-        self.jwt_generator = JWTTokenGenerator()
+        self.jwt_generator = CSATJWTTokenGenerator()
         self.project = Project.objects.create(name="Test Project")
         self.sector = Sector.objects.create(
             name="Test Sector",

--- a/chats/apps/api/v1/internal/csat/views.py
+++ b/chats/apps/api/v1/internal/csat/views.py
@@ -2,7 +2,7 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework.response import Response
 from rest_framework import status
 
-from chats.apps.api.authentication.classes import GenericJWTAuthentication
+from chats.apps.api.authentication.classes import CSATJWTAuthentication
 from chats.apps.api.v1.internal.csat.permissions import CSATWebhookPermission
 from chats.apps.api.v1.internal.csat.serializers import (
     CreateCSATWebhookSerializer,
@@ -14,7 +14,7 @@ from chats.apps.csat.models import CSATSurvey
 class CSATWebhookView(GenericViewSet):
     serializer_class = CreateCSATWebhookSerializer
     permission_classes = [CSATWebhookPermission]
-    authentication_classes = [GenericJWTAuthentication]
+    authentication_classes = [CSATJWTAuthentication]
 
     def create(self, request, *args, **kwargs):
         room_uuid = request.data.get("room")

--- a/chats/apps/csat/services.py
+++ b/chats/apps/csat/services.py
@@ -22,7 +22,7 @@ from chats.apps.csat.models import (
 )
 from chats.apps.sectors.models import Sector
 from chats.core.cache import BaseCacheClient
-from chats.apps.api.authentication.token import JWTTokenGenerator
+from chats.apps.api.authentication.token import CSATJWTTokenGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class CSATFlowService(BaseCSATService):
         self,
         flows_client: FlowRESTClient,
         cache_client: BaseCacheClient,
-        token_generator: JWTTokenGenerator,
+        token_generator: CSATJWTTokenGenerator,
     ):
         self.flows_client = flows_client
         self.cache_client = cache_client

--- a/chats/apps/csat/tasks.py
+++ b/chats/apps/csat/tasks.py
@@ -11,7 +11,7 @@ from chats.apps.rooms.models import Room
 from chats.apps.csat.services import CSATFlowService
 from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
 from chats.core.cache import CacheClient
-from chats.apps.api.authentication.token import JWTTokenGenerator
+from chats.apps.api.authentication.token import CSATJWTTokenGenerator
 
 
 @app.task
@@ -21,7 +21,7 @@ def start_csat_flow(room_uuid: str):
     CSATFlowService(
         flows_client=FlowRESTClient(),
         cache_client=CacheClient(),
-        token_generator=JWTTokenGenerator(),
+        token_generator=CSATJWTTokenGenerator(),
     ).start_csat_flow(room)
 
 
@@ -32,7 +32,7 @@ def create_csat_flow(project_uuid: str):
     CSATFlowService(
         flows_client=FlowRESTClient(),
         cache_client=CacheClient(),
-        token_generator=JWTTokenGenerator(),
+        token_generator=CSATJWTTokenGenerator(),
     ).create_csat_flow(project)
 
 
@@ -63,7 +63,7 @@ def update_project_csat_flow_definition(
     CSATFlowService(
         flows_client=FlowRESTClient(),
         cache_client=CacheClient(),
-        token_generator=JWTTokenGenerator(),
+        token_generator=CSATJWTTokenGenerator(),
     ).update_csat_flow_definition(project, definition, version)
 
 

--- a/chats/apps/csat/tests/test_services.py
+++ b/chats/apps/csat/tests/test_services.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from chats.apps.api.authentication.token import JWTTokenGenerator
+from chats.apps.api.authentication.token import CSATJWTTokenGenerator
 from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
 from chats.apps.csat.flows.definitions.flow import (
     CSAT_FLOW_DEFINITION_DATA,
@@ -24,7 +24,7 @@ class TestCSATFlowService(TestCase):
     def setUp(self):
         self.mock_cache_client = Mock(spec=CacheClient)
         self.mock_flows_client = Mock(spec=FlowRESTClient)
-        self.mock_token_generator = Mock(spec=JWTTokenGenerator)
+        self.mock_token_generator = Mock(spec=CSATJWTTokenGenerator)
 
         self.service = CSATFlowService(
             flows_client=self.mock_flows_client,


### PR DESCRIPTION
### What

- Renamed `JWTTokenGenerator` to `CSATJWTTokenGenerator` and `GenericJWTAuthentication` to `CSATJWTAuthentication`
- Updated docstrings to clarify these components are for CSAT flow and webhook JWT authentication (HS256 with Django's `SECRET_KEY`)
- Removed the unused `generate_api_token` method from the token generator
- Updated all references across CSAT services, tasks, views, and tests to use the new names

### Why

The previous generic names (`JWTTokenGenerator`, `GenericJWTAuthentication`) did not reflect that these classes are scoped to CSAT integration. Renaming them makes the purpose explicit, reduces ambiguity with other JWT authentication in the codebase, and keeps the token generator focused on CSAT-specific token generation and verification.