### PR TITLE
feat: add filter_moderators config to exclude admins from transfer agents

### DIFF
--- a/chats/apps/api/v1/queues/viewsets.py
+++ b/chats/apps/api/v1/queues/viewsets.py
@@ -380,17 +380,21 @@ class QueueViewset(ModelViewSet):
         project = Project.objects.get(sectors__queues=instance)
         project_admins = project.admins
 
-        combined_permissions = queue_agents.union(sector_agents, project_admins)
+        project_config = project.config if isinstance(project.config, dict) else {}
+        filter_offline_agents = project_config.get("filter_offline_agents", False)
+        filter_moderators = project_config.get("filter_moderators", False)
 
-        if isinstance(project.config, dict) and project.config.get(
-            "filter_offline_agents", False
-        ):
+        if filter_offline_agents:
             online_queue_agents = instance.online_agents
             online_sector_managers = sector.online_managers
-            online_admins = project.online_admins
-            combined_permissions = online_queue_agents.union(
-                online_sector_managers, online_admins
-            )
+            combined_permissions = online_queue_agents.union(online_sector_managers)
+            if not filter_moderators:
+                online_admins = project.online_admins
+                combined_permissions = combined_permissions.union(online_admins)
+        else:
+            combined_permissions = queue_agents.union(sector_agents)
+            if not filter_moderators:
+                combined_permissions = combined_permissions.union(project_admins)
 
         agents_pks = set(combined_permissions.values_list("id", flat=True))
         agents = User.objects.filter(id__in=agents_pks)

--- a/chats/apps/queues/tests/test_viewsets.py
+++ b/chats/apps/queues/tests/test_viewsets.py
@@ -536,6 +536,118 @@ class QueueTransferAgentsTests(APITestCase):
         self.assertNotIn(offline_agent.email, returned_emails)
         self.assertNotIn(offline_admin.email, returned_emails)
 
+    @with_project_permission()
+    def test_transfer_agents_filter_moderators_hides_project_admins(self):
+        self.project.config = {"filter_moderators": True}
+        self.project.save(update_fields=["config"])
+
+        agent = User.objects.create(email="agent-filter-mod@test.com")
+        agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=agent_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        manager = User.objects.create(email="manager-filter-mod@test.com")
+        manager_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=manager,
+            role=ProjectPermission.ROLE_ATTENDANT,
+        )
+        SectorAuthorization.objects.create(
+            sector=self.sector,
+            permission=manager_perm,
+            role=SectorAuthorization.ROLE_MANAGER,
+        )
+
+        admin = User.objects.create(email="admin-filter-mod@test.com")
+        ProjectPermission.objects.create(
+            project=self.project,
+            user=admin,
+            role=ProjectPermission.ROLE_ADMIN,
+        )
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_emails = [user_data.get("email") for user_data in response.data]
+
+        self.assertIn(agent.email, returned_emails)
+        self.assertIn(manager.email, returned_emails)
+        self.assertNotIn(admin.email, returned_emails)
+
+    @with_project_permission()
+    def test_transfer_agents_filter_moderators_and_offline_agents(self):
+        self.project.config = {
+            "filter_moderators": True,
+            "filter_offline_agents": True,
+        }
+        self.project.save(update_fields=["config"])
+
+        online_agent = User.objects.create(email="online-agent-both@test.com")
+        online_agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=online_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=online_agent_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        offline_agent = User.objects.create(email="offline-agent-both@test.com")
+        offline_agent_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=offline_agent,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_OFFLINE,
+        )
+        QueueAuthorization.objects.create(
+            queue=self.queue,
+            permission=offline_agent_perm,
+            role=QueueAuthorization.ROLE_AGENT,
+        )
+
+        online_manager = User.objects.create(email="online-manager-both@test.com")
+        online_manager_perm = ProjectPermission.objects.create(
+            project=self.project,
+            user=online_manager,
+            role=ProjectPermission.ROLE_ATTENDANT,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+        SectorAuthorization.objects.create(
+            sector=self.sector,
+            permission=online_manager_perm,
+            role=SectorAuthorization.ROLE_MANAGER,
+        )
+
+        online_admin = User.objects.create(email="online-admin-both@test.com")
+        ProjectPermission.objects.create(
+            project=self.project,
+            user=online_admin,
+            role=ProjectPermission.ROLE_ADMIN,
+            status=ProjectPermission.STATUS_ONLINE,
+        )
+
+        url = reverse("queue-transfer-agents", args=[self.queue.pk])
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_emails = [user_data.get("email") for user_data in response.data]
+
+        self.assertIn(online_agent.email, returned_emails)
+        self.assertIn(online_manager.email, returned_emails)
+        self.assertNotIn(offline_agent.email, returned_emails)
+        self.assertNotIn(online_admin.email, returned_emails)
+
     @override_settings(VTEX_INTERNAL_DOMAINS=["vtex.com", "weni.ai"])
     def test_transfer_agents_with_when_user_is_internal(self):
         domains = get_vtex_internal_domains_with_at_symbol()


### PR DESCRIPTION
### What
The `transfer_agents` endpoint now supports a `filter_moderators` project configuration flag. When enabled, project admins are excluded from the list of agents available for chat transfer. This flag works independently and also in combination with the existing `filter_offline_agents` flag — when both are active, only online queue agents and online sector managers are returned, with project admins excluded entirely.

### Why
Previously, project admins were always included in the transfer agents list (either all admins or only online admins, depending on the `filter_offline_agents` setting). Some projects need to restrict transfers to only direct queue agents and sector managers, hiding higher-level admins from the transfer options. The new `filter_moderators` flag provides this control without affecting projects that don't opt into it.