### PR TITLE
chore: reduce Sentry noise by logging expected errors only

### DIFF
--- a/chats/apps/ai_features/history_summary/services.py
+++ b/chats/apps/ai_features/history_summary/services.py
@@ -2,8 +2,10 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
+from botocore.exceptions import ClientError
 from django.db.models import Q
 from sentry_sdk import capture_message
+
 from chats.apps.ai_features.history_summary.models import HistorySummaryStatus
 from chats.apps.ai_features.integrations.base_client import BaseAIPlatformClient
 from chats.apps.ai_features.integrations.dataclass import PromptMessage
@@ -19,6 +21,25 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+_TRANSIENT_BEDROCK_ERROR_CODES = frozenset(
+    {
+        "ServiceUnavailableException",
+        "InternalServerException",
+        "ThrottlingException",
+        "ModelTimeoutException",
+        "ModelNotReadyException",
+    }
+)
+
+
+def _is_transient_bedrock_error(exc: BaseException) -> bool:
+    if isinstance(exc, ClientError):
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in _TRANSIENT_BEDROCK_ERROR_CODES:
+            return True
+    text = str(exc)
+    return any(code in text for code in _TRANSIENT_BEDROCK_ERROR_CODES)
 
 
 class HistorySummaryService:
@@ -137,12 +158,19 @@ class HistorySummaryService:
 
         except Exception as e:
             history_summary.update_status(HistorySummaryStatus.UNAVAILABLE)
-            logger.error(
-                "Error generating history summary for room %s: %s", room.uuid, e
-            )
-            capture_message(
-                "Error generating history summary for room %s: %s" % (room.uuid, e),
-                level="error",
-            )
+            if _is_transient_bedrock_error(e):
+                logger.warning(
+                    "Transient Bedrock error generating history summary for room %s: %s",
+                    room.uuid,
+                    e,
+                )
+            else:
+                logger.error(
+                    "Error generating history summary for room %s: %s", room.uuid, e
+                )
+                capture_message(
+                    "Error generating history summary for room %s: %s" % (room.uuid, e),
+                    level="error",
+                )
 
         return history_summary

--- a/chats/apps/ai_features/history_summary/tests/test_services.py
+++ b/chats/apps/ai_features/history_summary/tests/test_services.py
@@ -125,3 +125,43 @@ class TestHistorySummaryService(TestCase):
         self.assertIsNone(result)
         self.assertEqual(self.history_summary.status, HistorySummaryStatus.UNAVAILABLE)
         self.mock_integration_client.generate_text.assert_not_called()
+
+    @patch("chats.apps.ai_features.history_summary.services.capture_message")
+    @patch("chats.apps.ai_features.history_summary.services.FeaturePrompt.objects")
+    def test_generate_summary_transient_bedrock_error_skips_sentry(
+        self, mock_feature_prompt_objects, mock_capture_message
+    ):
+        from botocore.exceptions import ClientError
+
+        mock_feature_prompt_objects.filter.return_value.order_by.return_value.last.return_value = (
+            self.feature_prompt
+        )
+        self.mock_integration_client.generate_text.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ServiceUnavailableException",
+                    "Message": "Bedrock is unable to process your request.",
+                }
+            },
+            "InvokeModel",
+        )
+
+        result = self.service.generate_summary(self.room, self.history_summary)
+
+        self.assertEqual(result.status, HistorySummaryStatus.UNAVAILABLE)
+        mock_capture_message.assert_not_called()
+
+    @patch("chats.apps.ai_features.history_summary.services.capture_message")
+    @patch("chats.apps.ai_features.history_summary.services.FeaturePrompt.objects")
+    def test_generate_summary_unexpected_error_reports_sentry(
+        self, mock_feature_prompt_objects, mock_capture_message
+    ):
+        mock_feature_prompt_objects.filter.return_value.order_by.return_value.last.return_value = (
+            self.feature_prompt
+        )
+        self.mock_integration_client.generate_text.side_effect = RuntimeError("boom")
+
+        result = self.service.generate_summary(self.room, self.history_summary)
+
+        self.assertEqual(result.status, HistorySummaryStatus.UNAVAILABLE)
+        mock_capture_message.assert_called_once()

--- a/chats/apps/ai_features/integrations/aws/bedrock/client.py
+++ b/chats/apps/ai_features/integrations/aws/bedrock/client.py
@@ -72,6 +72,21 @@ class BedrockClient(BaseAIPlatformClient):
 
             return self.get_text_from_response(response_body)
 
-        except (ClientError, Exception) as e:
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in {
+                "ServiceUnavailableException",
+                "InternalServerException",
+                "ThrottlingException",
+                "ModelTimeoutException",
+                "ModelNotReadyException",
+            }:
+                logger.warning(
+                    "Transient Bedrock error invoking '%s': %s", self.model_id, e
+                )
+            else:
+                logger.error("ERROR: Can't invoke '%s'. Reason: %s", self.model_id, e)
+            raise
+        except Exception as e:
             logger.error("ERROR: Can't invoke '%s'. Reason: %s", self.model_id, e)
-            raise e
+            raise

--- a/chats/apps/api/v2/quickmessages/permissions.py
+++ b/chats/apps/api/v2/quickmessages/permissions.py
@@ -1,7 +1,20 @@
+import logging
+from uuid import UUID
+
 from rest_framework import permissions
 
 from chats.apps.projects.models import ProjectPermission
 from chats.apps.sectors.models import Sector
+
+logger = logging.getLogger(__name__)
+
+
+def _is_valid_uuid(value) -> bool:
+    try:
+        UUID(str(value))
+        return True
+    except (ValueError, TypeError, AttributeError):
+        return False
 
 
 class SectorQuickMessageProjectPermission(permissions.BasePermission):
@@ -14,11 +27,23 @@ class SectorQuickMessageProjectPermission(permissions.BasePermission):
             sector_uuid = request.query_params.get("sector")
 
             if project_uuid:
+                if not _is_valid_uuid(project_uuid):
+                    logger.warning(
+                        "Invalid project UUID in sector_quick_messages query params",
+                        extra={"project": project_uuid},
+                    )
+                    return False
                 return ProjectPermission.objects.filter(
                     project__uuid=project_uuid, user=request.user
                 ).exists()
 
             if sector_uuid:
+                if not _is_valid_uuid(sector_uuid):
+                    logger.warning(
+                        "Invalid sector UUID in sector_quick_messages query params",
+                        extra={"sector": sector_uuid},
+                    )
+                    return False
                 try:
                     sector = Sector.objects.get(uuid=sector_uuid)
                 except Sector.DoesNotExist:

--- a/chats/apps/api/websockets/rooms/consumers/agent.py
+++ b/chats/apps/api/websockets/rooms/consumers/agent.py
@@ -31,6 +31,7 @@ from chats.apps.projects.models.models import ProjectPermission
 from chats.apps.projects.usecases.status_service import InServiceStatusService
 from chats.apps.rooms.models import Room
 from chats.core.cache import CacheClient
+from chats.core.sentry import is_closed_websocket_error
 
 logger = logging.getLogger(__name__)
 
@@ -186,11 +187,44 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
 
         return response
 
+    async def safe_send_json(self, content):
+        """Send JSON, ignoring races where the client already disconnected."""
+        try:
+            await self.send_json(content)
+        except Exception as exc:
+            if is_closed_websocket_error(exc):
+                logger.warning(
+                    "Skipping WS send on closed connection",
+                    extra={
+                        "user": getattr(getattr(self, "user", None), "email", None),
+                        "connection_id": str(getattr(self, "connection_id", "")),
+                        "error": str(exc),
+                    },
+                )
+                return
+            raise
+
     async def receive_json(self, payload):
         """
         Called when we get a text frame. Channels will JSON-decode the payload
         for us and pass it as the first argument.
         """
+        try:
+            await self._handle_receive_json(payload)
+        except Exception as exc:
+            if is_closed_websocket_error(exc):
+                logger.warning(
+                    "Ignoring closed WebSocket during receive_json",
+                    extra={
+                        "user": getattr(getattr(self, "user", None), "email", None),
+                        "connection_id": str(getattr(self, "connection_id", "")),
+                        "error": str(exc),
+                    },
+                )
+                return
+            raise
+
+    async def _handle_receive_json(self, payload):
         ws_messages_received_total.labels(consumer=self.CONSUMER_TYPE).inc()
 
         # Messages will have a "command" key we can switch on
@@ -205,7 +239,7 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
                     action,
                     getattr(self.user, "email", "unknown"),
                 )
-                await self.send_json(
+                await self.safe_send_json(
                     {
                         "type": "notify",
                         "action": "method.error",
@@ -223,7 +257,7 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
             self.last_ping = timezone.now()
             if await self.is_ping_timeout_feature_enabled():
                 await self.maybe_update_last_seen()
-            await self.send_json({"type": "pong"})
+            await self.safe_send_json({"type": "pong"})
 
     # METHODS
 
@@ -284,7 +318,7 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
             )
             return
 
-        await self.send_json(
+        await self.safe_send_json(
             {
                 "type": "notify",
                 "action": "msg.create.success",
@@ -302,7 +336,7 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
         if request_id is not None:
             content["request_id"] = request_id
 
-        await self.send_json(
+        await self.safe_send_json(
             {
                 "type": "notify",
                 "action": "msg.create.error",
@@ -389,7 +423,7 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
                 connection_id=event["content"].get("connection_id"), response=True
             )
         elif event.get("action") == "rooms.inactivity":
-            await self.send_json(event)
+            await self.safe_send_json(event)
         elif "rooms." in event.get("action"):
             content = event.get("content", {})
 
@@ -400,7 +434,8 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
                 room_uuid = content.get("uuid")
 
                 if not room_uuid:
-                    return self.send_json(event)
+                    await self.safe_send_json(event)
+                    return
 
                 has_history = await self.get_has_history_by_room_uuid(room_uuid)
                 content["has_history"] = has_history
@@ -413,11 +448,12 @@ class AgentRoomConsumer(AsyncJsonWebsocketConsumer):
                 )
             except Exception as e:
                 logger.error(f"Error getting history rooms queryset by contact: {e}")
-                return self.send_json(event)
+                await self.safe_send_json(event)
+                return
 
-            await self.send_json(event)
+            await self.safe_send_json(event)
         else:
-            await self.send_json(event)
+            await self.safe_send_json(event)
 
     # SYNC HELPER FUNCTIONS
 

--- a/chats/apps/api/websockets/rooms/consumers/contact.py
+++ b/chats/apps/api/websockets/rooms/consumers/contact.py
@@ -13,12 +13,29 @@ from chats.apps.api.v1.prometheus.metrics import (
     ws_messages_received_total,
 )
 from chats.apps.rooms.models import Room
+from chats.core.sentry import is_closed_websocket_error
 
 logger = logging.getLogger(__name__)
 
 
 class ContactRoomConsumer(AsyncJsonWebsocketConsumer):
     CONSUMER_TYPE = "contact"
+
+    async def safe_send_json(self, content):
+        """Send JSON, ignoring races where the client already disconnected."""
+        try:
+            await self.send_json(content)
+        except Exception as exc:
+            if is_closed_websocket_error(exc):
+                logger.warning(
+                    "Skipping WS send on closed connection",
+                    extra={
+                        "room_id": getattr(self, "room_id", None),
+                        "error": str(exc),
+                    },
+                )
+                return
+            raise
 
     async def connect(self):
         self._start_time = time.time()
@@ -75,7 +92,7 @@ class ContactRoomConsumer(AsyncJsonWebsocketConsumer):
 
     async def notify(self, event):
         # event["content"] is expected to be a dict/JSON-compatible object
-        await self.send_json(event["content"])
+        await self.safe_send_json(event["content"])
 
     @database_sync_to_async
     def get_room(self):
@@ -89,7 +106,7 @@ class ContactRoomConsumer(AsyncJsonWebsocketConsumer):
 
     async def send_msgs(self):
         messages = await self.get_msgs()
-        await self.send_json(
+        await self.safe_send_json(
             {
                 "type": "notify",
                 "action": "message.load",

--- a/chats/apps/feature_flags/integrations/growthbook/clients.py
+++ b/chats/apps/feature_flags/integrations/growthbook/clients.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 
 import requests
 from growthbook import GrowthBook
-from sentry_sdk import capture_exception
 
 from chats.core.cache import CacheClient
 
@@ -161,11 +160,11 @@ class GrowthbookClient(BaseGrowthbookClient):
             try:
                 cached_feature_flags = json.loads(cached_feature_flags)
             except json.JSONDecodeError as e:
-                logger.error(
+                logger.warning(
                     "Failed to parse feature flags from short cache: %s",
                     cached_feature_flags,
+                    exc_info=e,
                 )
-                capture_exception(e)
                 return None
 
         return cached_feature_flags
@@ -183,11 +182,11 @@ class GrowthbookClient(BaseGrowthbookClient):
             try:
                 cached_feature_flags = json.loads(cached_feature_flags)
             except json.JSONDecodeError as e:
-                logger.error(
+                logger.warning(
                     "Failed to parse feature flags from long cache: %s",
                     cached_feature_flags,
+                    exc_info=e,
                 )
-                capture_exception(e)
                 return None
 
         return cached_feature_flags
@@ -253,13 +252,11 @@ class GrowthbookClient(BaseGrowthbookClient):
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            logger.error(
-                "Failed to update feature flags definitions: %s",
+            logger.warning(
+                "Failed to update feature flags definitions from GrowthBook: %s",
                 e,
             )
-            capture_exception(e)
-
-            raise e
+            raise
 
         response = response.json()
         features = response.get("features", {})

--- a/chats/apps/msgs/models.py
+++ b/chats/apps/msgs/models.py
@@ -2,7 +2,6 @@ import json
 import logging
 
 import requests
-import sentry_sdk
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -185,19 +184,17 @@ class Message(BaseModelWithManualCreatedOn):
                         f"Message ID: {self.pk}, "
                         f"HTTP {response.status_code}: {response.text[:200]}"
                     )
-                    logger.error(error_msg)
-
-                    sentry_sdk.capture_message(
-                        error_msg,
-                        level="error",
-                        extras={
-                            "message_uuid": self.pk,
-                            "room_uuid": self.room.uuid,
-                            "callback_url": self.room.callback_url,
-                            "status_code": response.status_code,
-                            "response_text": response.text[:500],
-                        },
-                    )
+                    log_extra = {
+                        "message_uuid": str(self.pk),
+                        "room_uuid": str(self.room.uuid),
+                        "callback_url": self.room.callback_url,
+                        "status_code": response.status_code,
+                    }
+                    # Partner callback failures are expected noise — log only.
+                    if 400 <= response.status_code < 500:
+                        logger.warning(error_msg, extra=log_extra)
+                    else:
+                        logger.error(error_msg, extra=log_extra)
 
             except Exception as error:
                 error_msg = (
@@ -205,13 +202,11 @@ class Message(BaseModelWithManualCreatedOn):
                     f"Message ID: {self.pk}, "
                     f"Error: {type(error).__name__}: {str(error)[:200]}"
                 )
-                logger.error(error_msg)
-
-                sentry_sdk.capture_exception(
-                    error,
-                    extras={
-                        "message_uuid": self.pk,
-                        "room_uuid": self.room.uuid,
+                logger.error(
+                    error_msg,
+                    extra={
+                        "message_uuid": str(self.pk),
+                        "room_uuid": str(self.room.uuid),
                         "callback_url": self.room.callback_url,
                     },
                 )
@@ -376,20 +371,18 @@ class MessageMedia(BaseModelWithManualCreatedOn):
                         f"MessageMedia ID: {self.pk}, "
                         f"HTTP {response.status_code}: {response.text[:200]}"
                     )
-                    logger.error(error_msg)
-
-                    sentry_sdk.capture_message(
-                        error_msg,
-                        level="error",
-                        extras={
-                            "media_uuid": self.pk,
-                            "message_uuid": self.message.pk,
-                            "room_uuid": self.message.room.uuid,
-                            "callback_url": self.message.room.callback_url,
-                            "status_code": response.status_code,
-                            "response_text": response.text[:500],
-                        },
-                    )
+                    log_extra = {
+                        "media_uuid": str(self.pk),
+                        "message_uuid": str(self.message.pk),
+                        "room_uuid": str(self.message.room.uuid),
+                        "callback_url": self.message.room.callback_url,
+                        "status_code": response.status_code,
+                    }
+                    # Partner callback failures are expected noise — log only.
+                    if 400 <= response.status_code < 500:
+                        logger.warning(error_msg, extra=log_extra)
+                    else:
+                        logger.error(error_msg, extra=log_extra)
 
             except Exception as error:
                 error_msg = (
@@ -397,14 +390,12 @@ class MessageMedia(BaseModelWithManualCreatedOn):
                     f"MessageMedia ID: {self.pk}, "
                     f"Error: {type(error).__name__}: {str(error)[:200]}"
                 )
-                logger.error(error_msg)
-
-                sentry_sdk.capture_exception(
-                    error,
-                    extras={
-                        "media_uuid": self.pk,
-                        "message_uuid": self.message.pk,
-                        "room_uuid": self.message.room.uuid,
+                logger.error(
+                    error_msg,
+                    extra={
+                        "media_uuid": str(self.pk),
+                        "message_uuid": str(self.message.pk),
+                        "room_uuid": str(self.message.room.uuid),
                         "callback_url": self.message.room.callback_url,
                     },
                 )

--- a/chats/apps/msgs/tests/test_set_external_id_usecase.py
+++ b/chats/apps/msgs/tests/test_set_external_id_usecase.py
@@ -104,3 +104,28 @@ class TestSetMsgExternalIdUseCase(TestCase):
             any("unexpected error setting external_id" in line for line in logs.output),
             f"expected exception log, got: {logs.output}",
         )
+
+    def test_expected_validation_errors_are_logged_without_sentry(self):
+        """
+        Closed-room / 24h ValidationErrors are business rules — log only.
+        """
+        from rest_framework.exceptions import ValidationError
+
+        with mock.patch(
+            "chats.apps.msgs.usecases.set_msg_external_id.Message.objects"
+        ) as mocked_manager, mock.patch(
+            "chats.apps.msgs.usecases.set_msg_external_id.sentry_sdk.capture_exception"
+        ) as mocked_capture, self.assertLogs(
+            "chats.apps.msgs.usecases.set_msg_external_id", level="WARNING"
+        ) as logs:
+            mocked_manager.select_for_update.return_value.get.side_effect = (
+                ValidationError({"detail": "Closed rooms can't receive messages"})
+            )
+
+            self.use_case.execute(self.message.uuid, "any-external-id")
+
+        mocked_capture.assert_not_called()
+        self.assertTrue(
+            any("expected validation failure" in line for line in logs.output),
+            f"expected warning log, got: {logs.output}",
+        )

--- a/chats/apps/msgs/usecases/set_msg_external_id.py
+++ b/chats/apps/msgs/usecases/set_msg_external_id.py
@@ -2,9 +2,11 @@ import logging
 
 import sentry_sdk
 from django.db import transaction
+from rest_framework.exceptions import ValidationError
 
 from chats.apps.api.utils import create_reply_index
 from chats.apps.msgs.models import Message, MessageMedia
+from chats.core.sentry import is_expected_validation_error
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +41,20 @@ class SetMsgExternalIdUseCase:
                             extra={"msg_uuid": str(msg_uuid)},
                         )
                         return
+        except ValidationError as error:
+            # Business rules (closed room / 24h window) — log only.
+            if is_expected_validation_error(error):
+                logger.warning(
+                    "SetMsgExternalIdUseCase: expected validation failure",
+                    extra={"msg_uuid": str(msg_uuid), "detail": str(error)},
+                )
+                return
+            logger.exception(
+                "SetMsgExternalIdUseCase: unexpected ValidationError",
+                extra={"msg_uuid": str(msg_uuid)},
+            )
+            sentry_sdk.capture_exception(error)
+            return
         except Exception as error:
             # Bug #1 observability: any unexpected error (DB integrity,
             # connection issues, etc.) used to be silently swallowed by a

--- a/chats/apps/sectors/services.py
+++ b/chats/apps/sectors/services.py
@@ -4,12 +4,14 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.db import transaction
+from rest_framework.exceptions import ValidationError
 from sentry_sdk import capture_exception
 
 from chats.apps.api.v1.internal.rest_clients.flows_rest_client import FlowRESTClient
 from chats.apps.msgs.models import AutomaticMessage, AutomaticMessageType, Message
 from chats.apps.projects.models.models import Project
 from chats.apps.rooms.models import Room
+from chats.core.sentry import is_expected_validation_error
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +136,22 @@ class AutomaticMessagesService:
                     "[AUTOMATIC MESSAGES SERVICE] Automatic message sent to room %s",
                     room.pk,
                 )
+        except ValidationError as e:
+            if is_expected_validation_error(e):
+                logger.warning(
+                    "[AUTOMATIC MESSAGES SERVICE] Expected validation failure "
+                    "for room %s: %s",
+                    room.pk,
+                    e,
+                )
+                return False
+            logger.exception(
+                "[AUTOMATIC MESSAGES SERVICE] Unexpected ValidationError "
+                "sending automatic message to room %s",
+                room.pk,
+            )
+            capture_exception(e)
+            return False
         except Exception as e:
             logger.error(
                 "[AUTOMATIC MESSAGES SERVICE] Error sending automatic message to room %s: %s"

--- a/chats/core/sentry.py
+++ b/chats/core/sentry.py
@@ -1,0 +1,94 @@
+"""
+Sentry helpers: filter expected/noisy events so they stay in logs only.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+_IGNORED_EXCEPTION_NAMES = frozenset(
+    {
+        "Disconnected",
+        "ConnectionClosed",
+        "ConnectionClosedError",
+        "ConnectionClosedOK",
+        "WorkerLostError",
+    }
+)
+
+_IGNORED_MESSAGE_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"Attempt to send on a closed protocol",
+        r"Closed rooms can't receive messages",
+        r"after 24h from the last contact message",
+        r"more than one active status per project",
+        r"is not a valid UUID",
+        r"Worker exited prematurely: signal 15 \(SIGTERM\)",
+        r"ServiceUnavailableException",
+        r"InternalServerException",
+        r"ThrottlingException",
+        r"ModelTimeoutException",
+        r"growthbook",
+        r"accounts\.weni\.ai",
+        r"Error getting feature flags definitions from GrowthBook",
+    )
+)
+
+_EXPECTED_VALIDATION_DETAILS = (
+    "Closed rooms can't receive messages",
+    "You can't send messages after 24h from the last contact message",
+    "you can't have more than one active status per project",
+)
+
+
+def is_closed_websocket_error(exc: BaseException) -> bool:
+    """True when the client already closed the WS connection."""
+    if type(exc).__name__ in _IGNORED_EXCEPTION_NAMES:
+        return True
+    return "closed protocol" in str(exc).lower()
+
+
+def is_expected_validation_error(exc: BaseException) -> bool:
+    """True for known business-rule ValidationErrors (not product bugs)."""
+    detail = str(exc)
+    return any(expected in detail for expected in _EXPECTED_VALIDATION_DETAILS)
+
+
+def _event_text(event: dict, exc_value: Optional[BaseException]) -> str:
+    parts = []
+    if event.get("message"):
+        parts.append(str(event["message"]))
+    if exc_value is not None:
+        parts.append(str(exc_value))
+    for entry in event.get("exception", {}).get("values") or []:
+        if entry.get("type"):
+            parts.append(str(entry["type"]))
+        if entry.get("value"):
+            parts.append(str(entry["value"]))
+    return " ".join(parts)
+
+
+def sentry_before_send(event: dict, hint: dict) -> Optional[dict]:
+    """
+    Drop expected noise from Sentry. Real bugs must still pass through.
+    """
+    exc_info = hint.get("exc_info")
+    exc_type = None
+    exc_value = None
+    if exc_info:
+        exc_type, exc_value, _ = exc_info
+        name = getattr(exc_type, "__name__", "")
+        if name in _IGNORED_EXCEPTION_NAMES:
+            return None
+        if is_expected_validation_error(exc_value):
+            return None
+        if is_closed_websocket_error(exc_value):
+            return None
+
+    text = _event_text(event, exc_value)
+    if any(pattern.search(text) for pattern in _IGNORED_MESSAGE_PATTERNS):
+        return None
+
+    return event

--- a/chats/core/tests/test_sentry.py
+++ b/chats/core/tests/test_sentry.py
@@ -1,0 +1,106 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.test import SimpleTestCase
+from rest_framework.exceptions import ValidationError as DRFValidationError
+
+from chats.core.sentry import (
+    is_closed_websocket_error,
+    is_expected_validation_error,
+    sentry_before_send,
+)
+
+
+class TestSentryBeforeSend(SimpleTestCase):
+    def test_drops_closed_protocol_message(self):
+        event = {"message": "Attempt to send on a closed protocol"}
+        self.assertIsNone(sentry_before_send(event, {}))
+
+    def test_drops_disconnected_exception(self):
+        class Disconnected(Exception):
+            pass
+
+        event = {"message": "ws error"}
+        hint = {"exc_info": (Disconnected, Disconnected("closed"), None)}
+        self.assertIsNone(sentry_before_send(event, hint))
+
+    def test_drops_expected_validation_error(self):
+        exc = DRFValidationError(
+            {"detail": "Closed rooms can't receive messages"}
+        )
+        event = {"message": str(exc)}
+        hint = {"exc_info": (DRFValidationError, exc, None)}
+        self.assertIsNone(sentry_before_send(event, hint))
+
+    def test_drops_worker_lost_sigterm(self):
+        class WorkerLostError(Exception):
+            pass
+
+        exc = WorkerLostError(
+            "Worker exited prematurely: signal 15 (SIGTERM) Job: 1."
+        )
+        event = {"message": str(exc)}
+        hint = {"exc_info": (WorkerLostError, exc, None)}
+        self.assertIsNone(sentry_before_send(event, hint))
+
+    def test_drops_bedrock_service_unavailable(self):
+        event = {
+            "message": (
+                "An error occurred (ServiceUnavailableException) when calling "
+                "the InvokeModel operation"
+            )
+        }
+        self.assertIsNone(sentry_before_send(event, {}))
+
+    def test_drops_growthbook_and_keycloak_noise(self):
+        self.assertIsNone(
+            sentry_before_send(
+                {"message": "Error getting feature flags definitions from GrowthBook"},
+                {},
+            )
+        )
+        self.assertIsNone(
+            sentry_before_send(
+                {
+                    "message": (
+                        "HTTPSConnectionPool(host='accounts.weni.ai', port=443): "
+                        "Max retries exceeded"
+                    )
+                },
+                {},
+            )
+        )
+
+    def test_keeps_real_bugs(self):
+        event = {"message": "'NoneType' object has no attribute 'project'"}
+        self.assertEqual(sentry_before_send(event, {}), event)
+
+        exc = AttributeError("'NoneType' object has no attribute 'project'")
+        hint = {"exc_info": (AttributeError, exc, None)}
+        self.assertEqual(
+            sentry_before_send({"message": str(exc)}, hint),
+            {"message": str(exc)},
+        )
+
+
+class TestSentryHelpers(SimpleTestCase):
+    def test_is_closed_websocket_error(self):
+        self.assertTrue(
+            is_closed_websocket_error(RuntimeError("Attempt to send on a closed protocol"))
+        )
+        self.assertFalse(is_closed_websocket_error(RuntimeError("other")))
+
+    def test_is_expected_validation_error(self):
+        self.assertTrue(
+            is_expected_validation_error(
+                DRFValidationError({"detail": "Closed rooms can't receive messages"})
+            )
+        )
+        self.assertTrue(
+            is_expected_validation_error(
+                DjangoValidationError(
+                    "you can't have more than one active status per project."
+                )
+            )
+        )
+        self.assertFalse(
+            is_expected_validation_error(DRFValidationError({"detail": "other"}))
+        )

--- a/chats/settings.py
+++ b/chats/settings.py
@@ -489,10 +489,13 @@ CORS_ORIGIN_ALLOW_ALL = True
 USE_SENTRY = env.bool("USE_SENTRY", default=False)
 
 if USE_SENTRY:
+    from chats.core.sentry import sentry_before_send
+
     sentry_sdk.init(
         dsn=env.str("SENTRY_DSN"),
         integrations=[DjangoIntegration()],
         environment=env.str("ENVIRONMENT", default="develop"),
+        before_send=sentry_before_send,
     )
 
 # JWT


### PR DESCRIPTION
### What
Added a shared Sentry filter (chats/core/sentry.py + before_send in settings) so expected noise is dropped while real bugs still reach Sentry.
WebSocket agent/contact consumers: safe_send_json logs closed-protocol disconnects instead of raising to Sentry.
Message/MessageMedia callbacks: partner HTTP 4xx → warning; 5xx/network errors → error log only (no capture_*).
SetMsgExternalIdUseCase and automatic messages: known business ValidationErrors (closed room, 24h window) → warning only; unexpected errors still go to Sentry.
Bedrock / history summary: transient AWS errors (ServiceUnavailable, InternalServerException, etc.) → warning and UNAVAILABLE; unexpected failures still reported.
GrowthBook client: API/cache failures log only (no Sentry).
sector_quick_messages permission: invalid UUID query params return deny + warning instead of unhandled ValidationError.

### Why
Sentry was flooded with expected operational and business-rule events (WS disconnect races, validation rules, partner callback 4xx, Bedrock outages, GrowthBook/Keycloak blips, Celery SIGTERM). That noise hid real bugs and made triage expensive. These cases already have a correct product behavior (400/deny, degrade feature, skip send); they belong in logs/metrics, not as Error issues. This change keeps Sentry for actual defects while preserving observability via structured logging.

### Sequence diagram
_Optional. Mermaid sequence diagram explaining the new feature process._
