### PR TITLE
fix: exclude soft-deleted queue authorizations from agent retrieval

### DIFF
--- a/chats/apps/queues/models.py
+++ b/chats/apps/queues/models.py
@@ -99,6 +99,7 @@ class Queue(AuditableMixin, BaseSoftDeleteModel, BaseConfigurableModel, BaseMode
         return User.objects.filter(
             project_permissions__project=self.sector.project,
             project_permissions__queue_authorizations__queue=self,
+            project_permissions__queue_authorizations__is_deleted=False,
             project_permissions__is_deleted=False,
         )
 
@@ -130,6 +131,7 @@ class Queue(AuditableMixin, BaseSoftDeleteModel, BaseConfigurableModel, BaseMode
             "project_permissions__project": self.sector.project,
             "project_permissions__queue_authorizations__queue": self,
             "project_permissions__queue_authorizations__role": 1,
+            "project_permissions__queue_authorizations__is_deleted": False,
         }
 
         # If ping timeout feature is enabled, also filter by last_seen

--- a/chats/apps/queues/tests/test_models.py
+++ b/chats/apps/queues/tests/test_models.py
@@ -415,6 +415,16 @@ class QueueAuthorizationSoftDeleteTestCase(QueueSetUpMixin, TestCase):
 
         self.assertEqual(self.queue.agent_count, 1)
 
+    def test_agents_excludes_soft_deleted_authorization(self):
+        self.assertIn(self.agent, self.queue.agents)
+        self.assertIn(self.agent_2, self.queue.agents)
+
+        self.agent_auth.delete()
+
+        agents = list(self.queue.agents)
+        self.assertNotIn(self.agent, agents)
+        self.assertIn(self.agent_2, agents)
+
 
 class TestQueueOnlineAgents(TestCase):
     def setUp(self):


### PR DESCRIPTION
### What

- Filters soft-deleted `QueueAuthorization` records when resolving queue agents (`Queue.agents` and `Queue.online_agents`)
- Adds a test ensuring soft-deleted authorizations are excluded from `Queue.agents`

### Why

`QueueAuthorization` uses soft-delete, but agent lookups via reverse relations did not filter `is_deleted=False`. As a result, users with only deleted authorizations could still appear as agents of the queue.