### PR TITLE
fix: rearm risk alert on room-threshold crossings and scope toast to …

### DIFF
--- a/chats/apps/api/v1/dashboard/metric_goals/services.py
+++ b/chats/apps/api/v1/dashboard/metric_goals/services.py
@@ -61,9 +61,8 @@ class MetricGoalBreachService:
 
     Goals are flagged as breached as soon as a single room is above the
     threshold. `rooms_threshold_count` / `rooms_threshold_percent` do not
-    gate this widget alert — they only gate the email notification (see
-    `chats.apps.dashboard.services.metric_goal_alerts.Violation.meets_email_threshold`),
-    since email is opt-in and independent from the real-time alert.
+    gate this widget alert — they gate the email/toast notification (see
+    `chats.apps.dashboard.services.metric_goal_alerts.Violation.meets_rooms_threshold`).
     """
 
     def get_goals_payload(

--- a/chats/apps/api/websockets/dashboard/consumers/metric_goal_alerts.py
+++ b/chats/apps/api/websockets/dashboard/consumers/metric_goal_alerts.py
@@ -1,13 +1,15 @@
 """WebSocket consumer that streams metric goal alerts to a project.
 
 The consumer authenticates via the existing ``TokenAuthMiddleware`` and
-joins the ``metric_goal_alerts:{project_uuid}`` Channels group. Once
-joined, it receives broadcasts produced by the Celery sweep at
-``chats.apps.dashboard.tasks.check_metric_goal_violations``.
+joins the per-user Channels group
+``metric_goal_alerts:{project_uuid}:{user_hash}``. Toast alerts
+(``metric_goal.alert``) are fan-out only to configured email recipients,
+so users without email configured never receive the socket event.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 
@@ -26,7 +28,20 @@ logger = logging.getLogger(__name__)
 class MetricGoalAlertConsumer(AsyncJsonWebsocketConsumer):
     """Minimal read-only consumer for metric goal alerts."""
 
-    GROUP_TEMPLATE = "metric_goal_alerts:{project_uuid}"
+    # Channels group names only accept ``[A-Za-z0-9._-]`` and are capped
+    # at 100 chars. We hash the (normalized) email so ``@``, ``+`` and
+    # unicode addresses can't break the channel layer, and use ``.`` as
+    # separator since ``:`` isn't allowed.
+    GROUP_TEMPLATE = "metric_goal_alerts.{project_uuid}.{user_hash}"
+
+    @classmethod
+    def group_name_for(cls, project_uuid: str, user_email: str) -> str:
+        normalized = user_email.strip().lower().encode("utf-8")
+        user_hash = hashlib.sha1(normalized).hexdigest()[:16]
+        return cls.GROUP_TEMPLATE.format(
+            project_uuid=project_uuid,
+            user_hash=user_hash,
+        )
 
     async def connect(self):
         self.project_uuid = None
@@ -43,6 +58,7 @@ class MetricGoalAlertConsumer(AsyncJsonWebsocketConsumer):
             self.user is None
             or getattr(self.user, "is_anonymous", True)
             or not self.project_uuid
+            or not getattr(self.user, "email", None)
         ):
             await self.close()
             return
@@ -63,7 +79,7 @@ class MetricGoalAlertConsumer(AsyncJsonWebsocketConsumer):
             await self.close()
             return
 
-        self.group_name = self.GROUP_TEMPLATE.format(project_uuid=self.project_uuid)
+        self.group_name = self.group_name_for(self.project_uuid, self.user.email)
         await self.channel_layer.group_add(self.group_name, self.channel_name)
         await self.accept()
 
@@ -80,7 +96,11 @@ class MetricGoalAlertConsumer(AsyncJsonWebsocketConsumer):
         if isinstance(content, dict) and content.get("type") == "ping":
             await self.send_json({"type": "pong"})
 
+    async def metric_goal_alert(self, event):
+        await self._forward(event, "metric_goal.alert")
+
     async def metric_goal_violated(self, event):
+        # Legacy Channels type; prefer metric_goal_alert / metric_goal.alert.
         await self._forward(event, "metric_goal.violated")
 
     async def metric_goal_update(self, event):

--- a/chats/apps/api/websockets/dashboard/consumers/metric_goal_alerts.py
+++ b/chats/apps/api/websockets/dashboard/consumers/metric_goal_alerts.py
@@ -1,10 +1,13 @@
 """WebSocket consumer that streams metric goal alerts to a project.
 
 The consumer authenticates via the existing ``TokenAuthMiddleware`` and
-joins the per-user Channels group
-``metric_goal_alerts:{project_uuid}:{user_hash}``. Toast alerts
-(``metric_goal.alert``) are fan-out only to configured email recipients,
-so users without email configured never receive the socket event.
+joins two Channels groups:
+
+* ``metric_goal_alerts.{project_uuid}`` — project-wide events
+  (``metric_goal.violated`` / ``update`` / ``resolved``) for every
+  dashboard viewer.
+* ``metric_goal_alerts.{project_uuid}.{user_hash}`` — toast events
+  (``metric_goal.alert``) fan-out only to configured email recipients.
 """
 
 from __future__ import annotations
@@ -29,23 +32,28 @@ class MetricGoalAlertConsumer(AsyncJsonWebsocketConsumer):
     """Minimal read-only consumer for metric goal alerts."""
 
     # Channels group names only accept ``[A-Za-z0-9._-]`` and are capped
-    # at 100 chars. We hash the (normalized) email so ``@``, ``+`` and
-    # unicode addresses can't break the channel layer, and use ``.`` as
-    # separator since ``:`` isn't allowed.
-    GROUP_TEMPLATE = "metric_goal_alerts.{project_uuid}.{user_hash}"
+    # at 100 chars. We use ``.`` as separator since ``:`` isn't allowed.
+    PROJECT_GROUP_TEMPLATE = "metric_goal_alerts.{project_uuid}"
+    USER_GROUP_TEMPLATE = "metric_goal_alerts.{project_uuid}.{user_hash}"
+
+    @classmethod
+    def project_group_name(cls, project_uuid: str) -> str:
+        return cls.PROJECT_GROUP_TEMPLATE.format(project_uuid=project_uuid)
 
     @classmethod
     def group_name_for(cls, project_uuid: str, user_email: str) -> str:
+        """Per-user group used for toast (``metric_goal.alert``) fan-out."""
         normalized = user_email.strip().lower().encode("utf-8")
         user_hash = hashlib.sha1(normalized).hexdigest()[:16]
-        return cls.GROUP_TEMPLATE.format(
+        return cls.USER_GROUP_TEMPLATE.format(
             project_uuid=project_uuid,
             user_hash=user_hash,
         )
 
     async def connect(self):
         self.project_uuid = None
-        self.group_name = None
+        self.project_group_name = None
+        self.user_group_name = None
 
         try:
             self.user = self.scope["user"]
@@ -79,16 +87,24 @@ class MetricGoalAlertConsumer(AsyncJsonWebsocketConsumer):
             await self.close()
             return
 
-        self.group_name = self.group_name_for(self.project_uuid, self.user.email)
-        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        self.project_group_name = MetricGoalAlertConsumer.project_group_name(
+            self.project_uuid
+        )
+        self.user_group_name = MetricGoalAlertConsumer.group_name_for(
+            self.project_uuid, self.user.email
+        )
+        # Backwards-compat alias used by disconnect / older call sites.
+        self.group_name = self.user_group_name
+        await self.channel_layer.group_add(self.project_group_name, self.channel_name)
+        await self.channel_layer.group_add(self.user_group_name, self.channel_name)
         await self.accept()
 
     async def disconnect(self, code):
-        if getattr(self, "group_name", None):
+        for name in (self.project_group_name, self.user_group_name):
+            if not name:
+                continue
             try:
-                await self.channel_layer.group_discard(
-                    self.group_name, self.channel_name
-                )
+                await self.channel_layer.group_discard(name, self.channel_name)
             except Exception:
                 logger.debug("group_discard failed", exc_info=True)
 
@@ -100,7 +116,6 @@ class MetricGoalAlertConsumer(AsyncJsonWebsocketConsumer):
         await self._forward(event, "metric_goal.alert")
 
     async def metric_goal_violated(self, event):
-        # Legacy Channels type; prefer metric_goal_alert / metric_goal.alert.
         await self._forward(event, "metric_goal.violated")
 
     async def metric_goal_update(self, event):

--- a/chats/apps/api/websockets/dashboard/tests/test_metric_goal_alert_consumer.py
+++ b/chats/apps/api/websockets/dashboard/tests/test_metric_goal_alert_consumer.py
@@ -6,10 +6,13 @@ from unittest.mock import patch
 from channels.layers import get_channel_layer
 from channels.routing import URLRouter
 from channels.testing import WebsocketCommunicator
-from django.test import TestCase, override_settings
+from django.test import TransactionTestCase, override_settings
 
 from chats.apps.accounts.authentication.channels.middleware import TokenAuthMiddleware
 from chats.apps.api.utils import create_user_and_token
+from chats.apps.api.websockets.dashboard.consumers.metric_goal_alerts import (
+    MetricGoalAlertConsumer,
+)
 from chats.apps.api.websockets.rooms.routing import websocket_urlpatterns
 from chats.apps.projects.models import Project, ProjectPermission
 from chats.apps.sectors.models import Sector, SectorAuthorization
@@ -20,7 +23,7 @@ from chats.apps.sectors.models import Sector, SectorAuthorization
         "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
     }
 )
-class MetricGoalAlertConsumerTestCase(TestCase):
+class MetricGoalAlertConsumerTestCase(TransactionTestCase):
     def setUp(self):
         self.application = TokenAuthMiddleware(URLRouter(websocket_urlpatterns))
 
@@ -128,7 +131,7 @@ class MetricGoalAlertConsumerTestCase(TestCase):
         self.assertTrue(connected)
         await comm.disconnect()
 
-    async def test_receives_broadcast_for_own_project(self):
+    async def test_receives_broadcast_for_own_user_group(self):
         comm = WebsocketCommunicator(
             self.application,
             self._ws_url(self.project.uuid, self.admin_token.key),
@@ -138,18 +141,53 @@ class MetricGoalAlertConsumerTestCase(TestCase):
 
         layer = get_channel_layer()
         await layer.group_send(
-            f"metric_goal_alerts:{self.project.uuid}",
+            MetricGoalAlertConsumer.group_name_for(
+                str(self.project.uuid), self.admin.email
+            ),
             {
-                "type": "metric_goal_violated",
-                "action": "metric_goal.violated",
-                "content": json.dumps({"project_uuid": str(self.project.uuid)}),
+                "type": "metric_goal_alert",
+                "action": "metric_goal.alert",
+                "content": json.dumps(
+                    {
+                        "project_uuid": str(self.project.uuid),
+                        "recipients": [self.admin.email.lower()],
+                    }
+                ),
             },
         )
         message = await comm.receive_json_from(timeout=2)
-        self.assertEqual(message["type"], "metric_goal.violated")
+        self.assertEqual(message["type"], "metric_goal.alert")
         self.assertEqual(
             message["content"]["project_uuid"], str(self.project.uuid)
         )
+        await comm.disconnect()
+
+    async def test_does_not_receive_broadcast_for_other_user(self):
+        """Toast socket only reaches the recipient's own group."""
+        comm = WebsocketCommunicator(
+            self.application,
+            self._ws_url(self.project.uuid, self.admin_token.key),
+        )
+        connected, _ = await comm.connect()
+        self.assertTrue(connected)
+
+        layer = get_channel_layer()
+        await layer.group_send(
+            MetricGoalAlertConsumer.group_name_for(
+                str(self.project.uuid), self.manager.email
+            ),
+            {
+                "type": "metric_goal_alert",
+                "action": "metric_goal.alert",
+                "content": json.dumps(
+                    {
+                        "project_uuid": str(self.project.uuid),
+                        "recipients": [self.manager.email.lower()],
+                    }
+                ),
+            },
+        )
+        self.assertTrue(await comm.receive_nothing(timeout=0.5))
         await comm.disconnect()
 
     async def test_does_not_receive_broadcast_for_other_project(self):
@@ -162,10 +200,12 @@ class MetricGoalAlertConsumerTestCase(TestCase):
 
         layer = get_channel_layer()
         await layer.group_send(
-            f"metric_goal_alerts:{self.other_project.uuid}",
+            MetricGoalAlertConsumer.group_name_for(
+                str(self.other_project.uuid), self.admin.email
+            ),
             {
-                "type": "metric_goal_violated",
-                "action": "metric_goal.violated",
+                "type": "metric_goal_alert",
+                "action": "metric_goal.alert",
                 "content": json.dumps(
                     {"project_uuid": str(self.other_project.uuid)}
                 ),

--- a/chats/apps/api/websockets/dashboard/tests/test_metric_goal_alert_consumer.py
+++ b/chats/apps/api/websockets/dashboard/tests/test_metric_goal_alert_consumer.py
@@ -19,9 +19,7 @@ from chats.apps.sectors.models import Sector, SectorAuthorization
 
 
 @override_settings(
-    CHANNEL_LAYERS={
-        "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}
-    }
+    CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
 )
 class MetricGoalAlertConsumerTestCase(TransactionTestCase):
     def setUp(self):
@@ -77,9 +75,7 @@ class MetricGoalAlertConsumerTestCase(TransactionTestCase):
         self.addCleanup(self.ff_patch.stop)
 
     def _ws_url(self, project_uuid, token):
-        return (
-            f"/ws/dashboard/metric-goals?project={project_uuid}&Token={token}"
-        )
+        return f"/ws/dashboard/metric-goals?project={project_uuid}&Token={token}"
 
     async def test_rejects_without_token(self):
         comm = WebsocketCommunicator(
@@ -129,6 +125,32 @@ class MetricGoalAlertConsumerTestCase(TransactionTestCase):
         )
         connected, _ = await comm.connect()
         self.assertTrue(connected)
+        await comm.disconnect()
+
+    async def test_receives_project_broadcast_violated(self):
+        comm = WebsocketCommunicator(
+            self.application,
+            self._ws_url(self.project.uuid, self.admin_token.key),
+        )
+        connected, _ = await comm.connect()
+        self.assertTrue(connected)
+
+        layer = get_channel_layer()
+        await layer.group_send(
+            MetricGoalAlertConsumer.project_group_name(str(self.project.uuid)),
+            {
+                "type": "metric_goal_violated",
+                "action": "metric_goal.violated",
+                "content": json.dumps(
+                    {"project_uuid": str(self.project.uuid)}
+                ),
+            },
+        )
+        message = await comm.receive_json_from(timeout=2)
+        self.assertEqual(message["type"], "metric_goal.violated")
+        self.assertEqual(
+            message["content"]["project_uuid"], str(self.project.uuid)
+        )
         await comm.disconnect()
 
     async def test_receives_broadcast_for_own_user_group(self):
@@ -200,12 +222,12 @@ class MetricGoalAlertConsumerTestCase(TransactionTestCase):
 
         layer = get_channel_layer()
         await layer.group_send(
-            MetricGoalAlertConsumer.group_name_for(
-                str(self.other_project.uuid), self.admin.email
+            MetricGoalAlertConsumer.project_group_name(
+                str(self.other_project.uuid)
             ),
             {
-                "type": "metric_goal_alert",
-                "action": "metric_goal.alert",
+                "type": "metric_goal_violated",
+                "action": "metric_goal.violated",
                 "content": json.dumps(
                     {"project_uuid": str(self.other_project.uuid)}
                 ),

--- a/chats/apps/dashboard/services/metric_goal_alerts.py
+++ b/chats/apps/dashboard/services/metric_goal_alerts.py
@@ -11,12 +11,15 @@ not via the denormalized ``Room.project_uuid`` field, since that field
 is only populated by one of the room-creation paths and would otherwise
 undercount violations.
 
-``rooms_threshold_count`` / ``rooms_threshold_percent`` only gate the
-*email* notification. The WebSocket/toast alert (and the widget state)
-fires as soon as a single room breaches ``threshold_seconds`` — per the
-product epic, the "how many rooms" configuration is specific to the
-email channel, since email is opt-in and independent from the
-real-time alert.
+Email and toast (``metric_goal.alert``) fire together when:
+
+1. ``email_enabled`` is true, and
+2. ``violating_count`` crosses into ``>= rooms_threshold_count``.
+
+While the count stays at or above the rooms threshold, we only emit
+``metric_goal.update`` (no new toast/email). When the count drops below
+the rooms threshold, state is cleared so the next time the count reaches
+the threshold again, email and toast fire once more.
 """
 
 from __future__ import annotations
@@ -25,7 +28,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from math import ceil
-from typing import Iterable
+from typing import Dict, Iterable, List, Set
 
 from django.conf import settings
 from django.core.cache import cache
@@ -89,10 +92,8 @@ def is_metric_goal_alerts_enabled(project_uuid: str) -> bool:
 STATE_VIOLATING = "violating"
 
 DEFAULT_STATE_TTL_SECONDS = 30 * 60
-DEFAULT_EMAIL_COOLDOWN_SECONDS = 15 * 60
 
 STATE_KEY_TEMPLATE = "metric_goal_state:{project_uuid}:{metric}"
-EMAIL_COOLDOWN_KEY_TEMPLATE = "metric_goal_email_sent:{project_uuid}:{metric}"
 
 
 TRANSITION_NEW = "new"
@@ -102,13 +103,12 @@ TRANSITION_RESOLVED = "resolved"
 
 @dataclass(frozen=True)
 class Violation:
-    """A project currently in breach of a metric goal.
+    """A project with one or more rooms currently above ``threshold_seconds``.
 
-    ``violating_count`` is the real-time count of rooms in breach and is
-    what drives the WebSocket/toast/widget alert — that alert fires as
-    soon as ``violating_count >= 1``. ``rooms_threshold_count`` /
-    ``rooms_threshold_percent`` are only used to decide whether the
-    *email* notification should also be sent (see ``meets_email_threshold``).
+    Email/toast only fire when ``email_enabled`` is true and
+    ``meets_rooms_threshold`` is true (see ``process_violations``). The
+    dashboard widget still treats a single breached room as alertable via
+    ``MetricGoalBreachService``.
     """
 
     project_uuid: str
@@ -123,9 +123,14 @@ class Violation:
     detected_at: datetime = field(default_factory=timezone.now)
 
     @property
-    def meets_email_threshold(self) -> bool:
-        """Whether enough rooms are in breach to justify sending an email."""
+    def meets_rooms_threshold(self) -> bool:
+        """Whether enough rooms are in breach to fire email/toast."""
         return self.violating_count >= self.rooms_threshold_count
+
+    # Backwards-compatible alias used by older call sites / docs.
+    @property
+    def meets_email_threshold(self) -> bool:
+        return self.meets_rooms_threshold
 
     def as_broadcast_payload(self, state: str) -> dict:
         return {
@@ -206,7 +211,7 @@ def _resolve_threshold_count(
     )
 
 
-def _project_active_room_counts(project_uuids: Iterable[str]) -> dict[str, int]:
+def _project_active_room_counts(project_uuids: Iterable[str]) -> Dict[str, int]:
     if not project_uuids:
         return {}
     rows = (
@@ -223,12 +228,16 @@ def _project_active_room_counts(project_uuids: Iterable[str]) -> dict[str, int]:
 
 def detect_violations(
     metric: str, now: datetime | None = None
-) -> list[Violation]:
+) -> List[Violation]:
     """Return the list of projects currently violating ``metric``.
 
     One small aggregate query is issued per configured ``MetricGoal``.
     With ~230 active projects this stays well within the planner's
     sweet spot and keeps query shapes index-friendly.
+
+    A project is included as soon as at least one room breaches
+    ``threshold_seconds``. ``process_violations`` applies the rooms /
+    email gates before claiming Redis state or firing notifications.
     """
     now = now or timezone.now()
     goals = [
@@ -252,7 +261,7 @@ def detect_violations(
     )
 
     age_field = _max_age_field(metric)
-    violations: list[Violation] = []
+    violations: List[Violation] = []
 
     for goal in goals:
         project_uuid = str(goal["project__uuid"])
@@ -266,10 +275,6 @@ def detect_violations(
         if violating_count == 0:
             continue
 
-        # The WebSocket/toast/widget alert fires with a single room in
-        # breach. `threshold_count` is only computed here to carry it
-        # along on the Violation, so `process_violations` can later decide
-        # whether the email threshold was also met.
         active_count = active_counts.get(project_uuid)
         threshold_count = _resolve_threshold_count(goal, active_count)
 
@@ -298,20 +303,14 @@ def _state_key(project_uuid: str, metric: str) -> str:
     return STATE_KEY_TEMPLATE.format(project_uuid=project_uuid, metric=metric)
 
 
-def _email_cooldown_key(project_uuid: str, metric: str) -> str:
-    return EMAIL_COOLDOWN_KEY_TEMPLATE.format(
-        project_uuid=project_uuid, metric=metric
-    )
-
-
 def _claim_state(
     redis_conn, project_uuid: str, metric: str, ttl_seconds: int
 ) -> bool:
-    """Attempt to mark the (project, metric) as violating.
+    """Attempt to mark the (project, metric) as above the rooms threshold.
 
     Returns ``True`` when this call transitioned the state from clean to
-    violating (i.e. a fresh alert). Returns ``False`` when the state was
-    already set, in which case we simply refresh the TTL.
+    alerting (i.e. a fresh email/toast). Returns ``False`` when the state
+    was already set, in which case we simply refresh the TTL.
     """
     key = _state_key(project_uuid, metric)
     was_set = redis_conn.set(key, STATE_VIOLATING, nx=True, ex=ttl_seconds)
@@ -326,18 +325,10 @@ def _clear_state(redis_conn, project_uuid: str, metric: str) -> bool:
     return bool(redis_conn.delete(_state_key(project_uuid, metric)))
 
 
-def _claim_email_slot(
-    redis_conn, project_uuid: str, metric: str, ttl_seconds: int
-) -> bool:
-    """Reserve the email cooldown slot. Returns ``True`` if newly claimed."""
-    key = _email_cooldown_key(project_uuid, metric)
-    return bool(redis_conn.set(key, "1", nx=True, ex=ttl_seconds))
-
-
-def _violating_keys_for_metric(redis_conn, metric: str) -> set[str]:
-    """List ``project_uuid`` values currently flagged as violating."""
+def _alerting_keys_for_metric(redis_conn, metric: str) -> Set[str]:
+    """List ``project_uuid`` values currently flagged as above threshold."""
     pattern = STATE_KEY_TEMPLATE.format(project_uuid="*", metric=metric)
-    project_uuids: set[str] = set()
+    project_uuids: Set[str] = set()
     for raw in redis_conn.scan_iter(match=pattern):
         key = raw.decode() if isinstance(raw, bytes) else raw
         try:
@@ -351,9 +342,9 @@ def _violating_keys_for_metric(redis_conn, metric: str) -> set[str]:
 @dataclass(frozen=True)
 class ProcessingResult:
     metric: str
-    new_alerts: list[Violation]
-    updates: list[Violation]
-    resolved: list[str]
+    new_alerts: List[Violation]
+    updates: List[Violation]
+    resolved: List[str]
 
 
 def _safe_call(
@@ -382,31 +373,42 @@ def process_violations(
     metric: str,
     *,
     state_ttl_seconds: int = DEFAULT_STATE_TTL_SECONDS,
-    email_cooldown_seconds: int = DEFAULT_EMAIL_COOLDOWN_SECONDS,
     on_new_alert=None,
     on_update=None,
     on_resolved=None,
     on_email=None,
     now: datetime | None = None,
+    # Kept for call-site compatibility; rearm-by-threshold replaced cooldown.
+    email_cooldown_seconds: int | None = None,
 ) -> ProcessingResult:
     """Detect violations and reconcile with the Redis state machine.
+
+    Alert state is claimed only when ``email_enabled`` and
+    ``violating_count >= rooms_threshold_count``. Dropping below that
+    count clears state so a later climb back to the threshold fires
+    email/toast again.
 
     The callbacks are intentionally optional so the service can be
     exercised in tests without the Celery/Channels stack. Real callers
     (see ``chats.apps.dashboard.tasks``) wire them to broadcast helpers.
     """
+    del email_cooldown_seconds  # unused; kept for backwards-compatible kwargs
+
     violations = detect_violations(metric, now=now)
     redis_conn = get_redis_connection()
 
-    previously_violating = _violating_keys_for_metric(redis_conn, metric)
-    currently_violating: set[str] = set()
+    previously_alerting = _alerting_keys_for_metric(redis_conn, metric)
+    currently_alerting: Set[str] = set()
 
-    new_alerts: list[Violation] = []
-    updates: list[Violation] = []
-    emails_sent: list[Violation] = []
+    new_alerts: List[Violation] = []
+    updates: List[Violation] = []
+    emails_sent: List[Violation] = []
 
     for violation in violations:
-        currently_violating.add(violation.project_uuid)
+        if not violation.email_enabled or not violation.meets_rooms_threshold:
+            continue
+
+        currently_alerting.add(violation.project_uuid)
         is_new = _claim_state(
             redis_conn, violation.project_uuid, metric, state_ttl_seconds
         )
@@ -420,6 +422,14 @@ def process_violations(
                 metric,
                 violation,
             )
+            if _safe_call(
+                on_email,
+                "metric_goal: on_email failed (project=%s metric=%s)",
+                violation.project_uuid,
+                metric,
+                violation,
+            ):
+                emails_sent.append(violation)
         else:
             updates.append(violation)
             _safe_call(
@@ -430,31 +440,7 @@ def process_violations(
                 violation,
             )
 
-        # Email is gated by rooms_threshold_count ("Quando"), which may be
-        # crossed on the first breach (new) or only later (update). The
-        # cooldown slot ensures we still send at most once per metric
-        # until the TTL expires.
-        if (
-            on_email is not None
-            and violation.email_enabled
-            and violation.meets_email_threshold
-            and _claim_email_slot(
-                redis_conn,
-                violation.project_uuid,
-                metric,
-                email_cooldown_seconds,
-            )
-            and _safe_call(
-                on_email,
-                "metric_goal: on_email failed (project=%s metric=%s)",
-                violation.project_uuid,
-                metric,
-                violation,
-            )
-        ):
-            emails_sent.append(violation)
-
-    resolved_uuids = list(previously_violating - currently_violating)
+    resolved_uuids = list(previously_alerting - currently_alerting)
     for project_uuid in resolved_uuids:
         _clear_state(redis_conn, project_uuid, metric)
         _safe_call(

--- a/chats/apps/dashboard/services/metric_goal_alerts.py
+++ b/chats/apps/dashboard/services/metric_goal_alerts.py
@@ -11,15 +11,15 @@ not via the denormalized ``Room.project_uuid`` field, since that field
 is only populated by one of the room-creation paths and would otherwise
 undercount violations.
 
-Email and toast (``metric_goal.alert``) fire together when:
+Two independent Redis state machines run in parallel:
 
-1. ``email_enabled`` is true, and
-2. ``violating_count`` crosses into ``>= rooms_threshold_count``.
-
-While the count stays at or above the rooms threshold, we only emit
-``metric_goal.update`` (no new toast/email). When the count drops below
-the rooms threshold, state is cleared so the next time the count reaches
-the threshold again, email and toast fire once more.
+1. **Widget / project broadcast** (``metric_goal.violated`` /
+   ``update`` / ``resolved``): claimed as soon as a single room breaches
+   ``threshold_seconds``. Cleared when no rooms remain in breach.
+2. **Toast / email** (``metric_goal.alert`` + email): claimed when
+   ``email_enabled`` is true and ``violating_count`` crosses into
+   ``>= rooms_threshold_count``. Dropping below that count clears the
+   toast state so the next climb back to the threshold fires again.
 """
 
 from __future__ import annotations
@@ -90,10 +90,12 @@ def is_metric_goal_alerts_enabled(project_uuid: str) -> bool:
 
 
 STATE_VIOLATING = "violating"
+STATE_ALERTING = "alerting"
 
 DEFAULT_STATE_TTL_SECONDS = 30 * 60
 
 STATE_KEY_TEMPLATE = "metric_goal_state:{project_uuid}:{metric}"
+ALERT_STATE_KEY_TEMPLATE = "metric_goal_alert_state:{project_uuid}:{metric}"
 
 
 TRANSITION_NEW = "new"
@@ -105,10 +107,10 @@ TRANSITION_RESOLVED = "resolved"
 class Violation:
     """A project with one or more rooms currently above ``threshold_seconds``.
 
-    Email/toast only fire when ``email_enabled`` is true and
-    ``meets_rooms_threshold`` is true (see ``process_violations``). The
-    dashboard widget still treats a single breached room as alertable via
-    ``MetricGoalBreachService``.
+    Widget broadcasts (``metric_goal.violated`` / ``update`` / ``resolved``)
+    fire as soon as ``violating_count >= 1``. Email/toast
+    (``metric_goal.alert``) only fire when ``email_enabled`` is true and
+    ``meets_rooms_threshold`` is true (see ``process_violations``).
     """
 
     project_uuid: str
@@ -200,9 +202,7 @@ def _max_age_field(metric: str) -> str:
     return "first_user_assigned_at"
 
 
-def _resolve_threshold_count(
-    goal_data: dict, active_rooms_count: int | None
-) -> int:
+def _resolve_threshold_count(goal_data: dict, active_rooms_count: int | None) -> int:
     percent = goal_data.get("rooms_threshold_percent")
     if percent and active_rooms_count is not None:
         return max(1, ceil(active_rooms_count * percent / 100))
@@ -221,9 +221,7 @@ def _project_active_room_counts(project_uuids: Iterable[str]) -> Dict[str, int]:
         .values("queue__sector__project__uuid")
         .annotate(count=Count("uuid"))
     )
-    return {
-        str(row["queue__sector__project__uuid"]): row["count"] for row in rows
-    }
+    return {str(row["queue__sector__project__uuid"]): row["count"] for row in rows}
 
 
 def detect_violations(
@@ -236,8 +234,9 @@ def detect_violations(
     sweet spot and keeps query shapes index-friendly.
 
     A project is included as soon as at least one room breaches
-    ``threshold_seconds``. ``process_violations`` applies the rooms /
-    email gates before claiming Redis state or firing notifications.
+    ``threshold_seconds``. ``process_violations`` then drives the widget
+    state machine on that list and applies the rooms / email gates only
+    for toast and email notifications.
     """
     now = now or timezone.now()
     goals = [
@@ -303,31 +302,55 @@ def _state_key(project_uuid: str, metric: str) -> str:
     return STATE_KEY_TEMPLATE.format(project_uuid=project_uuid, metric=metric)
 
 
-def _claim_state(
-    redis_conn, project_uuid: str, metric: str, ttl_seconds: int
-) -> bool:
-    """Attempt to mark the (project, metric) as above the rooms threshold.
+def _alert_state_key(project_uuid: str, metric: str) -> str:
+    return ALERT_STATE_KEY_TEMPLATE.format(
+        project_uuid=project_uuid, metric=metric
+    )
 
-    Returns ``True`` when this call transitioned the state from clean to
-    alerting (i.e. a fresh email/toast). Returns ``False`` when the state
-    was already set, in which case we simply refresh the TTL.
-    """
-    key = _state_key(project_uuid, metric)
-    was_set = redis_conn.set(key, STATE_VIOLATING, nx=True, ex=ttl_seconds)
+
+def _claim_key(redis_conn, key: str, value: str, ttl_seconds: int) -> bool:
+    """SET NX + refresh TTL. Returns True when the key was newly created."""
+    was_set = redis_conn.set(key, value, nx=True, ex=ttl_seconds)
     if was_set:
         return True
     redis_conn.expire(key, ttl_seconds)
     return False
 
 
+def _claim_state(
+    redis_conn, project_uuid: str, metric: str, ttl_seconds: int
+) -> bool:
+    """Mark (project, metric) as violating (any room in breach)."""
+    return _claim_key(
+        redis_conn, _state_key(project_uuid, metric), STATE_VIOLATING, ttl_seconds
+    )
+
+
+def _claim_alert_state(
+    redis_conn, project_uuid: str, metric: str, ttl_seconds: int
+) -> bool:
+    """Mark (project, metric) as above the rooms threshold for toast/email."""
+    return _claim_key(
+        redis_conn,
+        _alert_state_key(project_uuid, metric),
+        STATE_ALERTING,
+        ttl_seconds,
+    )
+
+
 def _clear_state(redis_conn, project_uuid: str, metric: str) -> bool:
-    """Remove the state key. Returns ``True`` when something was cleared."""
+    """Remove the violating state key."""
     return bool(redis_conn.delete(_state_key(project_uuid, metric)))
 
 
-def _alerting_keys_for_metric(redis_conn, metric: str) -> Set[str]:
-    """List ``project_uuid`` values currently flagged as above threshold."""
-    pattern = STATE_KEY_TEMPLATE.format(project_uuid="*", metric=metric)
+def _clear_alert_state(redis_conn, project_uuid: str, metric: str) -> bool:
+    """Remove the toast/email alerting state key."""
+    return bool(redis_conn.delete(_alert_state_key(project_uuid, metric)))
+
+
+def _keys_for_metric(redis_conn, template: str, metric: str) -> Set[str]:
+    """List ``project_uuid`` values currently flagged for ``template``."""
+    pattern = template.format(project_uuid="*", metric=metric)
     project_uuids: Set[str] = set()
     for raw in redis_conn.scan_iter(match=pattern):
         key = raw.decode() if isinstance(raw, bytes) else raw
@@ -339,12 +362,23 @@ def _alerting_keys_for_metric(redis_conn, metric: str) -> Set[str]:
     return project_uuids
 
 
+def _violating_keys_for_metric(redis_conn, metric: str) -> Set[str]:
+    """List ``project_uuid`` values currently flagged as violating."""
+    return _keys_for_metric(redis_conn, STATE_KEY_TEMPLATE, metric)
+
+
+def _alerting_keys_for_metric(redis_conn, metric: str) -> Set[str]:
+    """List ``project_uuid`` values currently flagged for toast/email."""
+    return _keys_for_metric(redis_conn, ALERT_STATE_KEY_TEMPLATE, metric)
+
+
 @dataclass(frozen=True)
 class ProcessingResult:
     metric: str
     new_alerts: List[Violation]
     updates: List[Violation]
     resolved: List[str]
+    toasts: List[Violation] = field(default_factory=list)
 
 
 def _safe_call(
@@ -376,17 +410,21 @@ def process_violations(
     on_new_alert=None,
     on_update=None,
     on_resolved=None,
+    on_toast=None,
     on_email=None,
     now: datetime | None = None,
     # Kept for call-site compatibility; rearm-by-threshold replaced cooldown.
     email_cooldown_seconds: int | None = None,
 ) -> ProcessingResult:
-    """Detect violations and reconcile with the Redis state machine.
+    """Detect violations and reconcile with the Redis state machines.
 
-    Alert state is claimed only when ``email_enabled`` and
-    ``violating_count >= rooms_threshold_count``. Dropping below that
-    count clears state so a later climb back to the threshold fires
-    email/toast again.
+    Widget path (``on_new_alert`` / ``on_update`` / ``on_resolved``):
+    claimed as soon as any room breaches ``threshold_seconds``.
+
+    Toast/email path (``on_toast`` / ``on_email``): claimed only when
+    ``email_enabled`` and ``violating_count >= rooms_threshold_count``.
+    Dropping below that count clears toast state so a later climb back
+    fires toast/email again.
 
     The callbacks are intentionally optional so the service can be
     exercised in tests without the Celery/Channels stack. Real callers
@@ -397,18 +435,18 @@ def process_violations(
     violations = detect_violations(metric, now=now)
     redis_conn = get_redis_connection()
 
+    previously_violating = _violating_keys_for_metric(redis_conn, metric)
     previously_alerting = _alerting_keys_for_metric(redis_conn, metric)
+    currently_violating: Set[str] = set()
     currently_alerting: Set[str] = set()
 
     new_alerts: List[Violation] = []
     updates: List[Violation] = []
+    toasts: List[Violation] = []
     emails_sent: List[Violation] = []
 
     for violation in violations:
-        if not violation.email_enabled or not violation.meets_rooms_threshold:
-            continue
-
-        currently_alerting.add(violation.project_uuid)
+        currently_violating.add(violation.project_uuid)
         is_new = _claim_state(
             redis_conn, violation.project_uuid, metric, state_ttl_seconds
         )
@@ -422,14 +460,6 @@ def process_violations(
                 metric,
                 violation,
             )
-            if _safe_call(
-                on_email,
-                "metric_goal: on_email failed (project=%s metric=%s)",
-                violation.project_uuid,
-                metric,
-                violation,
-            ):
-                emails_sent.append(violation)
         else:
             updates.append(violation)
             _safe_call(
@@ -440,9 +470,37 @@ def process_violations(
                 violation,
             )
 
-    resolved_uuids = list(previously_alerting - currently_alerting)
+        if not violation.email_enabled or not violation.meets_rooms_threshold:
+            continue
+
+        currently_alerting.add(violation.project_uuid)
+        is_new_toast = _claim_alert_state(
+            redis_conn, violation.project_uuid, metric, state_ttl_seconds
+        )
+        if not is_new_toast:
+            continue
+
+        toasts.append(violation)
+        _safe_call(
+            on_toast,
+            "metric_goal: on_toast failed (project=%s metric=%s)",
+            violation.project_uuid,
+            metric,
+            violation,
+        )
+        if _safe_call(
+            on_email,
+            "metric_goal: on_email failed (project=%s metric=%s)",
+            violation.project_uuid,
+            metric,
+            violation,
+        ):
+            emails_sent.append(violation)
+
+    resolved_uuids = list(previously_violating - currently_violating)
     for project_uuid in resolved_uuids:
         _clear_state(redis_conn, project_uuid, metric)
+        _clear_alert_state(redis_conn, project_uuid, metric)
         _safe_call(
             on_resolved,
             "metric_goal: on_resolved failed (project=%s metric=%s)",
@@ -452,12 +510,20 @@ def process_violations(
             metric,
         )
 
+    # Dropped below rooms threshold but still violating: clear toast state
+    # so the next climb re-fires toast/email without a widget resolve.
+    for project_uuid in previously_alerting - currently_alerting:
+        if project_uuid in currently_violating:
+            _clear_alert_state(redis_conn, project_uuid, metric)
+
     logger.info(
-        "metric_goal sweep: metric=%s new=%s updates=%s resolved=%s emails=%s",
+        "metric_goal sweep: metric=%s new=%s updates=%s resolved=%s "
+        "toasts=%s emails=%s",
         metric,
         len(new_alerts),
         len(updates),
         len(resolved_uuids),
+        len(toasts),
         len(emails_sent),
     )
 
@@ -466,4 +532,5 @@ def process_violations(
         new_alerts=new_alerts,
         updates=updates,
         resolved=resolved_uuids,
+        toasts=toasts,
     )

--- a/chats/apps/dashboard/services/metric_goal_alerts.py
+++ b/chats/apps/dashboard/services/metric_goal_alerts.py
@@ -188,7 +188,10 @@ def _build_violation_queryset(metric: str, project_uuid: str, cutoff: datetime):
         )
 
     if metric == MetricGoal.METRIC_CONVERSATION_DURATION:
+        # Must match MetricGoalBreachService / TimeMetricsService: only
+        # rooms currently assigned to an agent count as "in conversation".
         return base.filter(
+            user__isnull=False,
             first_user_assigned_at__isnull=False,
             first_user_assigned_at__lte=cutoff,
         )

--- a/chats/apps/dashboard/tasks.py
+++ b/chats/apps/dashboard/tasks.py
@@ -846,6 +846,15 @@ def process_pending_reports():
         _handle_report_error(report, e, user_email)
 
 
+def _metric_goal_project_group(project_uuid: str) -> str:
+    """Project-wide group for violated / update / resolved broadcasts."""
+    from chats.apps.api.websockets.dashboard.consumers.metric_goal_alerts import (
+        MetricGoalAlertConsumer,
+    )
+
+    return MetricGoalAlertConsumer.project_group_name(project_uuid)
+
+
 def _metric_goal_user_group(project_uuid: str, user_email: str) -> str:
     """Per-user group so toast alerts only reach configured email recipients.
 
@@ -858,6 +867,22 @@ def _metric_goal_user_group(project_uuid: str, user_email: str) -> str:
     )
 
     return MetricGoalAlertConsumer.group_name_for(project_uuid, user_email)
+
+
+def _broadcast_metric_goal(
+    *,
+    project_uuid: str,
+    call_type: str,
+    action: str,
+    content: dict,
+) -> None:
+    """Send a metric goal event to the project's WebSocket group."""
+    send_channels_group(
+        group_name=_metric_goal_project_group(project_uuid),
+        call_type=call_type,
+        content=content,
+        action=action,
+    )
 
 
 def _broadcast_metric_goal_to_emails(
@@ -915,6 +940,18 @@ def _recipients_for_project_metric(project_uuid: str, metric: str) -> List[str]:
 
 
 def _broadcast_new_alert(violation: Violation) -> None:
+    """Send ``metric_goal.violated`` to every dashboard viewer on the project."""
+    payload = violation.as_broadcast_payload(state="violating")
+    payload["transition"] = "new"
+    _broadcast_metric_goal(
+        project_uuid=violation.project_uuid,
+        call_type="metric_goal_violated",
+        action="metric_goal.violated",
+        content=payload,
+    )
+
+
+def _broadcast_toast(violation: Violation) -> None:
     """Send ``metric_goal.alert`` only to users with email configured."""
     recipients = _recipients_for_project_metric(
         violation.project_uuid, violation.metric
@@ -935,17 +972,10 @@ def _broadcast_new_alert(violation: Violation) -> None:
 
 
 def _broadcast_update(violation: Violation) -> None:
-    recipients = _recipients_for_project_metric(
-        violation.project_uuid, violation.metric
-    )
-    if not recipients:
-        return
-
     payload = violation.as_broadcast_payload(state="violating")
     payload["transition"] = "update"
-    _broadcast_metric_goal_to_emails(
+    _broadcast_metric_goal(
         project_uuid=violation.project_uuid,
-        emails=recipients,
         call_type="metric_goal_update",
         action="metric_goal.update",
         content=payload,
@@ -953,19 +983,14 @@ def _broadcast_update(violation: Violation) -> None:
 
 
 def _broadcast_resolved(project_uuid: str, metric: str) -> None:
-    recipients = _recipients_for_project_metric(project_uuid, metric)
-    if not recipients:
-        return
-
     payload = {
         "project_uuid": project_uuid,
         "metric": metric,
         "state": "ok",
         "detected_at": datetime.now(timezone.utc).isoformat(),
     }
-    _broadcast_metric_goal_to_emails(
+    _broadcast_metric_goal(
         project_uuid=project_uuid,
-        emails=recipients,
         call_type="metric_goal_resolved",
         action="metric_goal.resolved",
         content=payload,
@@ -1006,6 +1031,7 @@ def check_metric_goal_violations():
                 on_new_alert=_broadcast_new_alert,
                 on_update=_broadcast_update,
                 on_resolved=_broadcast_resolved,
+                on_toast=_broadcast_toast,
                 on_email=_queue_metric_goal_email,
             )
         except Exception:

--- a/chats/apps/dashboard/tasks.py
+++ b/chats/apps/dashboard/tasks.py
@@ -846,35 +846,106 @@ def process_pending_reports():
         _handle_report_error(report, e, user_email)
 
 
-def _metric_goal_group(project_uuid: str) -> str:
-    return f"metric_goal_alerts:{project_uuid}"
+def _metric_goal_user_group(project_uuid: str, user_email: str) -> str:
+    """Per-user group so toast alerts only reach configured email recipients.
 
-
-def _broadcast_metric_goal(call_type: str, action: str, content: dict) -> None:
-    """Send a metric goal event to the project's WebSocket group."""
-    project_uuid = content["project_uuid"]
-    send_channels_group(
-        group_name=_metric_goal_group(project_uuid),
-        call_type=call_type,
-        content=content,
-        action=action,
+    Channels group names only accept ``[A-Za-z0-9._-]`` and are capped at
+    100 chars, so we hash the (normalized) email to avoid ``@``/``+``/
+    unicode breaking the channel layer in production.
+    """
+    from chats.apps.api.websockets.dashboard.consumers.metric_goal_alerts import (
+        MetricGoalAlertConsumer,
     )
+
+    return MetricGoalAlertConsumer.group_name_for(project_uuid, user_email)
+
+
+def _broadcast_metric_goal_to_emails(
+    *,
+    project_uuid: str,
+    emails: List[str],
+    call_type: str,
+    action: str,
+    content: dict,
+) -> None:
+    """Fan-out a metric goal event to each recipient's WebSocket group."""
+    seen: set = set()
+    for email in emails:
+        if not email:
+            continue
+        normalized = email.strip().lower()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        send_channels_group(
+            group_name=_metric_goal_user_group(project_uuid, normalized),
+            call_type=call_type,
+            content=content,
+            action=action,
+        )
+
+
+def _eligible_recipient_emails(goal: MetricGoal) -> List[str]:
+    """Return the emails of recipients still eligible for notifications."""
+    permissions = goal.recipients.select_related("user").prefetch_related(
+        "sector_authorizations"
+    )
+    emails: List[str] = []
+    for permission in permissions:
+        user = getattr(permission, "user", None)
+        if not user or not user.email:
+            continue
+        if permission.is_admin or permission.sector_authorizations.all():
+            emails.append(user.email.strip().lower())
+    return emails
+
+
+def _goal_for(project_uuid: str, metric: str) -> Optional[MetricGoal]:
+    try:
+        return MetricGoal.objects.get(project__uuid=project_uuid, metric=metric)
+    except MetricGoal.DoesNotExist:
+        return None
+
+
+def _recipients_for_project_metric(project_uuid: str, metric: str) -> List[str]:
+    goal = _goal_for(project_uuid, metric)
+    if goal is None:
+        return []
+    return _eligible_recipient_emails(goal)
 
 
 def _broadcast_new_alert(violation: Violation) -> None:
+    """Send ``metric_goal.alert`` only to users with email configured."""
+    recipients = _recipients_for_project_metric(
+        violation.project_uuid, violation.metric
+    )
+    if not recipients:
+        return
+
     payload = violation.as_broadcast_payload(state="violating")
     payload["transition"] = "new"
-    _broadcast_metric_goal(
-        call_type="metric_goal_violated",
-        action="metric_goal.violated",
+    payload["recipients"] = recipients
+    _broadcast_metric_goal_to_emails(
+        project_uuid=violation.project_uuid,
+        emails=recipients,
+        call_type="metric_goal_alert",
+        action="metric_goal.alert",
         content=payload,
     )
 
 
 def _broadcast_update(violation: Violation) -> None:
+    recipients = _recipients_for_project_metric(
+        violation.project_uuid, violation.metric
+    )
+    if not recipients:
+        return
+
     payload = violation.as_broadcast_payload(state="violating")
     payload["transition"] = "update"
-    _broadcast_metric_goal(
+    _broadcast_metric_goal_to_emails(
+        project_uuid=violation.project_uuid,
+        emails=recipients,
         call_type="metric_goal_update",
         action="metric_goal.update",
         content=payload,
@@ -882,13 +953,19 @@ def _broadcast_update(violation: Violation) -> None:
 
 
 def _broadcast_resolved(project_uuid: str, metric: str) -> None:
+    recipients = _recipients_for_project_metric(project_uuid, metric)
+    if not recipients:
+        return
+
     payload = {
         "project_uuid": project_uuid,
         "metric": metric,
         "state": "ok",
         "detected_at": datetime.now(timezone.utc).isoformat(),
     }
-    _broadcast_metric_goal(
+    _broadcast_metric_goal_to_emails(
+        project_uuid=project_uuid,
+        emails=recipients,
         call_type="metric_goal_resolved",
         action="metric_goal.resolved",
         content=payload,
@@ -921,15 +998,11 @@ def check_metric_goal_violations():
         MetricGoal.METRIC_CONVERSATION_DURATION,
     ]
     state_ttl = getattr(settings, "METRIC_GOAL_STATE_TTL_SECONDS", 30 * 60)
-    email_cooldown = getattr(
-        settings, "METRIC_GOAL_EMAIL_COOLDOWN_SECONDS", 15 * 60
-    )
     for metric in metrics:
         try:
             process_violations(
                 metric,
                 state_ttl_seconds=state_ttl,
-                email_cooldown_seconds=email_cooldown,
                 on_new_alert=_broadcast_new_alert,
                 on_update=_broadcast_update,
                 on_resolved=_broadcast_resolved,
@@ -939,21 +1012,6 @@ def check_metric_goal_violations():
             logger.exception(
                 "metric_goal sweep failed for metric=%s", metric
             )
-
-
-def _eligible_recipient_emails(goal: MetricGoal) -> List[str]:
-    """Return the emails of recipients still eligible for notifications."""
-    permissions = goal.recipients.select_related("user").prefetch_related(
-        "sector_authorizations"
-    )
-    emails: List[str] = []
-    for permission in permissions:
-        user = getattr(permission, "user", None)
-        if not user or not user.email:
-            continue
-        if permission.is_admin or permission.sector_authorizations.all():
-            emails.append(user.email)
-    return emails
 
 
 @app.task(name="send_metric_goal_email")

--- a/chats/apps/dashboard/tests/test_metric_goal_alerts_service.py
+++ b/chats/apps/dashboard/tests/test_metric_goal_alerts_service.py
@@ -234,7 +234,7 @@ class DetectViolationsTestCase(TestCase):
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].violating_count, 1)
-        self.assertEqual(assigned.user_id, user.pk)
+        self.assertEqual(assigned.user_id, user.email)
 
 
 class ProcessViolationsTestCase(TestCase):

--- a/chats/apps/dashboard/tests/test_metric_goal_alerts_service.py
+++ b/chats/apps/dashboard/tests/test_metric_goal_alerts_service.py
@@ -65,9 +65,7 @@ def _build_active_room(project, queue, *, user=None, age_seconds=0):
     )
     past = timezone.now() - timedelta(seconds=age_seconds)
     if user is None:
-        Room.objects.filter(pk=room.pk).update(
-            added_to_queue_at=past, user=None
-        )
+        Room.objects.filter(pk=room.pk).update(added_to_queue_at=past, user=None)
     else:
         Room.objects.filter(pk=room.pk).update(
             added_to_queue_at=past,
@@ -99,9 +97,7 @@ class DetectViolationsTestCase(TestCase):
         self.addCleanup(self.ff_patch.stop)
 
     def test_returns_empty_when_no_active_goals(self):
-        self.assertEqual(
-            detect_violations(MetricGoal.METRIC_WAITING_TIME), []
-        )
+        self.assertEqual(detect_violations(MetricGoal.METRIC_WAITING_TIME), [])
 
     def test_detects_waiting_time_when_threshold_reached(self):
         MetricGoal.objects.create(
@@ -252,13 +248,16 @@ class ProcessViolationsTestCase(TestCase):
     def test_first_run_emits_new_alert_and_email(self):
         self._seed_violation()
         new_alerts: list[Violation] = []
+        toasts: list[Violation] = []
         emails: list[Violation] = []
         result = process_violations(
             MetricGoal.METRIC_WAITING_TIME,
             on_new_alert=new_alerts.append,
+            on_toast=toasts.append,
             on_email=emails.append,
         )
         self.assertEqual(len(new_alerts), 1)
+        self.assertEqual(len(toasts), 1)
         self.assertEqual(len(emails), 1)
         self.assertEqual(result.resolved, [])
         state_key = STATE_KEY_TEMPLATE.format(
@@ -290,9 +289,7 @@ class ProcessViolationsTestCase(TestCase):
             MetricGoal.METRIC_WAITING_TIME,
             on_new_alert=lambda v: None,
         )
-        Room.objects.filter(project_uuid=str(self.project.uuid)).update(
-            is_active=False
-        )
+        Room.objects.filter(project_uuid=str(self.project.uuid)).update(is_active=False)
         resolved: list[str] = []
         result = process_violations(
             MetricGoal.METRIC_WAITING_TIME,
@@ -325,13 +322,17 @@ class ProcessViolationsTestCase(TestCase):
         ).update(email_enabled=False)
         self._seed_violation()
         emails: list[Violation] = []
+        toasts: list[Violation] = []
         result = process_violations(
             MetricGoal.METRIC_WAITING_TIME,
             on_new_alert=lambda v: None,
+            on_toast=toasts.append,
             on_email=emails.append,
         )
         self.assertEqual(len(emails), 0)
-        self.assertEqual(len(result.new_alerts), 0)
+        self.assertEqual(len(toasts), 0)
+        # Widget path still fires with a single breached room.
+        self.assertEqual(len(result.new_alerts), 1)
 
     def test_alert_and_email_skipped_when_below_rooms_threshold(self):
         """Below rooms_threshold_count: no toast and no email."""
@@ -342,16 +343,19 @@ class ProcessViolationsTestCase(TestCase):
         self._seed_violation()
 
         new_alerts: list[Violation] = []
+        toasts: list[Violation] = []
         emails: list[Violation] = []
         result = process_violations(
             MetricGoal.METRIC_WAITING_TIME,
             on_new_alert=new_alerts.append,
+            on_toast=toasts.append,
             on_email=emails.append,
         )
 
-        self.assertEqual(len(new_alerts), 0)
+        self.assertEqual(len(new_alerts), 1)
+        self.assertEqual(len(toasts), 0)
         self.assertEqual(len(emails), 0)
-        self.assertEqual(len(result.new_alerts), 0)
+        self.assertEqual(len(result.toasts), 0)
 
     def test_alert_and_email_fire_when_rooms_threshold_is_reached(self):
         """Crossing into rooms_threshold_count fires toast + email together."""
@@ -362,22 +366,25 @@ class ProcessViolationsTestCase(TestCase):
 
         self._seed_violation()
         emails: list[Violation] = []
+        toasts: list[Violation] = []
         first = process_violations(
             MetricGoal.METRIC_WAITING_TIME,
             on_new_alert=lambda v: None,
+            on_toast=toasts.append,
             on_email=emails.append,
         )
-        self.assertEqual(len(first.new_alerts), 0)
+        self.assertEqual(len(first.new_alerts), 1)
+        self.assertEqual(len(toasts), 0)
         self.assertEqual(len(emails), 0)
 
         self._seed_violation()
-        new_alerts: list[Violation] = []
         process_violations(
             MetricGoal.METRIC_WAITING_TIME,
-            on_new_alert=new_alerts.append,
+            on_update=lambda v: None,
+            on_toast=toasts.append,
             on_email=emails.append,
         )
-        self.assertEqual(len(new_alerts), 1)
+        self.assertEqual(len(toasts), 1)
         self.assertEqual(len(emails), 1)
         self.assertEqual(emails[0].violating_count, 2)
 
@@ -393,17 +400,18 @@ class ProcessViolationsTestCase(TestCase):
             for _ in range(5)
         ]
         emails: list[Violation] = []
-        alerts: list[Violation] = []
+        toasts: list[Violation] = []
 
         process_violations(
             MetricGoal.METRIC_WAITING_TIME,
-            on_new_alert=alerts.append,
+            on_new_alert=lambda v: None,
+            on_toast=toasts.append,
             on_email=emails.append,
         )
-        self.assertEqual(len(alerts), 1)
+        self.assertEqual(len(toasts), 1)
         self.assertEqual(len(emails), 1)
 
-        # Resolve 3 rooms → 2 remain (below threshold) → clear state.
+        # Resolve 3 rooms → 2 remain (still violating, below toast threshold).
         for room in rooms[:3]:
             room.is_active = False
             room.save(update_fields=["is_active"])
@@ -411,22 +419,24 @@ class ProcessViolationsTestCase(TestCase):
         resolved: list[str] = []
         process_violations(
             MetricGoal.METRIC_WAITING_TIME,
+            on_update=lambda v: None,
             on_resolved=lambda uuid, metric: resolved.append(uuid),
             on_email=emails.append,
         )
-        self.assertEqual(resolved, [str(self.project.uuid)])
+        self.assertEqual(resolved, [])
         self.assertEqual(len(emails), 1)
 
-        # 3 new rooms → 5 again → fire once more.
+        # 3 new rooms → 5 again → fire toast/email once more.
         for _ in range(3):
             _build_active_room(self.project, self.queue, age_seconds=300)
 
         process_violations(
             MetricGoal.METRIC_WAITING_TIME,
-            on_new_alert=alerts.append,
+            on_update=lambda v: None,
+            on_toast=toasts.append,
             on_email=emails.append,
         )
-        self.assertEqual(len(alerts), 2)
+        self.assertEqual(len(toasts), 2)
         self.assertEqual(len(emails), 2)
         self.assertEqual(emails[-1].violating_count, 5)
 

--- a/chats/apps/dashboard/tests/test_metric_goal_alerts_service.py
+++ b/chats/apps/dashboard/tests/test_metric_goal_alerts_service.py
@@ -11,7 +11,6 @@ from chats.apps.contacts.models import Contact
 from chats.apps.dashboard.models import MetricGoal, RoomMetrics
 from chats.apps.dashboard.services import metric_goal_alerts
 from chats.apps.dashboard.services.metric_goal_alerts import (
-    EMAIL_COOLDOWN_KEY_TEMPLATE,
     STATE_KEY_TEMPLATE,
     Violation,
     detect_violations,
@@ -123,12 +122,11 @@ class DetectViolationsTestCase(TestCase):
         self.assertGreaterEqual(violation.max_value_seconds, 60)
         self.assertEqual(violation.rooms_threshold_count, 2)
 
-    def test_violation_is_reported_even_when_below_email_threshold(self):
-        """The WS/toast/widget alert fires with a single room in breach.
+    def test_violation_is_reported_even_when_below_rooms_threshold(self):
+        """Detection still reports rooms below the "Quando" count.
 
-        `rooms_threshold_count` only gates the email notification (see
-        `ProcessViolationsTestCase`) — it must not prevent the violation
-        itself from being detected.
+        `process_violations` gates email/toast on `rooms_threshold_count`,
+        but `detect_violations` must keep returning the raw breach count.
         """
         MetricGoal.objects.create(
             project=self.project,
@@ -145,7 +143,7 @@ class DetectViolationsTestCase(TestCase):
         violation = results[0]
         self.assertEqual(violation.violating_count, 2)
         self.assertEqual(violation.rooms_threshold_count, 5)
-        self.assertFalse(violation.meets_email_threshold)
+        self.assertFalse(violation.meets_rooms_threshold)
 
     def test_skips_inactive_goals(self):
         MetricGoal.objects.create(
@@ -267,12 +265,7 @@ class ProcessViolationsTestCase(TestCase):
             project_uuid=str(self.project.uuid),
             metric=MetricGoal.METRIC_WAITING_TIME,
         )
-        cooldown_key = EMAIL_COOLDOWN_KEY_TEMPLATE.format(
-            project_uuid=str(self.project.uuid),
-            metric=MetricGoal.METRIC_WAITING_TIME,
-        )
         self.assertIn(state_key, self.fake_redis.store)
-        self.assertIn(cooldown_key, self.fake_redis.store)
 
     def test_second_run_emits_update_not_email(self):
         self._seed_violation()
@@ -325,7 +318,7 @@ class ProcessViolationsTestCase(TestCase):
             )
         self.assertEqual(len(emails), 1)
 
-    def test_email_skipped_when_email_disabled(self):
+    def test_email_and_toast_skipped_when_email_disabled(self):
         MetricGoal.objects.filter(
             project=self.project,
             metric=MetricGoal.METRIC_WAITING_TIME,
@@ -338,12 +331,10 @@ class ProcessViolationsTestCase(TestCase):
             on_email=emails.append,
         )
         self.assertEqual(len(emails), 0)
-        self.assertEqual(len(result.new_alerts), 1)
+        self.assertEqual(len(result.new_alerts), 0)
 
-    def test_alert_fires_but_email_skipped_when_below_rooms_threshold(self):
-        """A single breaching room is enough for the WS/toast alert, but the
-        email must wait until `rooms_threshold_count` rooms are breaching.
-        """
+    def test_alert_and_email_skipped_when_below_rooms_threshold(self):
+        """Below rooms_threshold_count: no toast and no email."""
         MetricGoal.objects.filter(
             project=self.project,
             metric=MetricGoal.METRIC_WAITING_TIME,
@@ -358,15 +349,12 @@ class ProcessViolationsTestCase(TestCase):
             on_email=emails.append,
         )
 
-        self.assertEqual(len(new_alerts), 1)
+        self.assertEqual(len(new_alerts), 0)
         self.assertEqual(len(emails), 0)
-        self.assertEqual(len(result.new_alerts), 1)
+        self.assertEqual(len(result.new_alerts), 0)
 
-    def test_email_fires_on_update_when_rooms_threshold_is_reached(self):
-        """Email must fire when violating_count first reaches the configured
-        "Quando" value, even if the alert was already active from an earlier
-        single-room breach.
-        """
+    def test_alert_and_email_fire_when_rooms_threshold_is_reached(self):
+        """Crossing into rooms_threshold_count fires toast + email together."""
         MetricGoal.objects.filter(
             project=self.project,
             metric=MetricGoal.METRIC_WAITING_TIME,
@@ -379,19 +367,68 @@ class ProcessViolationsTestCase(TestCase):
             on_new_alert=lambda v: None,
             on_email=emails.append,
         )
-        self.assertEqual(len(first.new_alerts), 1)
+        self.assertEqual(len(first.new_alerts), 0)
         self.assertEqual(len(emails), 0)
 
         self._seed_violation()
-        updates: list[Violation] = []
+        new_alerts: list[Violation] = []
         process_violations(
             MetricGoal.METRIC_WAITING_TIME,
-            on_update=updates.append,
+            on_new_alert=new_alerts.append,
             on_email=emails.append,
         )
-        self.assertEqual(len(updates), 1)
+        self.assertEqual(len(new_alerts), 1)
         self.assertEqual(len(emails), 1)
         self.assertEqual(emails[0].violating_count, 2)
+
+    def test_rearms_when_count_drops_below_threshold_then_rises_again(self):
+        """5 → 2 (below) → 5 again must fire email/toast a second time."""
+        MetricGoal.objects.filter(
+            project=self.project,
+            metric=MetricGoal.METRIC_WAITING_TIME,
+        ).update(rooms_threshold_count=5)
+
+        rooms = [
+            _build_active_room(self.project, self.queue, age_seconds=300)
+            for _ in range(5)
+        ]
+        emails: list[Violation] = []
+        alerts: list[Violation] = []
+
+        process_violations(
+            MetricGoal.METRIC_WAITING_TIME,
+            on_new_alert=alerts.append,
+            on_email=emails.append,
+        )
+        self.assertEqual(len(alerts), 1)
+        self.assertEqual(len(emails), 1)
+
+        # Resolve 3 rooms → 2 remain (below threshold) → clear state.
+        for room in rooms[:3]:
+            room.is_active = False
+            room.save(update_fields=["is_active"])
+
+        resolved: list[str] = []
+        process_violations(
+            MetricGoal.METRIC_WAITING_TIME,
+            on_resolved=lambda uuid, metric: resolved.append(uuid),
+            on_email=emails.append,
+        )
+        self.assertEqual(resolved, [str(self.project.uuid)])
+        self.assertEqual(len(emails), 1)
+
+        # 3 new rooms → 5 again → fire once more.
+        for _ in range(3):
+            _build_active_room(self.project, self.queue, age_seconds=300)
+
+        process_violations(
+            MetricGoal.METRIC_WAITING_TIME,
+            on_new_alert=alerts.append,
+            on_email=emails.append,
+        )
+        self.assertEqual(len(alerts), 2)
+        self.assertEqual(len(emails), 2)
+        self.assertEqual(emails[-1].violating_count, 5)
 
 
 class FeatureFlagCacheTestCase(TestCase):

--- a/chats/apps/dashboard/tests/test_metric_goal_alerts_service.py
+++ b/chats/apps/dashboard/tests/test_metric_goal_alerts_service.py
@@ -207,6 +207,35 @@ class DetectViolationsTestCase(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].violating_count, 1)
 
+    def test_conversation_duration_ignores_rooms_without_current_agent(self):
+        """Unassigned rooms with first_user_assigned_at must not count.
+
+        Matches MetricGoalBreachService / the dashboard widget, which only
+        treat rooms currently assigned to an agent as in conversation.
+        """
+        user = User.objects.create_user(email="cd-agent2@example.com")
+        self.project.permissions.create(user=user, role=1)
+        MetricGoal.objects.create(
+            project=self.project,
+            metric=MetricGoal.METRIC_CONVERSATION_DURATION,
+            threshold_seconds=60,
+            rooms_threshold_count=1,
+        )
+        assigned = _build_active_room(
+            self.project, self.queue, user=user, age_seconds=300
+        )
+        # Previously assigned, now back in queue (no current agent).
+        unassigned = _build_active_room(
+            self.project, self.queue, user=user, age_seconds=400
+        )
+        Room.objects.filter(pk=unassigned.pk).update(user=None)
+
+        results = detect_violations(MetricGoal.METRIC_CONVERSATION_DURATION)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].violating_count, 1)
+        self.assertEqual(assigned.user_id, user.pk)
+
 
 class ProcessViolationsTestCase(TestCase):
     def setUp(self):

--- a/chats/apps/dashboard/tests/test_metric_goal_alerts_tasks.py
+++ b/chats/apps/dashboard/tests/test_metric_goal_alerts_tasks.py
@@ -9,6 +9,9 @@ from django.test import TestCase
 from django.utils import timezone
 
 from chats.apps.api.utils import create_user_and_token
+from chats.apps.api.websockets.dashboard.consumers.metric_goal_alerts import (
+    MetricGoalAlertConsumer,
+)
 from chats.apps.contacts.models import Contact
 from chats.apps.dashboard import tasks as dashboard_tasks
 from chats.apps.dashboard.models import MetricGoal
@@ -137,10 +140,16 @@ class CheckMetricGoalViolationsTaskTestCase(TestCase):
         first_call = self.mock_send_group.call_args_list[0]
         self.assertEqual(
             first_call.kwargs["group_name"],
-            f"metric_goal_alerts:{self.project.uuid}",
+            MetricGoalAlertConsumer.group_name_for(
+                str(self.project.uuid), self.recipient.email
+            ),
         )
-        self.assertEqual(first_call.kwargs["action"], "metric_goal.violated")
+        self.assertEqual(first_call.kwargs["action"], "metric_goal.alert")
         self.assertEqual(first_call.kwargs["content"]["transition"], "new")
+        self.assertIn(
+            self.recipient.email.lower(),
+            first_call.kwargs["content"]["recipients"],
+        )
 
         self.assertTrue(mock_delay.called)
         kwargs = mock_delay.call_args.kwargs
@@ -178,7 +187,7 @@ class CheckMetricGoalViolationsTaskTestCase(TestCase):
             for call in self.mock_send_group.call_args_list
         ]
         self.assertIn("metric_goal.update", actions)
-        self.assertNotIn("metric_goal.violated", actions)
+        self.assertNotIn("metric_goal.alert", actions)
 
     def test_send_metric_goal_email_skips_when_disabled(self):
         self.goal.email_enabled = False

--- a/chats/apps/dashboard/tests/test_metric_goal_alerts_tasks.py
+++ b/chats/apps/dashboard/tests/test_metric_goal_alerts_tasks.py
@@ -137,18 +137,29 @@ class CheckMetricGoalViolationsTaskTestCase(TestCase):
             self.mock_send_group.called,
             "Expected at least one WebSocket broadcast",
         )
-        first_call = self.mock_send_group.call_args_list[0]
+        actions = {
+            call.kwargs["action"]: call
+            for call in self.mock_send_group.call_args_list
+        }
+        self.assertIn("metric_goal.violated", actions)
+        violated_call = actions["metric_goal.violated"]
         self.assertEqual(
-            first_call.kwargs["group_name"],
+            violated_call.kwargs["group_name"],
+            MetricGoalAlertConsumer.project_group_name(str(self.project.uuid)),
+        )
+        self.assertEqual(violated_call.kwargs["content"]["transition"], "new")
+
+        self.assertIn("metric_goal.alert", actions)
+        alert_call = actions["metric_goal.alert"]
+        self.assertEqual(
+            alert_call.kwargs["group_name"],
             MetricGoalAlertConsumer.group_name_for(
                 str(self.project.uuid), self.recipient.email
             ),
         )
-        self.assertEqual(first_call.kwargs["action"], "metric_goal.alert")
-        self.assertEqual(first_call.kwargs["content"]["transition"], "new")
         self.assertIn(
             self.recipient.email.lower(),
-            first_call.kwargs["content"]["recipients"],
+            alert_call.kwargs["content"]["recipients"],
         )
 
         self.assertTrue(mock_delay.called)
@@ -183,11 +194,11 @@ class CheckMetricGoalViolationsTaskTestCase(TestCase):
             dashboard_tasks.check_metric_goal_violations()
 
         actions = [
-            call.kwargs["action"]
-            for call in self.mock_send_group.call_args_list
+            call.kwargs["action"] for call in self.mock_send_group.call_args_list
         ]
         self.assertIn("metric_goal.update", actions)
         self.assertNotIn("metric_goal.alert", actions)
+        self.assertNotIn("metric_goal.violated", actions)
 
     def test_send_metric_goal_email_skips_when_disabled(self):
         self.goal.email_enabled = False
@@ -224,6 +235,4 @@ class MetricGoalCeleryQueueRoutingTests(TestCase):
         from django.conf import settings
 
         entry = settings.CELERY_BEAT_SCHEDULE["check-metric-goal-violations"]
-        self.assertEqual(
-            entry["options"]["queue"], settings.RISK_ALERT_CELERY_QUEUE
-        )
+        self.assertEqual(entry["options"]["queue"], settings.RISK_ALERT_CELERY_QUEUE)


### PR DESCRIPTION
### What
email and toast now fire together only when email_enabled is on and the violating room count crosses into >= rooms_threshold_count. While the count stays at or above the threshold, only metric_goal.update is emitted. When it drops below, Redis state is cleared so the alert can fire again (e.g. 5 → 2 → 5). The 15-minute email cooldown that blocked re-firing was removed.
WebSocket (tasks + MetricGoalAlertConsumer): new metric_goal.alert action is sent only when the toast should show, fan-out to each recipient. Each user joins metric_goal_alerts.{project_uuid}.{sha1(email)[:16]} — users not on the email recipient list never get the event.
Tests updated for rearm logic, the metric_goal.alert contract, and per-recipient isolation; the WS consumer suite now uses TransactionTestCase.

### Why
Previously, email/toast did not re-fire in the “hit the limit → some rooms resolve → count hits the limit again” case, and the WS broadcast went to the whole project (or the front decided from a 30s update). That caused either spam or missed alerts. This aligns the backend with the product rule: fire only on the threshold crossing, rearm when the count drops below it, and deliver the toast only to users with email configured.
