### PR TITLE
feat: implement keyset pagination for message archiving

### DIFF
--- a/chats/apps/archive_chats/services.py
+++ b/chats/apps/archive_chats/services.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from collections import defaultdict
 from datetime import timedelta
 import json
 import logging
@@ -16,6 +15,7 @@ from django.core.files.base import File
 from sentry_sdk import capture_exception
 from django.conf import settings
 from django.db import IntegrityError, transaction
+from django.db.models import Q
 from weni.feature_flags.services import FeatureFlagsService
 
 
@@ -369,28 +369,46 @@ class ArchiveChatsService(BaseArchiveChatsService):
         return self._iter_messages(room)
 
     def _iter_messages(self, room: Room) -> Iterable[dict]:
-        medias_by_message = defaultdict(list)
-        for media in MessageMedia.objects.filter(message__room=room):
-            medias_by_message[media.message_id].append(media)
+        page_size = settings.ARCHIVE_CHATS_MESSAGE_PAGE_SIZE
+        last_created_on = None
+        last_pk = None
 
-        messages = (
-            Message.objects.filter(room=room)
-            .select_related("automatic_message")
-            .order_by("created_on")
-        )
+        while True:
+            qs = (
+                Message.objects.filter(room=room)
+                .select_related(
+                    "user", "contact", "automatic_message", "internal_note"
+                )
+                .prefetch_related("medias", "internal_note__medias")
+                .order_by("created_on", "pk")
+            )
+            if last_pk is not None:
+                qs = qs.filter(
+                    Q(created_on__gt=last_created_on)
+                    | Q(created_on=last_created_on, pk__gt=last_pk)
+                )
 
-        for message in messages.iterator():
-            message_context = {"media": []}
-            for media in medias_by_message.get(message.pk, []):
-                url = self.process_media(media)
-                if url:
-                    message_context["media"].append({
-                        "url": url,
-                        "content_type": media.content_type,
-                        "created_on": media.created_on.isoformat(),
-                    })
+            page = list(qs[:page_size])
+            if not page:
+                break
 
-            yield ArchiveMessageSerializer(message, context=message_context).data
+            for message in page:
+                message_context = {"media": []}
+                for media in message.medias.all():
+                    url = self.process_media(media)
+                    if url:
+                        message_context["media"].append(
+                            {
+                                "url": url,
+                                "content_type": media.content_type,
+                                "created_on": media.created_on.isoformat(),
+                            }
+                        )
+
+                yield ArchiveMessageSerializer(message, context=message_context).data
+
+            last_created_on = page[-1].created_on
+            last_pk = page[-1].pk
 
     def upload_messages_file(
         self,
@@ -491,32 +509,31 @@ class ArchiveChatsService(BaseArchiveChatsService):
             f"[ArchiveChatsService] Deleting room messages for room {room.uuid}"
         )
 
-        messages_count = Message.objects.filter(room=room).count()
-        batches_count = messages_count // batch_size + 1
-
-        logger.info(
-            f"[ArchiveChatsService] Deleting {messages_count} messages "
-            f"for room {room.uuid} in {batches_count} batches"
-        )
-
-        with transaction.atomic():
-            for _ in range(batches_count):
-                messages_pks = Message.objects.filter(room=room).values_list(
-                    "pk", flat=True
-                )[:batch_size]
-
-                if len(messages_pks) == 0:
+        deleted = 0
+        while True:
+            with transaction.atomic():
+                messages_pks = list(
+                    Message.objects.filter(room=room).values_list("pk", flat=True)[
+                        :batch_size
+                    ]
+                )
+                if not messages_pks:
                     break
 
                 Message.objects.filter(pk__in=messages_pks).delete()
+                deleted += len(messages_pks)
 
-            room_archived_conversation.status = (
-                ArchiveConversationsJobStatus.MESSAGES_DELETED_FROM_DB
-            )
-            room_archived_conversation.messages_deleted_at = timezone.now()
-            room_archived_conversation.save(
-                update_fields=["status", "messages_deleted_at"]
-            )
+        logger.info(
+            f"[ArchiveChatsService] Deleted {deleted} messages for room {room.uuid}"
+        )
+
+        room_archived_conversation.status = (
+            ArchiveConversationsJobStatus.MESSAGES_DELETED_FROM_DB
+        )
+        room_archived_conversation.messages_deleted_at = timezone.now()
+        room_archived_conversation.save(
+            update_fields=["status", "messages_deleted_at"]
+        )
 
         logger.info(
             f"[ArchiveChatsService] Room archived conversation status updated to "

--- a/chats/apps/archive_chats/tests/test_services.py
+++ b/chats/apps/archive_chats/tests/test_services.py
@@ -286,12 +286,21 @@ class TestArchiveChatsService(TestCase):
         self.assertIn("savepoint_count", observed)
         self.assertEqual(observed["savepoint_count"], baseline_savepoints)
 
-    def test_process_messages(self):
+    @override_settings(ARCHIVE_CHATS_MESSAGE_PAGE_SIZE=2)
+    @patch(
+        "chats.apps.archive_chats.services.is_file_on_chats_bucket", return_value=True
+    )
+    def test_process_messages(self, mock_is_file_on_chats_bucket):
         message_a = Message.objects.create(
             room=self.room,
             user=self.user,
             text="Test message",
             created_on=timezone.now(),
+        )
+        MessageMedia.objects.create(
+            message=message_a,
+            content_type="image/png",
+            media_file="archives/test-a.png",
         )
         message_b = Message.objects.create(
             room=self.room,
@@ -314,6 +323,11 @@ class TestArchiveChatsService(TestCase):
             user=self.user,
             text="Test message",
             created_on=timezone.now(),
+        )
+        MessageMedia.objects.create(
+            message=message_d,
+            content_type="image/jpeg",
+            media_file="archives/test-d.jpg",
         )
         RoomNote.objects.create(
             room=self.room,
@@ -374,6 +388,19 @@ class TestArchiveChatsService(TestCase):
                         "text": internal_note.text,
                     },
                 )
+
+        media_a = messages_data[0].get("media")
+        self.assertEqual(len(media_a), 1)
+        self.assertEqual(media_a[0]["content_type"], "image/png")
+        self.assertIn("object_key=archives/test-a.png", media_a[0]["url"])
+
+        self.assertEqual(messages_data[1].get("media"), [])
+        self.assertEqual(messages_data[2].get("media"), [])
+
+        media_d = messages_data[3].get("media")
+        self.assertEqual(len(media_d), 1)
+        self.assertEqual(media_d[0]["content_type"], "image/jpeg")
+        self.assertIn("object_key=archives/test-d.jpg", media_d[0]["url"])
 
     def test_upload_messages_file(self):
         archived_conversation = RoomArchivedConversation.objects.create(

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -857,6 +857,11 @@ ARCHIVE_CHATS_BATCH_SIZE = env.int("ARCHIVE_CHATS_BATCH_SIZE", default=500)
 ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE = env.int(
     "ARCHIVE_CHATS_BULK_CREATE_PENDING_BATCH_SIZE", default=2000
 )
+# Page size for keyset-paginated message iteration during archive.
+# Keeps peak memory bounded to one page of messages + their medias.
+ARCHIVE_CHATS_MESSAGE_PAGE_SIZE = env.int(
+    "ARCHIVE_CHATS_MESSAGE_PAGE_SIZE", default=500
+)
 # Soft-lock threshold used by ArchiveChatsService to decide whether an
 # in-progress RoomArchivedConversation is still being processed by another
 # worker or stale enough to be reclaimed.


### PR DESCRIPTION
### What

- Replaces loading all room messages (and all medias) into memory with keyset pagination (`created_on` + `pk`) in `_iter_messages`, using `ARCHIVE_CHATS_MESSAGE_PAGE_SIZE` (default 500)
- Prefetches medias and related fields per page instead of building a full `medias_by_message` map upfront
- Refactors message deletion to a simple batch loop (no pre-count / fixed batch count), updating archive status only after all deletes finish
- Updates tests to cover paginated iteration with medias

### Why

Large rooms were exhausting memory during archive because every message and media was loaded at once. Keyset pagination keeps peak memory to one page, making archive safer and more scalable for high-volume conversations.