### PR TITLE
Remove explicit image_arch configuration from build workflow

### DIFF
--- a/.github/workflows/build-chats-engine-push-tag-shared.yaml
+++ b/.github/workflows/build-chats-engine-push-tag-shared.yaml
@@ -37,15 +37,4 @@ jobs:
       target_repository: weni-ai/kubernetes-manifests-chats
       target_application: chats-engine
       target_patch_file: deployment.json
-      image_arch: |-
-        [
-          {
-            "platform": "linux/amd64",
-            "runner": "ubuntu-latest"
-          }
-        ]
-#          {
-#            "platform": "linux/arm64",
-#            "runner": "ubuntu-latest"
-#          },
     secrets: inherit


### PR DESCRIPTION
### What
Remove the explicit `image_arch` configuration from the build workflow to generate both available architectures.

### Why
_Explain the motivation. What problem or limitation existed before? What does this change enable, fix, or simplify for consumers of the code?_

### Sequence diagram
<img width="1723" height="301" alt="evidencia-ci" src="https://github.com/user-attachments/assets/201919ad-c837-427a-b892-4ca55479f7fa" />
