### PR TITLE
refactor: simplify date field definition in BulkSendHistorySerializer

### DIFF
--- a/chats/apps/api/v1/msgs/serializers.py
+++ b/chats/apps/api/v1/msgs/serializers.py
@@ -137,9 +137,7 @@ class BulkSendHistorySerializer(serializers.ModelSerializer):
     contact = serializers.SerializerMethodField()
     queue = serializers.SerializerMethodField()
     sent_by = serializers.SerializerMethodField()
-    date = serializers.DateTimeField(
-        source="created_on", format="%Y-%m-%d", read_only=True
-    )
+    date = serializers.DateTimeField(source="created_on", read_only=True)
 
     class Meta:
         model = BulkMessageSendMessage

--- a/chats/apps/api/v1/msgs/tests/test_bulk_send.py
+++ b/chats/apps/api/v1/msgs/tests/test_bulk_send.py
@@ -6,6 +6,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.fields import DateTimeField
 from rest_framework.response import Response
 from rest_framework.test import APITestCase
 
@@ -824,7 +825,7 @@ class TestBulkSendHistoryViewSetAsAuthenticatedUser(BaseBulkSendHistoryViewSetTe
                 "contact": {"name": "Eduardo"},
                 "queue": {"name": "Pokedex"},
                 "sent_by": {"name": "Kallil"},
-                "date": bulk_message.created_on.date().isoformat(),
+                "date": DateTimeField().to_representation(bulk_message.created_on),
                 "status": BulkMessageSendMessageStatus.FAILED,
             },
         )
@@ -875,11 +876,11 @@ class TestBulkSendHistoryViewSetAsAuthenticatedUser(BaseBulkSendHistoryViewSetTe
         self.assertEqual(set(contact_names), {"Matching Start", "Matching End"})
         self.assertEqual(
             response.data["results"][0]["date"],
-            matching_end.created_on.date().isoformat(),
+            DateTimeField().to_representation(matching_end.created_on),
         )
         self.assertEqual(
             response.data["results"][1]["date"],
-            matching_start.created_on.date().isoformat(),
+            DateTimeField().to_representation(matching_start.created_on),
         )
 
     @with_project_permission()

--- a/chats/apps/api/v1/msgs/viewsets.py
+++ b/chats/apps/api/v1/msgs/viewsets.py
@@ -48,12 +48,6 @@ from chats.apps.msgs.usecases.start_bulk_send_messages import (
     StartBulkSendMessagesUseCase,
 )
 from chats.apps.msgs.usecases.get_bulk_send_history import GetBulkSendHistoryUseCase
-from chats.apps.msgs.usecases.start_bulk_send_messages import (
-    StartBulkSendMessagesUseCase,
-)
-from chats.apps.msgs.usecases.start_bulk_send_messages import (
-    StartBulkSendMessagesUseCase,
-)
 from chats.apps.api.v1.permissions import ProjectQueryIsAdmin
 from chats.apps.rooms.usecases.get_rooms_count_for_send_bulk_msgs import (
     GetRoomsCountForSendBulkMsgsUseCase,


### PR DESCRIPTION
### What

- Bulk send history `date` field now returns a full ISO-8601 datetime instead of date-only (`YYYY-MM-DD`)
- Updated related tests to assert the datetime representation

### Why

- Consumers need the exact send timestamp, not just the day, when listing bulk send history